### PR TITLE
feat: Console frontend session-first UI

### DIFF
--- a/console/server/app.py
+++ b/console/server/app.py
@@ -18,6 +18,7 @@ from server.dependencies import (
 )
 from server.channels.base import safe_close_all
 from server.channels.feishu import FeishuChannelService
+from server.channels.feishu.store.memory import InMemoryFeishuChannelStore
 from server.services.agent_registry import AgentRegistry, AgentConfigRecord
 from server.services.agent_lifecycle import build_default_agent_options
 from server.services.storage_wiring import (
@@ -67,6 +68,9 @@ async def lifespan(app: FastAPI):
     sched = Scheduler(scheduler_config)
     await sched.start()
 
+    console_session_store = InMemoryFeishuChannelStore()
+    await console_session_store.connect()
+
     feishu_channel_service: FeishuChannelService | None = None
     if config.feishu_enabled:
         logger.info("feishu_channel_enabled", enabled=True)
@@ -110,6 +114,7 @@ async def lifespan(app: FastAPI):
             agent_registry=agent_registry,
             scheduler=sched,
             feishu_channel_service=feishu_channel_service,
+            session_store=console_session_store,
         ),
     )
 

--- a/console/server/dependencies.py
+++ b/console/server/dependencies.py
@@ -10,6 +10,7 @@ from agiwo.observability.base import BaseTraceStorage
 from agiwo.scheduler.engine import Scheduler
 
 from server.channels.feishu import FeishuChannelService
+from server.channels.session.models import ChannelChatSessionStore
 from server.config import ConsoleConfig
 from server.services.agent_registry import AgentRegistry
 
@@ -24,6 +25,7 @@ class ConsoleRuntime:
     agent_registry: AgentRegistry
     scheduler: Scheduler | None = None
     feishu_channel_service: FeishuChannelService | None = None
+    session_store: ChannelChatSessionStore | None = None
 
 
 def bind_console_runtime(app: FastAPI, runtime: ConsoleRuntime) -> None:

--- a/console/server/routers/chat.py
+++ b/console/server/routers/chat.py
@@ -55,11 +55,9 @@ async def list_agent_sessions(
 
 def _get_session_service(runtime: ConsoleRuntime) -> RemoteWorkspaceSessionService:
     """Build a RemoteWorkspaceSessionService from the console runtime."""
-    if runtime.feishu_channel_service is not None:
-        return (
-            runtime.feishu_channel_service.session_service.as_remote_workspace_service()
-        )
-    raise RuntimeError("Session service not available — Feishu channel not configured")
+    if runtime.session_store is not None:
+        return RemoteWorkspaceSessionService(store=runtime.session_store)
+    raise RuntimeError("Session store not available")
 
 
 @router.post("/{agent_id}/sessions/create")

--- a/console/web/src/app/agents/[id]/chat/page.tsx
+++ b/console/web/src/app/agents/[id]/chat/page.tsx
@@ -1,40 +1,100 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, PanelRight } from "lucide-react";
 import { ChatInputBar } from "@/components/chat-input-bar";
 import { ChatMessageItem } from "@/components/chat-message";
 import { EmptyStateMessage, FullPageMessage } from "@/components/state-message";
-import { getAgent, chatStreamUrl, parseStreamEventPayload } from "@/lib/api";
-import type { AgentConfig, AgentStreamEventPayload, ToolCallPayload } from "@/lib/api";
+import { SessionPanel } from "@/components/session-panel/session-panel";
+import { getAgent, chatStreamUrl, getSessionSteps } from "@/lib/api";
+import type { AgentConfig, StepResponse } from "@/lib/api";
+import { useChatStream } from "@/hooks/use-chat-stream";
+import type { ChatMessage } from "@/lib/chat-types";
+import { genMessageId } from "@/lib/chat-types";
 
-function genId(): string {
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
-
-interface ChatMessage {
-  id: string;
-  role: "user" | "assistant" | "tool";
-  content: string;
-  name?: string;
-  tool_calls?: ToolCallPayload[];
-  reasoning_content?: string;
-  isStreaming?: boolean;
+function stepsToMessages(steps: StepResponse[]): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  for (const step of steps) {
+    if (step.role === "user" && step.user_input) {
+      const text =
+        typeof step.user_input === "string"
+          ? step.user_input
+          : JSON.stringify(step.user_input);
+      if (text) {
+        msgs.push({ id: genMessageId(), role: "user", content: text });
+      }
+    } else if (step.role === "assistant") {
+      const content =
+        typeof step.content === "string"
+          ? step.content
+          : step.content
+            ? JSON.stringify(step.content)
+            : "";
+      if (content || (step.tool_calls && step.tool_calls.length > 0)) {
+        msgs.push({
+          id: genMessageId(),
+          role: "assistant",
+          content: content || "",
+          tool_calls: step.tool_calls ?? undefined,
+          reasoning_content: step.reasoning_content ?? undefined,
+        });
+      }
+    } else if (step.role === "tool") {
+      const content =
+        typeof step.content === "string"
+          ? step.content
+          : JSON.stringify(step.content);
+      msgs.push({
+        id: genMessageId(),
+        role: "tool",
+        content,
+        name: step.name || undefined,
+      });
+    }
+  }
+  return msgs;
 }
 
 export default function AgentChatPage() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const agentId = params.id as string;
 
   const [agent, setAgent] = useState<AgentConfig | null>(null);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(
+    searchParams.get("session"),
+  );
   const [loading, setLoading] = useState(true);
+  const [showSessionPanel, setShowSessionPanel] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const updateSessionUrl = useCallback(
+    (sid: string) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("session", sid);
+      router.replace(url.pathname + url.search);
+    },
+    [router],
+  );
+
+  const {
+    messages,
+    isStreaming,
+    sendMessage,
+    clearMessages,
+    loadHistoryMessages,
+  } = useChatStream(chatStreamUrl(agentId), {
+    onSessionCaptured: (sid) => {
+      if (!sessionId) {
+        setSessionId(sid);
+        updateSessionUrl(sid);
+      }
+    },
+  });
 
   useEffect(() => {
     getAgent(agentId)
@@ -44,174 +104,49 @@ export default function AgentChatPage() {
   }, [agentId]);
 
   useEffect(() => {
+    if (sessionId && messages.length === 0 && !isStreaming) {
+      getSessionSteps(sessionId)
+        .then((steps) => {
+          const history = stepsToMessages(steps);
+          if (history.length > 0) {
+            loadHistoryMessages(history);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const sendMessage = async () => {
+  const handleSend = () => {
     const text = input.trim();
     if (!text || isStreaming) return;
-
     setInput("");
-    setIsStreaming(true);
+    sendMessage(text, sessionId);
+  };
 
-    const userMsg: ChatMessage = {
-      id: genId(),
-      role: "user",
-      content: text,
-    };
-    setMessages((prev) => [...prev, userMsg]);
-
-    const assistantMsg: ChatMessage = {
-      id: genId(),
-      role: "assistant",
-      content: "",
-      isStreaming: true,
-    };
-    setMessages((prev) => [...prev, assistantMsg]);
-
+  const handleSessionSwitch = async (targetSessionId: string) => {
+    setSessionId(targetSessionId);
+    updateSessionUrl(targetSessionId);
+    clearMessages();
     try {
-      const res = await fetch(chatStreamUrl(agentId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message: text,
-          session_id: sessionId,
-        }),
-      });
+      const steps = await getSessionSteps(targetSessionId);
+      loadHistoryMessages(stepsToMessages(steps));
+    } catch {}
+  };
 
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
+  const handleSessionCreated = (newSessionId: string) => {
+    setSessionId(newSessionId);
+    updateSessionUrl(newSessionId);
+    clearMessages();
+  };
 
-      const reader = res.body?.getReader();
-      const decoder = new TextDecoder();
-      let currentAssistantContent = "";
-      let currentReasoningContent = "";
-      const pendingToolMessages: ChatMessage[] = [];
-      let capturedSessionId = sessionId;
-
-      if (!reader) throw new Error("No response body");
-
-      let buffer = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data:")) continue;
-          const dataStr = line.slice(5).trim();
-          if (!dataStr || dataStr === "") continue;
-
-          try {
-            const data = parseStreamEventPayload(dataStr);
-            if (!data) {
-              continue;
-            }
-            const agentEvent = data as AgentStreamEventPayload;
-
-            if (agentEvent.type === "run_started" && agentEvent.session_id) {
-              capturedSessionId = agentEvent.session_id;
-              if (!sessionId) setSessionId(capturedSessionId);
-            }
-
-            if (agentEvent.type === "step_delta" && agentEvent.delta) {
-              if (agentEvent.delta.content) {
-                currentAssistantContent += agentEvent.delta.content;
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMsg.id
-                      ? { ...m, content: currentAssistantContent, reasoning_content: currentReasoningContent || undefined }
-                      : m
-                  )
-                );
-              }
-              if (agentEvent.delta.reasoning_content) {
-                currentReasoningContent += agentEvent.delta.reasoning_content;
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMsg.id
-                      ? { ...m, reasoning_content: currentReasoningContent }
-                      : m
-                  )
-                );
-              }
-            }
-
-            if (agentEvent.type === "step_completed" && agentEvent.step) {
-              const step = agentEvent.step;
-              if (step.role === "assistant") {
-                const tc = step.tool_calls;
-                if (tc && tc.length > 0) {
-                  setMessages((prev) =>
-                    prev.map((m) =>
-                      m.id === assistantMsg.id
-                        ? { ...m, tool_calls: tc, isStreaming: false }
-                        : m
-                    )
-                  );
-                }
-              }
-              if (step.role === "tool") {
-                const toolMsg: ChatMessage = {
-                  id: genId(),
-                  role: "tool",
-                  content:
-                    typeof step.content === "string"
-                      ? step.content
-                      : JSON.stringify(step.content),
-                  name: step.name || undefined,
-                };
-                pendingToolMessages.push(toolMsg);
-                setMessages((prev) => [...prev, toolMsg]);
-
-                // New assistant message for next LLM response
-                const nextAssistant: ChatMessage = {
-                  id: genId(),
-                  role: "assistant",
-                  content: "",
-                  isStreaming: true,
-                };
-                assistantMsg.id = nextAssistant.id;
-                currentAssistantContent = "";
-                currentReasoningContent = "";
-                setMessages((prev) => [...prev, nextAssistant]);
-              }
-            }
-
-            if (agentEvent.type === "run_completed") {
-              setMessages((prev) =>
-                prev
-                  .map((m) =>
-                    m.id === assistantMsg.id
-                      ? { ...m, isStreaming: false }
-                      : m
-                  )
-                  .filter((m) => !(m.role === "assistant" && !m.content && !m.tool_calls && !m.isStreaming))
-              );
-            }
-          } catch {
-          }
-        }
-      }
-    } catch (err) {
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantMsg.id
-            ? {
-                ...m,
-                content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-                isStreaming: false,
-              }
-            : m
-        )
-      );
-    } finally {
-      setIsStreaming(false);
-    }
+  const handleSessionForked = async (forkedSessionId: string) => {
+    setSessionId(forkedSessionId);
+    updateSessionUrl(forkedSessionId);
+    clearMessages();
   };
 
   if (loading) {
@@ -223,46 +158,76 @@ export default function AgentChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="shrink-0 px-5 py-3 border-b border-zinc-800 flex items-center gap-3 bg-zinc-900/50">
-        <Link
-          href="/agents"
-          className="p-1.5 rounded hover:bg-zinc-800 transition-colors"
-        >
-          <ArrowLeft className="w-4 h-4" />
-        </Link>
-        <div>
-          <h1 className="text-sm font-medium">{agent.name}</h1>
-          <p className="text-xs text-zinc-500">
-            {agent.model_provider}/{agent.model_name}
-            {sessionId && (
-              <span className="ml-2 font-mono">{sessionId.slice(0, 8)}</span>
-            )}
-          </p>
+    <div className="flex h-full">
+      <div className="flex flex-col flex-1 min-w-0">
+        <div className="shrink-0 px-5 py-3 border-b border-zinc-800 flex items-center justify-between bg-zinc-900/50">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/agents"
+              className="p-1.5 rounded hover:bg-zinc-800 transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </Link>
+            <div>
+              <h1 className="text-sm font-medium">{agent.name}</h1>
+              <p className="text-xs text-zinc-500">
+                {agent.model_provider}/{agent.model_name}
+                {sessionId && (
+                  <span className="ml-2 font-mono">
+                    {sessionId.slice(0, 8)}
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => setShowSessionPanel((v) => !v)}
+            className={`p-1.5 rounded transition-colors ${
+              showSessionPanel
+                ? "bg-zinc-700 text-white"
+                : "hover:bg-zinc-800 text-zinc-500"
+            }`}
+            title="Toggle session panel"
+          >
+            <PanelRight className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
+          {messages.length === 0 && (
+            <EmptyStateMessage className="flex items-center justify-center h-full text-zinc-600 text-sm">
+              Send a message to start the conversation
+            </EmptyStateMessage>
+          )}
+
+          {messages.map((msg) => (
+            <ChatMessageItem key={msg.id} message={msg} />
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <div className="shrink-0 px-5 py-3 border-t border-zinc-800 bg-zinc-900/50">
+          <ChatInputBar
+            value={input}
+            onChange={setInput}
+            onSubmit={handleSend}
+            disabled={isStreaming}
+          />
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
-        {messages.length === 0 && (
-          <EmptyStateMessage className="flex items-center justify-center h-full text-zinc-600 text-sm">
-            Send a message to start the conversation
-          </EmptyStateMessage>
-        )}
-
-        {messages.map((msg) => (
-          <ChatMessageItem key={msg.id} message={msg} />
-        ))}
-        <div ref={messagesEndRef} />
-      </div>
-
-      <div className="shrink-0 px-5 py-3 border-t border-zinc-800 bg-zinc-900/50">
-        <ChatInputBar
-          value={input}
-          onChange={setInput}
-          onSubmit={sendMessage}
-          disabled={isStreaming}
-        />
-      </div>
+      {showSessionPanel && (
+        <div className="w-72 shrink-0 border-l border-zinc-800 bg-zinc-950/50">
+          <SessionPanel
+            agentId={agentId}
+            scopeId={agentId}
+            currentSessionId={sessionId}
+            onSwitch={handleSessionSwitch}
+            onCreated={handleSessionCreated}
+            onForked={handleSessionForked}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/console/web/src/app/agents/[id]/scheduler-chat/page.tsx
+++ b/console/web/src/app/agents/[id]/scheduler-chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import { useParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -14,50 +14,52 @@ import {
   Play,
   ChevronDown,
   ChevronRight,
+  PanelRight,
 } from "lucide-react";
 import {
   getAgent,
-  parseStreamEventPayload,
   schedulerChatStreamUrl,
   cancelSchedulerChat,
   getAgentStateChildren,
+  getSessionSteps,
 } from "@/lib/api";
 import { ChatInputBar } from "@/components/chat-input-bar";
 import { ChatMessageItem } from "@/components/chat-message";
 import { PillBadge } from "@/components/pill-badge";
 import { EmptyStateMessage, FullPageMessage } from "@/components/state-message";
 import { UserInputCompact } from "@/components/user-input-detail";
+import { SessionPanel } from "@/components/session-panel/session-panel";
+import { useChatStream } from "@/hooks/use-chat-stream";
+import type { ChatMessage } from "@/lib/chat-types";
+import { genMessageId } from "@/lib/chat-types";
 import type {
   AgentConfig,
   AgentStateListItem,
-  SchedulerFailedEventPayload,
-  StepResponse,
+  RunCompletedEventPayload,
   StreamEventPayload,
-  ToolCallPayload,
+  StepResponse,
 } from "@/lib/api";
 
-function genId(): string {
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
+type OrchestrationStatus =
+  | "idle"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled";
 
-interface ChatMessage {
-  id: string;
-  role: "user" | "assistant" | "tool" | "system";
-  content: string;
-  name?: string;
-  tool_calls?: ToolCallPayload[];
-  reasoning_content?: string;
-  isStreaming?: boolean;
-  agentId?: string;
-}
-
-type OrchestrationStatus = "idle" | "running" | "waiting" | "completed" | "failed" | "cancelled";
-
-const statusConfig: Record<OrchestrationStatus, { icon: typeof Play; color: string; label: string }> = {
+const statusConfig: Record<
+  OrchestrationStatus,
+  { icon: typeof Play; color: string; label: string }
+> = {
   idle: { icon: Clock, color: "text-zinc-500", label: "Idle" },
   running: { icon: Loader2, color: "text-blue-400", label: "Running" },
   waiting: { icon: Moon, color: "text-yellow-400", label: "Waiting" },
-  completed: { icon: CheckCircle2, color: "text-green-400", label: "Completed" },
+  completed: {
+    icon: CheckCircle2,
+    color: "text-green-400",
+    label: "Completed",
+  },
   failed: { icon: AlertCircle, color: "text-red-400", label: "Failed" },
   cancelled: { icon: XCircle, color: "text-zinc-400", label: "Cancelled" },
 };
@@ -72,44 +74,83 @@ const childStatusBadge: Record<string, string> = {
   failed: "bg-red-900/50 text-red-400",
 };
 
+function stepsToMessages(steps: StepResponse[]): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  for (const step of steps) {
+    if (step.role === "user" && step.user_input) {
+      const text =
+        typeof step.user_input === "string"
+          ? step.user_input
+          : JSON.stringify(step.user_input);
+      if (text) msgs.push({ id: genMessageId(), role: "user", content: text });
+    } else if (step.role === "assistant") {
+      const content =
+        typeof step.content === "string"
+          ? step.content
+          : step.content
+            ? JSON.stringify(step.content)
+            : "";
+      if (content || (step.tool_calls && step.tool_calls.length > 0)) {
+        msgs.push({
+          id: genMessageId(),
+          role: "assistant",
+          content: content || "",
+          tool_calls: step.tool_calls ?? undefined,
+          reasoning_content: step.reasoning_content ?? undefined,
+        });
+      }
+    } else if (step.role === "tool") {
+      const content =
+        typeof step.content === "string"
+          ? step.content
+          : JSON.stringify(step.content);
+      msgs.push({
+        id: genMessageId(),
+        role: "tool",
+        content,
+        name: step.name || undefined,
+      });
+    }
+  }
+  return msgs;
+}
+
 export default function SchedulerChatPage() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const agentId = params.id as string;
 
   const [agent, setAgent] = useState<AgentConfig | null>(null);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(
+    searchParams.get("session"),
+  );
   const [loading, setLoading] = useState(true);
-  const [orchestrationStatus, setOrchestrationStatus] = useState<OrchestrationStatus>("idle");
+  const [orchestrationStatus, setOrchestrationStatus] =
+    useState<OrchestrationStatus>("idle");
   const [stateId, setStateId] = useState<string | null>(null);
   const [children, setChildren] = useState<AgentStateListItem[]>([]);
-  const [expandedChildren, setExpandedChildren] = useState<Set<string>>(new Set());
-  const [childMessages, setChildMessages] = useState<Record<string, ChatMessage[]>>({});
+  const [expandedChildren, setExpandedChildren] = useState<Set<string>>(
+    new Set(),
+  );
+  const [childMessages, setChildMessages] = useState<
+    Record<string, ChatMessage[]>
+  >({});
   const [startTime, setStartTime] = useState<number | null>(null);
   const [elapsed, setElapsed] = useState(0);
+  const [showSessionPanel, setShowSessionPanel] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => {
-    getAgent(agentId)
-      .then(setAgent)
-      .catch(() => setAgent(null))
-      .finally(() => setLoading(false));
-  }, [agentId]);
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
-  useEffect(() => {
-    if (!startTime || orchestrationStatus === "completed" || orchestrationStatus === "failed") return;
-    const timer = setInterval(() => {
-      setElapsed(((Date.now() - startTime) / 1000));
-    }, 100);
-    return () => clearInterval(timer);
-  }, [startTime, orchestrationStatus]);
+  const updateSessionUrl = useCallback(
+    (sid: string) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("session", sid);
+      router.replace(url.pathname + url.search);
+    },
+    [router],
+  );
 
   const pollChildren = useCallback((sid: string) => {
     if (pollRef.current) clearInterval(pollRef.current);
@@ -117,9 +158,7 @@ export default function SchedulerChatPage() {
       try {
         const result = await getAgentStateChildren(sid);
         setChildren(result);
-      } catch {
-        // ignore polling errors
-      }
+      } catch {}
     }, 2000);
   }, []);
 
@@ -134,19 +173,179 @@ export default function SchedulerChatPage() {
     return stopPolling;
   }, [stopPolling]);
 
+  const handleChildEvent = useCallback(
+    (childAgentId: string, data: StreamEventPayload) => {
+      const type = data.type;
+      if (type === "step_delta" && "delta" in data && data.delta) {
+        const delta = data.delta;
+        if (delta.content) {
+          setChildMessages((prev) => {
+            const msgs = prev[childAgentId] || [];
+            const last = msgs[msgs.length - 1];
+            if (last && last.role === "assistant" && last.isStreaming) {
+              return {
+                ...prev,
+                [childAgentId]: msgs.map((m, i) =>
+                  i === msgs.length - 1
+                    ? { ...m, content: m.content + delta.content }
+                    : m,
+                ),
+              };
+            }
+            return {
+              ...prev,
+              [childAgentId]: [
+                ...msgs,
+                {
+                  id: genMessageId(),
+                  role: "assistant" as const,
+                  content: delta.content ?? "",
+                  isStreaming: true,
+                  agentId: childAgentId,
+                },
+              ],
+            };
+          });
+        }
+      }
+      if (type === "step_completed" && "step" in data && data.step) {
+        const step = data.step as StepResponse;
+        if (step.role === "tool") {
+          setChildMessages((prev) => ({
+            ...prev,
+            [childAgentId]: [
+              ...(prev[childAgentId] || []),
+              {
+                id: genMessageId(),
+                role: "tool" as const,
+                content:
+                  typeof step.content === "string"
+                    ? step.content
+                    : JSON.stringify(step.content),
+                name: step.name || undefined,
+                agentId: childAgentId,
+              },
+            ],
+          }));
+        }
+        if (step.role === "assistant" && step.tool_calls?.length) {
+          for (const call of step.tool_calls) {
+            if (call.function?.name === "sleep_and_wait") {
+              setOrchestrationStatus("waiting");
+            }
+          }
+        }
+      }
+      if (type === "run_completed") {
+        setChildMessages((prev) => {
+          const msgs = prev[childAgentId] || [];
+          return {
+            ...prev,
+            [childAgentId]: msgs.map((m) =>
+              m.isStreaming ? { ...m, isStreaming: false } : m,
+            ),
+          };
+        });
+      }
+    },
+    [],
+  );
+
+  const {
+    messages,
+    isStreaming,
+    sendMessage,
+    clearMessages,
+    loadHistoryMessages,
+  } = useChatStream(schedulerChatStreamUrl(agentId), {
+    onSessionCaptured: (sid) => {
+      if (!sessionId) {
+        setSessionId(sid);
+        updateSessionUrl(sid);
+      }
+    },
+    onRootAgentCaptured: (aid) => {
+      setStateId(aid);
+      pollChildren(aid);
+    },
+    onChildEvent: handleChildEvent,
+    onSchedulerFailed: (error) => {
+      setOrchestrationStatus("failed");
+      stopPolling();
+    },
+    onRunStarted: () => {
+      setOrchestrationStatus("running");
+    },
+    onRunCompleted: (event: RunCompletedEventPayload) => {
+      if (event.depth === 0) {
+        if (event.termination_reason === "sleeping") {
+          setOrchestrationStatus("waiting");
+        } else {
+          setOrchestrationStatus("completed");
+          stopPolling();
+          if (stateId) {
+            getAgentStateChildren(stateId)
+              .then(setChildren)
+              .catch(() => {});
+          }
+        }
+      }
+    },
+  });
+
+  useEffect(() => {
+    getAgent(agentId)
+      .then(setAgent)
+      .catch(() => setAgent(null))
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  useEffect(() => {
+    if (sessionId && messages.length === 0 && !isStreaming) {
+      getSessionSteps(sessionId)
+        .then((steps) => {
+          const history = stepsToMessages(steps);
+          if (history.length > 0) loadHistoryMessages(history);
+        })
+        .catch(() => {});
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    if (
+      !startTime ||
+      orchestrationStatus === "completed" ||
+      orchestrationStatus === "failed"
+    )
+      return;
+    const timer = setInterval(() => {
+      setElapsed((Date.now() - startTime) / 1000);
+    }, 100);
+    return () => clearInterval(timer);
+  }, [startTime, orchestrationStatus]);
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text || isStreaming) return;
+    setInput("");
+    setOrchestrationStatus("running");
+    setStartTime(Date.now());
+    setChildren([]);
+    setChildMessages({});
+    sendMessage(text, sessionId);
+  };
+
   const handleCancel = async () => {
     if (!stateId) return;
     try {
       await cancelSchedulerChat(agentId, stateId);
       setOrchestrationStatus("cancelled");
       stopPolling();
-      setMessages((prev) => [
-        ...prev,
-        { id: genId(), role: "system", content: "Orchestration cancelled by user." },
-      ]);
-    } catch (err) {
-      console.error("Cancel failed:", err);
-    }
+    } catch {}
   };
 
   const toggleChild = (childId: string) => {
@@ -158,304 +357,38 @@ export default function SchedulerChatPage() {
     });
   };
 
-  const sendMessage = async () => {
-    const text = input.trim();
-    if (!text || isStreaming) return;
-
-    setInput("");
-    setIsStreaming(true);
-    setOrchestrationStatus("running");
-    setStartTime(Date.now());
+  const handleSessionSwitch = async (targetSessionId: string) => {
+    setSessionId(targetSessionId);
+    updateSessionUrl(targetSessionId);
+    clearMessages();
+    setOrchestrationStatus("idle");
     setChildren([]);
     setChildMessages({});
-
-    const userMsg: ChatMessage = { id: genId(), role: "user", content: text };
-    setMessages((prev) => [...prev, userMsg]);
-
-    const assistantMsg: ChatMessage = {
-      id: genId(),
-      role: "assistant",
-      content: "",
-      isStreaming: true,
-    };
-    setMessages((prev) => [...prev, assistantMsg]);
-
-    let currentAssistantContent = "";
-    let currentReasoningContent = "";
-    let rootAgentId: string | null = null;
-
+    setStateId(null);
     try {
-      const res = await fetch(schedulerChatStreamUrl(agentId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text, session_id: sessionId }),
-      });
-
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-      const reader = res.body?.getReader();
-      const decoder = new TextDecoder();
-      if (!reader) throw new Error("No response body");
-
-      let buffer = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data:")) continue;
-          const dataStr = line.slice(5).trim();
-          if (!dataStr) continue;
-
-          try {
-            const data = parseStreamEventPayload(dataStr);
-            if (!data) {
-              continue;
-            }
-            if (data.type === "scheduler_failed") {
-              const event = data as SchedulerFailedEventPayload;
-              setOrchestrationStatus("failed");
-              stopPolling();
-              setMessages((prev) => [
-                ...prev.filter((m) => !(m.role === "assistant" && !m.content && !m.tool_calls)),
-                { id: genId(), role: "system", content: `Orchestration failed: ${event.error || "Unknown error"}` },
-              ]);
-              continue;
-            }
-            const eventAgentId =
-              "agent_id" in data && typeof data.agent_id === "string"
-                ? data.agent_id
-                : null;
-
-            if (data.type === "run_started" && data.session_id) {
-              const capturedSessionId = data.session_id;
-              if (!sessionId) setSessionId(capturedSessionId);
-              if (!rootAgentId) {
-                rootAgentId = eventAgentId;
-                setStateId(eventAgentId);
-                if (eventAgentId) pollChildren(eventAgentId);
-              }
-            }
-
-            const isChildEvent = rootAgentId && eventAgentId && eventAgentId !== rootAgentId;
-
-            if (isChildEvent) {
-              handleChildEvent(eventAgentId, data);
-              continue;
-            }
-
-            if (data.type === "step_delta" && "delta" in data && data.delta) {
-              if (data.delta.content) {
-                currentAssistantContent += data.delta.content;
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMsg.id
-                      ? { ...m, content: currentAssistantContent, reasoning_content: currentReasoningContent || undefined }
-                      : m
-                  )
-                );
-              }
-              if (data.delta.reasoning_content) {
-                currentReasoningContent += data.delta.reasoning_content;
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMsg.id
-                      ? { ...m, reasoning_content: currentReasoningContent }
-                      : m
-                  )
-                );
-              }
-            }
-
-            if (data.type === "step_completed" && "step" in data && data.step) {
-              const step = data.step;
-              if (step.role === "assistant") {
-                const tc = step.tool_calls;
-                if (tc && tc.length > 0) {
-                  setMessages((prev) =>
-                    prev.map((m) =>
-                      m.id === assistantMsg.id
-                        ? { ...m, tool_calls: tc, isStreaming: false }
-                        : m
-                    )
-                  );
-
-                  for (const call of tc) {
-                    const toolName = call.function?.name;
-                    if (toolName === "sleep_and_wait") {
-                      setOrchestrationStatus("waiting");
-                    }
-                  }
-                }
-              }
-              if (step.role === "tool") {
-                const toolMsg: ChatMessage = {
-                  id: genId(),
-                  role: "tool",
-                  content: typeof step.content === "string" ? step.content : JSON.stringify(step.content),
-                  name: step.name || undefined,
-                };
-                setMessages((prev) => [...prev, toolMsg]);
-
-                const nextAssistant: ChatMessage = {
-                  id: genId(),
-                  role: "assistant",
-                  content: "",
-                  isStreaming: true,
-                };
-                assistantMsg.id = nextAssistant.id;
-                currentAssistantContent = "";
-                currentReasoningContent = "";
-                setMessages((prev) => [...prev, nextAssistant]);
-              }
-            }
-
-            if (data.type === "run_completed") {
-              setMessages((prev) =>
-                prev
-                  .map((m) =>
-                    m.id === assistantMsg.id ? { ...m, isStreaming: false } : m
-                  )
-                  .filter((m) => !(m.role === "assistant" && !m.content && !m.tool_calls && !m.isStreaming))
-              );
-              if (data.depth === 0) {
-                if (data.termination_reason === "sleeping") {
-                  setOrchestrationStatus("waiting");
-                } else {
-                  setOrchestrationStatus("completed");
-                  stopPolling();
-                  if (stateId) {
-                    try {
-                      const finalChildren = await getAgentStateChildren(stateId);
-                      setChildren(finalChildren);
-                    } catch {
-                      // ignore final poll failures
-                    }
-                  }
-                }
-              }
-            }
-
-            if (data.type === "run_failed" && data.depth === 0) {
-              setOrchestrationStatus("failed");
-              stopPolling();
-              setMessages((prev) => [
-                ...prev.filter((m) => !(m.role === "assistant" && !m.content && !m.tool_calls)),
-                { id: genId(), role: "system", content: `Orchestration failed: ${data.error || "Unknown error"}` },
-              ]);
-            }
-
-            if (data.type === "run_started" && rootAgentId && eventAgentId === rootAgentId) {
-              setOrchestrationStatus("running");
-              if (!currentAssistantContent && assistantMsg.id) {
-                // woke up, start fresh assistant message
-                const wakeMsg: ChatMessage = {
-                  id: genId(),
-                  role: "system",
-                  content: "Agent woke up — resuming execution",
-                };
-                const nextAssistant: ChatMessage = {
-                  id: genId(),
-                  role: "assistant",
-                  content: "",
-                  isStreaming: true,
-                };
-                assistantMsg.id = nextAssistant.id;
-                currentAssistantContent = "";
-                currentReasoningContent = "";
-                setMessages((prev) => [
-                  ...prev.filter((m) => !(m.role === "assistant" && !m.content && !m.tool_calls)),
-                  wakeMsg,
-                  nextAssistant,
-                ]);
-              }
-            }
-
-          } catch {
-            // skip non-JSON lines
-          }
-        }
-      }
-    } catch (err) {
-      setOrchestrationStatus("failed");
-      stopPolling();
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantMsg.id
-            ? { ...m, content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`, isStreaming: false }
-            : m
-        )
-      );
-    } finally {
-      setIsStreaming(false);
-    }
+      const steps = await getSessionSteps(targetSessionId);
+      loadHistoryMessages(stepsToMessages(steps));
+    } catch {}
   };
 
-  const handleChildEvent = (childAgentId: string, data: StreamEventPayload) => {
-    const type = data.type;
-    if (type === "step_delta" && data.delta) {
-      const delta = data.delta;
-      if (delta.content) {
-        setChildMessages((prev) => {
-          const msgs = prev[childAgentId] || [];
-          const last = msgs[msgs.length - 1];
-          if (last && last.role === "assistant" && last.isStreaming) {
-            return {
-              ...prev,
-              [childAgentId]: msgs.map((m, i) =>
-                i === msgs.length - 1
-                  ? { ...m, content: m.content + delta.content }
-                  : m
-              ),
-            };
-          }
-          return {
-            ...prev,
-            [childAgentId]: [
-              ...msgs,
-              {
-                id: genId(),
-                role: "assistant" as const,
-                content: delta.content ?? "",
-                isStreaming: true,
-                agentId: childAgentId,
-              },
-            ],
-          };
-        });
-      }
-    }
-    if (type === "step_completed" && data.step) {
-      const step = data.step as StepResponse;
-      if (step.role === "tool") {
-        const toolMsg: ChatMessage = {
-          id: genId(),
-          role: "tool",
-          content: typeof step.content === "string" ? step.content : JSON.stringify(step.content),
-          name: step.name || undefined,
-          agentId: childAgentId,
-        };
-        setChildMessages((prev) => ({
-          ...prev,
-          [childAgentId]: [...(prev[childAgentId] || []), toolMsg],
-        }));
-      }
-    }
-    if (type === "run_completed") {
-      setChildMessages((prev) => {
-        const msgs = prev[childAgentId] || [];
-        return {
-          ...prev,
-          [childAgentId]: msgs.map((m) =>
-            m.isStreaming ? { ...m, isStreaming: false } : m
-          ),
-        };
-      });
-    }
+  const handleSessionCreated = (newSessionId: string) => {
+    setSessionId(newSessionId);
+    updateSessionUrl(newSessionId);
+    clearMessages();
+    setOrchestrationStatus("idle");
+    setChildren([]);
+    setChildMessages({});
+    setStateId(null);
+  };
+
+  const handleSessionForked = (forkedSessionId: string) => {
+    setSessionId(forkedSessionId);
+    updateSessionUrl(forkedSessionId);
+    clearMessages();
+    setOrchestrationStatus("idle");
+    setChildren([]);
+    setChildMessages({});
+    setStateId(null);
   };
 
   if (loading) {
@@ -472,10 +405,12 @@ export default function SchedulerChatPage() {
     <div className="flex h-full">
       {/* Left: Chat */}
       <div className="flex flex-col flex-1 min-w-0">
-        {/* Header */}
         <div className="shrink-0 px-5 py-3 border-b border-zinc-800 flex items-center justify-between bg-zinc-900/50">
           <div className="flex items-center gap-3">
-            <Link href="/agents" className="p-1.5 rounded hover:bg-zinc-800 transition-colors">
+            <Link
+              href="/agents"
+              className="p-1.5 rounded hover:bg-zinc-800 transition-colors"
+            >
               <ArrowLeft className="w-4 h-4" />
             </Link>
             <div>
@@ -487,22 +422,38 @@ export default function SchedulerChatPage() {
               </div>
               <p className="text-xs text-zinc-500">
                 {agent.model_provider}/{agent.model_name}
-                {sessionId && <span className="ml-2 font-mono">{sessionId.slice(0, 8)}</span>}
+                {sessionId && (
+                  <span className="ml-2 font-mono">
+                    {sessionId.slice(0, 8)}
+                  </span>
+                )}
               </p>
             </div>
           </div>
-          {isStreaming && (
+          <div className="flex items-center gap-2">
+            {isStreaming && (
+              <button
+                onClick={handleCancel}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-900/30 text-red-400 text-xs font-medium hover:bg-red-900/50 transition-colors"
+              >
+                <XCircle className="w-3.5 h-3.5" />
+                Cancel
+              </button>
+            )}
             <button
-              onClick={handleCancel}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-900/30 text-red-400 text-xs font-medium hover:bg-red-900/50 transition-colors"
+              onClick={() => setShowSessionPanel((v) => !v)}
+              className={`p-1.5 rounded transition-colors ${
+                showSessionPanel
+                  ? "bg-zinc-700 text-white"
+                  : "hover:bg-zinc-800 text-zinc-500"
+              }`}
+              title="Toggle session panel"
             >
-              <XCircle className="w-3.5 h-3.5" />
-              Cancel
+              <PanelRight className="w-4 h-4" />
             </button>
-          )}
+          </div>
         </div>
 
-        {/* Messages */}
         <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
           {messages.length === 0 && (
             <EmptyStateMessage className="flex items-center justify-center h-full text-zinc-600 text-sm">
@@ -516,27 +467,43 @@ export default function SchedulerChatPage() {
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Input */}
         <div className="shrink-0 px-5 py-3 border-t border-zinc-800 bg-zinc-900/50">
           <ChatInputBar
             value={input}
             onChange={setInput}
-            onSubmit={sendMessage}
+            onSubmit={handleSend}
             disabled={isStreaming}
           />
         </div>
       </div>
 
+      {/* Middle: Session Panel (togglable) */}
+      {showSessionPanel && (
+        <div className="w-72 shrink-0 border-l border-zinc-800 bg-zinc-950/50">
+          <SessionPanel
+            agentId={agentId}
+            scopeId={agentId}
+            currentSessionId={sessionId}
+            onSwitch={handleSessionSwitch}
+            onCreated={handleSessionCreated}
+            onForked={handleSessionForked}
+          />
+        </div>
+      )}
+
       {/* Right: Orchestration Panel */}
       <div className="w-80 shrink-0 border-l border-zinc-800 flex flex-col overflow-hidden bg-zinc-950/50">
-        {/* Status */}
         <div className="px-4 py-3 border-b border-zinc-800">
-          <h2 className="text-xs font-medium text-zinc-400 uppercase mb-2">Orchestration</h2>
+          <h2 className="text-xs font-medium text-zinc-400 uppercase mb-2">
+            Orchestration
+          </h2>
           <div className="flex items-center gap-2">
             <StatusIcon
               className={`w-4 h-4 ${statusConfig[orchestrationStatus].color} ${orchestrationStatus === "running" ? "animate-spin" : ""}`}
             />
-            <span className={`text-sm font-medium ${statusConfig[orchestrationStatus].color}`}>
+            <span
+              className={`text-sm font-medium ${statusConfig[orchestrationStatus].color}`}
+            >
               {statusConfig[orchestrationStatus].label}
             </span>
             {startTime && (
@@ -552,7 +519,6 @@ export default function SchedulerChatPage() {
           )}
         </div>
 
-        {/* Children */}
         <div className="flex-1 overflow-auto">
           <div className="px-4 py-3">
             <h2 className="text-xs font-medium text-zinc-400 uppercase mb-2">
@@ -572,7 +538,10 @@ export default function SchedulerChatPage() {
 
             <div className="space-y-2">
               {children.map((child) => (
-                <div key={child.id} className="rounded-lg bg-zinc-900/50 border border-zinc-800">
+                <div
+                  key={child.id}
+                  className="rounded-lg bg-zinc-900/50 border border-zinc-800"
+                >
                   <button
                     onClick={() => toggleChild(child.id)}
                     className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-zinc-800/50 transition-colors rounded-lg"
@@ -589,7 +558,9 @@ export default function SchedulerChatPage() {
                             ? "..." + child.id.slice(-16)
                             : child.id}
                         </span>
-                        <PillBadge className={`text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 ${childStatusBadge[child.status] || "bg-zinc-700 text-zinc-300"}`}>
+                        <PillBadge
+                          className={`text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 ${childStatusBadge[child.status] || "bg-zinc-700 text-zinc-300"}`}
+                        >
                           {child.status}
                         </PillBadge>
                       </div>
@@ -601,7 +572,9 @@ export default function SchedulerChatPage() {
                     <div className="px-3 pb-2 border-t border-zinc-800">
                       {child.result_summary && (
                         <div className="mt-2 text-xs text-zinc-400 whitespace-pre-wrap max-h-32 overflow-auto">
-                          <span className="text-zinc-500 font-medium">Result: </span>
+                          <span className="text-zinc-500 font-medium">
+                            Result:{" "}
+                          </span>
                           {child.result_summary.slice(0, 500)}
                         </div>
                       )}
@@ -609,20 +582,29 @@ export default function SchedulerChatPage() {
                         <div className="mt-2 space-y-1.5 max-h-48 overflow-auto">
                           {(childMessages[child.id] || []).map((cm) => (
                             <div key={cm.id} className="text-[11px]">
-                              <span className={`font-medium ${cm.role === "assistant" ? "text-green-400" : cm.role === "tool" ? "text-amber-400" : "text-zinc-400"}`}>
-                                {cm.role}{cm.name ? ` — ${cm.name}` : ""}:
+                              <span
+                                className={`font-medium ${cm.role === "assistant" ? "text-green-400" : cm.role === "tool" ? "text-amber-400" : "text-zinc-400"}`}
+                              >
+                                {cm.role}
+                                {cm.name ? ` — ${cm.name}` : ""}:
                               </span>{" "}
                               <span className="text-zinc-400 whitespace-pre-wrap">
-                                {cm.content.slice(0, 300)}{cm.content.length > 300 ? "..." : ""}
+                                {cm.content.slice(0, 300)}
+                                {cm.content.length > 300 ? "..." : ""}
                               </span>
-                              {cm.isStreaming && <Loader2 className="inline w-2.5 h-2.5 ml-1 animate-spin text-zinc-500" />}
+                              {cm.isStreaming && (
+                                <Loader2 className="inline w-2.5 h-2.5 ml-1 animate-spin text-zinc-500" />
+                              )}
                             </div>
                           ))}
                         </div>
                       )}
-                      {!child.result_summary && (childMessages[child.id] || []).length === 0 && (
-                        <p className="mt-2 text-[10px] text-zinc-600">No output yet</p>
-                      )}
+                      {!child.result_summary &&
+                        (childMessages[child.id] || []).length === 0 && (
+                          <p className="mt-2 text-[10px] text-zinc-600">
+                            No output yet
+                          </p>
+                        )}
                     </div>
                   )}
                 </div>

--- a/console/web/src/components/session-panel/fork-dialog.tsx
+++ b/console/web/src/components/session-panel/fork-dialog.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { GitBranch, X } from "lucide-react";
+
+interface ForkDialogProps {
+  onConfirm: (contextSummary: string) => void;
+  onCancel: () => void;
+}
+
+export function ForkDialog({ onConfirm, onCancel }: ForkDialogProps) {
+  const [summary, setSummary] = useState("");
+
+  return (
+    <div className="rounded-lg border border-zinc-700 bg-zinc-900 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-zinc-300">
+          <GitBranch className="w-3.5 h-3.5" />
+          Fork Session
+        </div>
+        <button
+          onClick={onCancel}
+          className="p-0.5 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <input
+        type="text"
+        value={summary}
+        onChange={(e) => setSummary(e.target.value)}
+        placeholder="Describe the fork context..."
+        className="w-full px-2.5 py-1.5 rounded bg-zinc-800 border border-zinc-700 text-xs focus:outline-none focus:border-zinc-500"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && summary.trim()) {
+            onConfirm(summary.trim());
+          }
+          if (e.key === "Escape") {
+            onCancel();
+          }
+        }}
+        autoFocus
+      />
+      <button
+        onClick={() => summary.trim() && onConfirm(summary.trim())}
+        disabled={!summary.trim()}
+        className="w-full py-1.5 rounded text-xs font-medium bg-blue-900/50 text-blue-400 hover:bg-blue-900/70 transition-colors disabled:opacity-30"
+      >
+        Create Fork
+      </button>
+    </div>
+  );
+}

--- a/console/web/src/components/session-panel/session-item.tsx
+++ b/console/web/src/components/session-panel/session-item.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { GitBranch, MessageSquare } from "lucide-react";
+import type { ChatSessionItem } from "@/lib/api";
+
+function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+interface SessionItemProps {
+  session: ChatSessionItem;
+  isCurrent: boolean;
+  onSwitch: () => void;
+  onFork: () => void;
+}
+
+export function SessionItem({
+  session,
+  isCurrent,
+  onSwitch,
+  onFork,
+}: SessionItemProps) {
+  return (
+    <div
+      className={`rounded-lg border p-3 transition-colors ${
+        isCurrent
+          ? "border-blue-700 bg-blue-950/30"
+          : "border-zinc-800 bg-zinc-900/50 hover:border-zinc-700 cursor-pointer"
+      }`}
+      onClick={isCurrent ? undefined : onSwitch}
+    >
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-mono text-zinc-300">
+            {session.session_id.slice(0, 8)}
+          </span>
+          {isCurrent && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-900/50 text-blue-400 font-medium">
+              current
+            </span>
+          )}
+        </div>
+        {isCurrent && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onFork();
+            }}
+            className="flex items-center gap-1 text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors px-1.5 py-0.5 rounded hover:bg-zinc-800"
+            title="Fork session"
+          >
+            <GitBranch className="w-3 h-3" />
+            Fork
+          </button>
+        )}
+      </div>
+
+      {session.current_task_id && (
+        <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 mb-1">
+          <MessageSquare className="w-3 h-3" />
+          <span className="font-mono">{session.current_task_id.slice(0, 8)}</span>
+          <span>({session.task_message_count ?? 0} msgs)</span>
+        </div>
+      )}
+
+      {session.source_session_id && (
+        <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 mb-1">
+          <GitBranch className="w-3 h-3" />
+          <span>from </span>
+          <span className="font-mono">{session.source_session_id.slice(0, 8)}</span>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-[11px] text-zinc-600">
+        <span>{session.run_count} runs</span>
+        <span>{formatRelativeTime(session.updated_at)}</span>
+      </div>
+
+      {session.fork_context_summary && (
+        <div className="mt-1.5 text-[10px] text-zinc-600 truncate" title={session.fork_context_summary}>
+          {session.fork_context_summary}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/web/src/components/session-panel/session-panel.tsx
+++ b/console/web/src/components/session-panel/session-panel.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Plus, RefreshCw } from "lucide-react";
+import {
+  listAgentChatSessions,
+  createAgentSession,
+  switchAgentSession,
+  forkAgentSession,
+} from "@/lib/api";
+import type { ChatSessionItem } from "@/lib/api";
+import { SessionItem } from "./session-item";
+import { ForkDialog } from "./fork-dialog";
+
+interface SessionPanelProps {
+  agentId: string;
+  scopeId: string;
+  currentSessionId: string | null;
+  onSwitch: (sessionId: string) => void;
+  onCreated: (sessionId: string) => void;
+  onForked: (sessionId: string) => void;
+}
+
+export function SessionPanel({
+  agentId,
+  scopeId,
+  currentSessionId,
+  onSwitch,
+  onCreated,
+  onForked,
+}: SessionPanelProps) {
+  const [sessions, setSessions] = useState<ChatSessionItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showForkDialog, setShowForkDialog] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const items = await listAgentChatSessions(agentId);
+      setSessions(items);
+    } catch {
+      // silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleCreate = async () => {
+    if (actionLoading) return;
+    setActionLoading(true);
+    try {
+      const result = await createAgentSession(agentId, scopeId);
+      onCreated(result.session_id);
+      await refresh();
+    } catch {
+      // silently fail
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleSwitch = async (targetSessionId: string) => {
+    if (actionLoading) return;
+    setActionLoading(true);
+    try {
+      await switchAgentSession(agentId, scopeId, targetSessionId);
+      onSwitch(targetSessionId);
+      await refresh();
+    } catch {
+      // silently fail
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleFork = async (contextSummary: string) => {
+    if (!currentSessionId || actionLoading) return;
+    setActionLoading(true);
+    try {
+      const result = await forkAgentSession(agentId, currentSessionId, contextSummary);
+      setShowForkDialog(false);
+      onForked(result.session_id);
+      await refresh();
+    } catch {
+      // silently fail
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-zinc-800 flex items-center justify-between">
+        <h2 className="text-xs font-medium text-zinc-400 uppercase">Sessions</h2>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className="p-1.5 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-30"
+            title="Refresh"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={actionLoading}
+            className="p-1.5 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-30"
+            title="New session"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto px-3 py-3 space-y-2">
+        {showForkDialog && (
+          <ForkDialog
+            onConfirm={handleFork}
+            onCancel={() => setShowForkDialog(false)}
+          />
+        )}
+
+        {sessions.length === 0 && !loading && (
+          <p className="text-xs text-zinc-600 text-center py-4">
+            No sessions yet
+          </p>
+        )}
+
+        {sessions.map((session) => (
+          <SessionItem
+            key={session.session_id}
+            session={session}
+            isCurrent={session.session_id === currentSessionId}
+            onSwitch={() => handleSwitch(session.session_id)}
+            onFork={() => setShowForkDialog(true)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/console/web/src/hooks/use-chat-stream.ts
+++ b/console/web/src/hooks/use-chat-stream.ts
@@ -1,0 +1,287 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { parseStreamEventPayload } from "@/lib/api";
+import type {
+  AgentStreamEventPayload,
+  RunCompletedEventPayload,
+  StreamEventPayload,
+  StepResponse,
+} from "@/lib/api";
+import type { ChatMessage } from "@/lib/chat-types";
+import { genMessageId } from "@/lib/chat-types";
+
+export interface ChatStreamCallbacks {
+  onSessionCaptured?: (sessionId: string) => void;
+  onRootAgentCaptured?: (agentId: string) => void;
+  onChildEvent?: (agentId: string, event: StreamEventPayload) => void;
+  onSchedulerFailed?: (error: string) => void;
+  onRunCompleted?: (event: RunCompletedEventPayload) => void;
+  onRunStarted?: (event: AgentStreamEventPayload) => void;
+}
+
+export function useChatStream(
+  streamUrl: string,
+  callbacks: ChatStreamCallbacks = {},
+) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
+
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+  }, []);
+
+  const loadHistoryMessages = useCallback((history: ChatMessage[]) => {
+    setMessages(history);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (text: string, sessionId: string | null) => {
+      if (!text.trim() || isStreaming) return;
+
+      setIsStreaming(true);
+
+      const userMsg: ChatMessage = {
+        id: genMessageId(),
+        role: "user",
+        content: text,
+      };
+
+      const assistantMsg: ChatMessage = {
+        id: genMessageId(),
+        role: "assistant",
+        content: "",
+        isStreaming: true,
+      };
+
+      setMessages((prev) => [...prev, userMsg, assistantMsg]);
+
+      let currentAssistantContent = "";
+      let currentReasoningContent = "";
+      let currentAssistantId = assistantMsg.id;
+      let rootAgentId: string | null = null;
+
+      try {
+        const res = await fetch(streamUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: text, session_id: sessionId }),
+        });
+
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+        const reader = res.body?.getReader();
+        const decoder = new TextDecoder();
+        if (!reader) throw new Error("No response body");
+
+        let buffer = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (!line.startsWith("data:")) continue;
+            const dataStr = line.slice(5).trim();
+            if (!dataStr) continue;
+
+            try {
+              const data = parseStreamEventPayload(dataStr);
+              if (!data) continue;
+
+              if (data.type === "scheduler_failed") {
+                callbacksRef.current.onSchedulerFailed?.(
+                  "error" in data ? String(data.error) : "Unknown error",
+                );
+                continue;
+              }
+
+              const agentEvent = data as AgentStreamEventPayload;
+              const eventAgentId =
+                "agent_id" in data && typeof data.agent_id === "string"
+                  ? data.agent_id
+                  : null;
+
+              if (agentEvent.type === "run_started" && agentEvent.session_id) {
+                callbacksRef.current.onSessionCaptured?.(agentEvent.session_id);
+                if (!rootAgentId && eventAgentId) {
+                  rootAgentId = eventAgentId;
+                  callbacksRef.current.onRootAgentCaptured?.(eventAgentId);
+                } else if (rootAgentId && eventAgentId === rootAgentId) {
+                  if (!currentAssistantContent) {
+                    const wakeMsg: ChatMessage = {
+                      id: genMessageId(),
+                      role: "system",
+                      content: "Agent woke up — resuming execution",
+                    };
+                    const nextAssistant: ChatMessage = {
+                      id: genMessageId(),
+                      role: "assistant",
+                      content: "",
+                      isStreaming: true,
+                    };
+                    currentAssistantId = nextAssistant.id;
+                    currentAssistantContent = "";
+                    currentReasoningContent = "";
+                    setMessages((prev) => [
+                      ...prev.filter(
+                        (m) =>
+                          !(
+                            m.role === "assistant" &&
+                            !m.content &&
+                            !m.tool_calls
+                          ),
+                      ),
+                      wakeMsg,
+                      nextAssistant,
+                    ]);
+                  }
+                }
+                callbacksRef.current.onRunStarted?.(agentEvent);
+              }
+
+              const isChildEvent =
+                rootAgentId && eventAgentId && eventAgentId !== rootAgentId;
+              if (isChildEvent) {
+                callbacksRef.current.onChildEvent?.(eventAgentId, data);
+                continue;
+              }
+
+              if (agentEvent.type === "step_delta" && "delta" in agentEvent && agentEvent.delta) {
+                if (agentEvent.delta.content) {
+                  currentAssistantContent += agentEvent.delta.content;
+                  const snapshot = currentAssistantContent;
+                  const reasoningSnapshot = currentReasoningContent;
+                  const aid = currentAssistantId;
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.id === aid
+                        ? {
+                            ...m,
+                            content: snapshot,
+                            reasoning_content: reasoningSnapshot || undefined,
+                          }
+                        : m,
+                    ),
+                  );
+                }
+                if (agentEvent.delta.reasoning_content) {
+                  currentReasoningContent += agentEvent.delta.reasoning_content;
+                  const snapshot = currentReasoningContent;
+                  const aid = currentAssistantId;
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.id === aid
+                        ? { ...m, reasoning_content: snapshot }
+                        : m,
+                    ),
+                  );
+                }
+              }
+
+              if (agentEvent.type === "step_completed" && "step" in agentEvent && agentEvent.step) {
+                const step = agentEvent.step as StepResponse;
+                if (step.role === "assistant") {
+                  const tc = step.tool_calls;
+                  if (tc && tc.length > 0) {
+                    const aid = currentAssistantId;
+                    setMessages((prev) =>
+                      prev.map((m) =>
+                        m.id === aid
+                          ? { ...m, tool_calls: tc, isStreaming: false }
+                          : m,
+                      ),
+                    );
+                  }
+                }
+                if (step.role === "tool") {
+                  const toolMsg: ChatMessage = {
+                    id: genMessageId(),
+                    role: "tool",
+                    content:
+                      typeof step.content === "string"
+                        ? step.content
+                        : JSON.stringify(step.content),
+                    name: step.name || undefined,
+                  };
+                  const nextAssistant: ChatMessage = {
+                    id: genMessageId(),
+                    role: "assistant",
+                    content: "",
+                    isStreaming: true,
+                  };
+                  currentAssistantId = nextAssistant.id;
+                  currentAssistantContent = "";
+                  currentReasoningContent = "";
+                  setMessages((prev) => [...prev, toolMsg, nextAssistant]);
+                }
+              }
+
+              if (agentEvent.type === "run_completed") {
+                const aid = currentAssistantId;
+                setMessages((prev) =>
+                  prev
+                    .map((m) =>
+                      m.id === aid ? { ...m, isStreaming: false } : m,
+                    )
+                    .filter(
+                      (m) =>
+                        !(
+                          m.role === "assistant" &&
+                          !m.content &&
+                          !m.tool_calls &&
+                          !m.isStreaming
+                        ),
+                    ),
+                );
+                callbacksRef.current.onRunCompleted?.(
+                  agentEvent as RunCompletedEventPayload,
+                );
+              }
+
+              if (agentEvent.type === "run_failed") {
+                const aid = currentAssistantId;
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === aid
+                      ? {
+                          ...m,
+                          content: `Error: ${"error" in agentEvent ? agentEvent.error : "Unknown error"}`,
+                          isStreaming: false,
+                        }
+                      : m,
+                  ),
+                );
+              }
+            } catch {
+              // skip non-JSON lines
+            }
+          }
+        }
+      } catch (err) {
+        const aid = currentAssistantId;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === aid
+              ? {
+                  ...m,
+                  content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
+                  isStreaming: false,
+                }
+              : m,
+          ),
+        );
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [streamUrl, isStreaming],
+  );
+
+  return { messages, isStreaming, sendMessage, clearMessages, loadHistoryMessages };
+}

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -505,6 +505,70 @@ export function getSchedulerStats() {
   return fetchJSON<SchedulerStats>(`/api/scheduler/stats`);
 }
 
+// ── Chat Sessions ──────────────────────────────────────────────────────
+
+export interface ChatSessionItem {
+  session_id: string;
+  run_count: number;
+  last_input: string | null;
+  last_response: string | null;
+  updated_at: string | null;
+  current_task_id?: string | null;
+  task_message_count?: number;
+  source_session_id?: string | null;
+  fork_context_summary?: string | null;
+}
+
+export interface SessionActionResult {
+  session_id: string;
+  task_id: string | null;
+  source_session_id: string | null;
+  previous_session_id?: string | null;
+}
+
+export function listAgentChatSessions(agentId: string) {
+  return fetchJSON<ChatSessionItem[]>(`/api/chat/${agentId}/sessions`);
+}
+
+export function createAgentSession(agentId: string, scopeId: string) {
+  return fetchJSON<SessionActionResult>(`/api/chat/${agentId}/sessions/create`, {
+    method: "POST",
+    body: JSON.stringify({
+      chat_context_scope_id: scopeId,
+      channel_instance_id: "console-web",
+      user_open_id: "console-user",
+    }),
+  });
+}
+
+export function switchAgentSession(
+  agentId: string,
+  scopeId: string,
+  targetSessionId: string,
+) {
+  return fetchJSON<SessionActionResult>(`/api/chat/${agentId}/sessions/switch`, {
+    method: "POST",
+    body: JSON.stringify({
+      chat_context_scope_id: scopeId,
+      target_session_id: targetSessionId,
+    }),
+  });
+}
+
+export function forkAgentSession(
+  agentId: string,
+  sessionId: string,
+  contextSummary: string,
+) {
+  return fetchJSON<SessionActionResult>(
+    `/api/chat/${agentId}/sessions/${sessionId}/fork`,
+    {
+      method: "POST",
+      body: JSON.stringify({ context_summary: contextSummary }),
+    },
+  );
+}
+
 // ── Chat ───────────────────────────────────────────────────────────────
 
 export function chatStreamUrl(agentId: string) {

--- a/console/web/src/lib/chat-types.ts
+++ b/console/web/src/lib/chat-types.ts
@@ -1,0 +1,18 @@
+import type { ToolCallPayload } from "./api";
+
+export type ChatRole = "user" | "assistant" | "tool" | "system";
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  name?: string;
+  tool_calls?: ToolCallPayload[];
+  reasoning_content?: string;
+  isStreaming?: boolean;
+  agentId?: string;
+}
+
+export function genMessageId(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}


### PR DESCRIPTION
## Summary

- **Backend**: Add standalone `InMemoryFeishuChannelStore` to `ConsoleRuntime` so session management APIs (`/sessions/create`, `/switch`, `/fork`) work without Feishu channel enabled. Decouple `_get_session_service()` from `FeishuChannelService`.
- **Frontend**: Full session-first interaction model for Console chat pages:
  - New API types and functions for session create/switch/fork/list
  - Shared `useChatStream` hook deduplicates ~400 lines of SSE streaming logic from both chat pages
  - `SessionPanel` component with session list, create, switch, fork dialog, task info, and fork lineage display
  - Both agent chat and scheduler chat pages rewritten to use shared hook + session panel
  - Session ID persisted in URL query params (`?session=xxx`) for refresh-safe navigation
  - History loading from `getSessionSteps` on session switch

## Test plan

- [ ] Backend: 155 console tests pass (verified)
- [ ] Backend lint (ruff check + format + import-linter + repo_guard) all green (verified)
- [ ] Frontend: TypeScript compiles with no new errors (verified, 5 pre-existing errors in agent-form.tsx remain)
- [ ] Manual: Agent chat page — send message, verify session captured in URL, toggle session panel, create new session, switch back
- [ ] Manual: Scheduler chat page — same session panel integration works alongside orchestration panel
- [ ] Manual: Fork session from panel, verify new session created with lineage


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat session management: create new sessions, switch between existing sessions, and fork sessions with context summaries.
  * Introduced a session panel UI for viewing, navigating, and managing chat sessions.
  * Automatic session history loading when switching between sessions.
  * Enhanced session persistence and tracking across chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->