### PR TITLE
fix: resolve 5 critical correctness bugs (C-1 ~ C-5)

### DIFF
--- a/agiwo/llm/anthropic.py
+++ b/agiwo/llm/anthropic.py
@@ -115,7 +115,7 @@ class AnthropicModel(Model):
         params = {
             "model": actual_model,
             "messages": anthropic_messages,
-            "max_tokens": self.max_output_tokens or self.max_tokens_to_sample,
+            "max_tokens": self.max_output_tokens,
             "temperature": self.temperature,
             "stream": True,
         }

--- a/agiwo/observability/sqlite_store.py
+++ b/agiwo/observability/sqlite_store.py
@@ -3,6 +3,7 @@ SQLite implementation of TraceStorage.
 """
 
 import json
+import re
 from typing import Any
 
 import aiosqlite
@@ -23,11 +24,18 @@ class SQLiteTraceStorage(BaseTraceStorage):
     SQLite implementation of TraceStorage.
     """
 
+    _VALID_TABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
     def __init__(
         self,
         db_path: str,
         collection_name: str,
     ) -> None:
+        if not self._VALID_TABLE_NAME.match(collection_name):
+            raise ValueError(
+                f"Invalid collection name '{collection_name}': "
+                "must contain only alphanumeric characters and underscores"
+            )
         self.db_path = db_path
         self.collection_name = collection_name
         self._connection: aiosqlite.Connection | None = None

--- a/agiwo/tool/builtin/config.py
+++ b/agiwo/tool/builtin/config.py
@@ -39,6 +39,7 @@ class WebReaderApiConfig:
     model_max_tokens: int = field(
         default_factory=lambda: settings.get_tool_model_max_tokens()
     )
+    max_retries: int = 3
     headless: bool = False
     wait_strategy: str = "domcontentloaded"
     max_browsers: int = 1

--- a/agiwo/tool/builtin/web_reader/playwright/core.py
+++ b/agiwo/tool/builtin/web_reader/playwright/core.py
@@ -5,9 +5,7 @@ Provides core functionality for fetching web content using Playwright.
 """
 
 import asyncio
-import json
 import time
-from pathlib import Path
 from typing import Any
 
 from playwright.async_api import Page
@@ -252,44 +250,3 @@ class PlaywrightCrawler:
         finally:
             if page:
                 await page.close()
-
-    async def crawl_batch(
-        self, urls: list[str], save_dir: Path | None = None
-    ) -> list[dict[str, Any]]:
-        """
-        Crawl URLs in batch.
-
-        Args:
-            urls: List of URLs
-            save_dir: Save directory
-
-        Returns:
-            List of successfully crawled content
-        """
-        results = []
-        save_dir = save_dir or Path("crawled_data")
-        save_dir.mkdir(parents=True, exist_ok=True)
-
-        self.logger.info(f"Starting batch crawl, total {len(urls)} URLs")
-
-        for i, url in enumerate(urls, 1):
-            self.logger.info(f"\n[{i}/{len(urls)}] Processing {url}")
-
-            try:
-                content = await self.crawl_url(url, retries=self._config.max_retries)
-                if content:
-                    results.append(content)
-
-                    # Save to file
-                    file_name = f"{content['timestamp']}_{hash(url)}.json"
-                    (save_dir / file_name).write_text(
-                        json.dumps(content, ensure_ascii=False, indent=2),
-                        encoding="utf-8",
-                    )
-            except Exception as e:  # noqa: BLE001
-                self.logger.error(f"Failed to process URL: {e}")
-
-        self.logger.info(
-            f"Batch crawl completed, successful {len(results)}/{len(urls)}"
-        )
-        return results

--- a/agiwo/tool/cache.py
+++ b/agiwo/tool/cache.py
@@ -40,6 +40,7 @@ class ToolResultCache:
             ttl_seconds: Time-to-live for cache entries (default: 1 hour)
         """
         self._cache: dict[str, CacheEntry] = {}
+        self._session_keys: dict[str, set[str]] = {}
         self._ttl = ttl_seconds
 
     def _make_key(self, session_id: str, tool_name: str, args: dict[str, Any]) -> str:
@@ -76,6 +77,11 @@ class ToolResultCache:
         # Check TTL
         if time.time() - entry.created_at > self._ttl:
             del self._cache[key]
+            session_set = self._session_keys.get(session_id)
+            if session_set is not None:
+                session_set.discard(key)
+                if not session_set:
+                    del self._session_keys[session_id]
             return None
 
         logger.debug(
@@ -106,6 +112,7 @@ class ToolResultCache:
 
         key = self._make_key(session_id, tool_name, args)
         self._cache[key] = CacheEntry(result=result)
+        self._session_keys.setdefault(session_id, set()).add(key)
 
         logger.debug(
             "tool_cache_set",
@@ -123,19 +130,15 @@ class ToolResultCache:
         Returns:
             Number of entries cleared
         """
-        # This is O(n) but cache size should be small
-        keys_to_delete = [
-            k
-            for k in self._cache
-            if k.startswith(session_id[:16])  # Rough prefix match
-        ]
+        keys_to_delete = self._session_keys.pop(session_id, set())
         for k in keys_to_delete:
-            del self._cache[k]
+            self._cache.pop(k, None)
         return len(keys_to_delete)
 
     def clear_all(self) -> None:
         """Clear entire cache."""
         self._cache.clear()
+        self._session_keys.clear()
 
 
 # Global cache instance (can be replaced with Redis etc. later)


### PR DESCRIPTION
## Summary

Fixes 5 critical correctness bugs identified in the agiwo code review:

- **C-1** `tool/cache.py`: `clear_session()` never cleared entries — SHA-256 cache keys have no relation to `session_id[:16]` prefix. Added `_session_keys` reverse index for accurate cleanup.
- **C-2** `llm/anthropic.py`: Removed reference to non-existent `max_tokens_to_sample` attribute (would crash when `max_output_tokens` is falsy).
- **C-3** `tool/builtin/web_reader/playwright/core.py`: Removed broken `crawl_batch()` that treated Pydantic model as dict — dead code guaranteed to crash.
- **C-4** `tool/builtin/config.py`: Added missing `max_retries: int = 3` field to `WebReaderApiConfig`.
- **C-5** `observability/sqlite_store.py`: Added regex validation for `collection_name` to prevent SQL injection via dynamic table names.

## Test plan

- [ ] Verify `ToolResultCache.clear_session()` actually removes entries for the given session
- [ ] Verify `AnthropicModel.arun_stream()` works when `max_output_tokens` uses its default value
- [ ] Verify `SQLiteTraceStorage` rejects invalid collection names like `"; DROP TABLE --`
- [ ] Run `python -c "import agiwo"` to confirm no import errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limit for web reader operations (default: 3 retries).

* **Bug Fixes**
  * Enforced collection name validation to prevent invalid identifiers.
  * Fixed streaming output token handling to respect explicit max output tokens.

* **Refactor**
  * Optimized cache session tracking for more reliable session clears.
  * Simplified web reader by removing batch crawling API; single-URL crawling remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->