### PR TITLE
refactor(agent): tighten RunContext encapsulation and deduplicate model serialization

### DIFF
--- a/agiwo/agent/models/_serialization.py
+++ b/agiwo/agent/models/_serialization.py
@@ -1,0 +1,21 @@
+"""Shared serialization helpers for agent models."""
+
+import dataclasses
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from agiwo.utils.serialization import serialize_optional_datetime
+
+
+def fields_to_dict(obj: object) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field_info in dataclasses.fields(obj):
+        value = getattr(obj, field_info.name)
+        if isinstance(value, datetime):
+            result[field_info.name] = serialize_optional_datetime(value)
+        elif isinstance(value, Enum):
+            result[field_info.name] = value.value
+        else:
+            result[field_info.name] = value
+    return result

--- a/agiwo/agent/models/run.py
+++ b/agiwo/agent/models/run.py
@@ -1,6 +1,5 @@
 """Run-scoped models and enums for agent execution."""
 
-import dataclasses
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -8,22 +7,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+from agiwo.agent.models._serialization import fields_to_dict
 from agiwo.agent.models.compact import CompactMetadata
 from agiwo.agent.models.input import UserInput
-from agiwo.utils.serialization import serialize_optional_datetime
-
-
-def _fields_to_dict(obj: object) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for field_info in dataclasses.fields(obj):
-        value = getattr(obj, field_info.name)
-        if isinstance(value, datetime):
-            result[field_info.name] = serialize_optional_datetime(value)
-        elif isinstance(value, Enum):
-            result[field_info.name] = value.value
-        else:
-            result[field_info.name] = value
-    return result
 
 
 class RunStatus(str, Enum):
@@ -103,7 +89,7 @@ class RunMetrics:
     response_latency: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return _fields_to_dict(self)
+        return fields_to_dict(self)
 
 
 @dataclass

--- a/agiwo/agent/models/step.py
+++ b/agiwo/agent/models/step.py
@@ -1,6 +1,5 @@
 """Step-scoped models for agent execution and LLM interaction."""
 
-import dataclasses
 import json
 import uuid
 from dataclasses import dataclass, field
@@ -8,29 +7,16 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from agiwo.agent.models._serialization import fields_to_dict
 from agiwo.agent.models.input import (
     ChannelContext,
     MessageContent,
     UserInput,
     UserMessage,
 )
-from agiwo.utils.serialization import serialize_optional_datetime
 
 if TYPE_CHECKING:
     from agiwo.agent.runtime.context import RunContext
-
-
-def _fields_to_dict(obj: object) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for field_info in dataclasses.fields(obj):
-        value = getattr(obj, field_info.name)
-        if isinstance(value, datetime):
-            result[field_info.name] = serialize_optional_datetime(value)
-        elif isinstance(value, Enum):
-            result[field_info.name] = value.value
-        else:
-            result[field_info.name] = value
-    return result
 
 
 def _serialize_user_input_structured(
@@ -71,7 +57,7 @@ class StepDelta:
     usage: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return _fields_to_dict(self)
+        return fields_to_dict(self)
 
 
 @dataclass
@@ -93,7 +79,7 @@ class StepMetrics:
     first_token_latency_ms: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return _fields_to_dict(self)
+        return fields_to_dict(self)
 
 
 @dataclass
@@ -157,7 +143,7 @@ class StepRecord:
         return None
 
     def to_dict(self) -> dict[str, Any]:
-        payload = _fields_to_dict(self)
+        payload = fields_to_dict(self)
         payload["user_input"] = _serialize_user_input_structured(self.user_input)
         payload["metrics"] = self.metrics.to_dict() if self.metrics else None
         return payload

--- a/agiwo/agent/runtime/context.py
+++ b/agiwo/agent/runtime/context.py
@@ -118,10 +118,6 @@ class RunContext:
     def start_time(self) -> float:
         return self.ledger.start_time
 
-    @start_time.setter
-    def start_time(self, value: float) -> None:
-        self.ledger.start_time = value
-
     @property
     def termination_reason(self) -> TerminationReason | None:
         return self.ledger.termination_reason
@@ -130,81 +126,41 @@ class RunContext:
     def total_tokens(self) -> int:
         return self.ledger.total_tokens
 
-    @total_tokens.setter
-    def total_tokens(self, value: int) -> None:
-        self.ledger.total_tokens = value
-
     @property
     def input_tokens(self) -> int:
         return self.ledger.input_tokens
-
-    @input_tokens.setter
-    def input_tokens(self, value: int) -> None:
-        self.ledger.input_tokens = value
 
     @property
     def output_tokens(self) -> int:
         return self.ledger.output_tokens
 
-    @output_tokens.setter
-    def output_tokens(self, value: int) -> None:
-        self.ledger.output_tokens = value
-
     @property
     def cache_read_tokens(self) -> int:
         return self.ledger.cache_read_tokens
-
-    @cache_read_tokens.setter
-    def cache_read_tokens(self, value: int) -> None:
-        self.ledger.cache_read_tokens = value
 
     @property
     def cache_creation_tokens(self) -> int:
         return self.ledger.cache_creation_tokens
 
-    @cache_creation_tokens.setter
-    def cache_creation_tokens(self, value: int) -> None:
-        self.ledger.cache_creation_tokens = value
-
     @property
     def token_cost(self) -> float:
         return self.ledger.token_cost
-
-    @token_cost.setter
-    def token_cost(self, value: float) -> None:
-        self.ledger.token_cost = value
 
     @property
     def steps_count(self) -> int:
         return self.ledger.steps_count
 
-    @steps_count.setter
-    def steps_count(self, value: int) -> None:
-        self.ledger.steps_count = value
-
     @property
     def tool_calls_count(self) -> int:
         return self.ledger.tool_calls_count
-
-    @tool_calls_count.setter
-    def tool_calls_count(self, value: int) -> None:
-        self.ledger.tool_calls_count = value
 
     @property
     def assistant_steps_count(self) -> int:
         return self.ledger.assistant_steps_count
 
-    @assistant_steps_count.setter
-    def assistant_steps_count(self, value: int) -> None:
-        self.ledger.assistant_steps_count = value
-
     @property
     def response_content(self) -> str | None:
         return self.ledger.response_content
-
-    @response_content.setter
-    def response_content(self, value: str | None) -> None:
-        self.ledger.response_content = value
 
     @property
     def last_compact_metadata(self) -> CompactMetadata | None:

--- a/tests/agent/test_state_tracking.py
+++ b/tests/agent/test_state_tracking.py
@@ -134,6 +134,15 @@ def test_run_context_disallows_direct_assignment_to_mutable_ledger_fields() -> N
     with pytest.raises(AttributeError):
         state.last_compact_metadata = metadata
 
+    with pytest.raises(AttributeError):
+        state.total_tokens = 99
+
+    with pytest.raises(AttributeError):
+        state.steps_count = 99
+
+    with pytest.raises(AttributeError):
+        state.response_content = "direct write"
+
     replace_messages(state, [{"role": "assistant", "content": "summary"}])
     snapshot = state.messages
     snapshot[0]["content"] = "mutated"


### PR DESCRIPTION
## Summary

对 agent-runtime-clarity-refactor plan 完成后的遗留卫生项进行收尾优化：

- **移除 RunContext 死代码 setter**：移除 `total_tokens`、`input_tokens`、`output_tokens`、`cache_read_tokens`、`cache_creation_tokens`、`token_cost`、`steps_count`、`tool_calls_count`、`assistant_steps_count`、`response_content`、`start_time` 等 property setter。所有 ledger 写入统一收口到 `runtime/state_ops.py`，getter 保留作为只读 API。
- **消除 `_fields_to_dict` 重复**：从 `models/run.py` 和 `models/step.py` 提取到共享的 `models/_serialization.py`。
- **增强封装测试**：在 `test_state_tracking.py` 中增加 `total_tokens`、`steps_count`、`response_content` 的 setter 拒绝测试，锁定封装边界。

## Context

来自 `2026-03-26-agent-runtime-clarity-refactor` plan 的收尾清理。该 plan 的 5 个核心任务已全部在之前的迭代中完成，本 PR 处理审查时发现的 3 项 hygiene 优化。

## Test plan

- [x] `uv run pytest tests/agent/ -v` — 108 tests passed
- [x] `uv run pytest console/tests/test_response_serialization.py console/tests/test_run_metrics.py -v` — 6 tests passed
- [x] `uv run python scripts/lint.py files` on all changed files — passed
- [x] `uv run ruff check` + `ruff format --check` on changed files — passed
- [x] import-linter contracts — all 8 kept
- [x] repo_guard — passed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * `RunContext` properties (`start_time`, `total_tokens`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `token_cost`, `steps_count`, `tool_calls_count`, `assistant_steps_count`, `response_content`) are now read-only and cannot be directly assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->