### PR TITLE
fix: resolve high-severity performance and architecture issues (H-1 ~ H-10)

### DIFF
--- a/agiwo/agent/run_loop.py
+++ b/agiwo/agent/run_loop.py
@@ -70,8 +70,9 @@ async def _complete_run(state: RunContext, run: Run, result: RunOutput) -> None:
         else RunStatus.COMPLETED
     )
     run.response_content = result.response
-    run.updated_at = datetime.now(timezone.utc)
-    run.metrics.end_at = datetime.now(timezone.utc).timestamp()
+    now = datetime.now(timezone.utc)
+    run.updated_at = now
+    run.metrics.end_at = now.timestamp()
     if result.metrics is not None:
         preserved_start_at = run.metrics.start_at
         preserved_end_at = run.metrics.end_at
@@ -96,8 +97,9 @@ async def _complete_run(state: RunContext, run: Run, result: RunOutput) -> None:
 
 async def _fail_run(state: RunContext, run: Run, error: Exception) -> None:
     run.status = RunStatus.FAILED
-    run.updated_at = datetime.now(timezone.utc)
-    run.metrics.end_at = datetime.now(timezone.utc).timestamp()
+    now = datetime.now(timezone.utc)
+    run.updated_at = now
+    run.metrics.end_at = now.timestamp()
     await state.session_runtime.run_step_storage.save_run(run)
     if state.session_runtime.trace_runtime is not None:
         await state.session_runtime.trace_runtime.on_run_failed(
@@ -129,30 +131,18 @@ def _build_output(state: RunContext) -> RunOutput:
     )
 
 
-async def execute_run(
+async def _prepare_run_context(
     user_input: UserInput,
     *,
     context: RunContext,
     system_prompt: str,
-    model: Model,
     tools: tuple[BaseTool, ...],
-    options: AgentOptions | None = None,
-    hooks: AgentHooks | None = None,
-    pending_tool_calls: list[dict] | None = None,
-    abort_signal: AbortSignal | None = None,
-    root_path: str | None = None,
-) -> RunOutput:
-    """Execute a single agent run — the core entry point."""
-    options = options or AgentOptions()
-    hooks = hooks or AgentHooks()
-    context.config = options
-    context.hooks = hooks
-
+    model: Model,
+    options: AgentOptions,
+    hooks: AgentHooks,
+) -> tuple[dict[str, BaseTool], list[dict] | None, int, int, StepRecord, Run]:
+    """Build all state needed before the main loop starts."""
     tools_map = {tool.get_name(): tool for tool in tools}
-    max_input_tokens_per_call = resolve_max_input_tokens_per_call(
-        options.max_input_tokens_per_call,
-        model,
-    )
     tool_schemas = [
         {
             "type": "function",
@@ -164,7 +154,6 @@ async def execute_run(
         }
         for tool in tools
     ] or None
-    max_context_window = resolve_max_context_window(model)
 
     before_run_hook_result = None
     if hooks.on_before_run is not None:
@@ -206,6 +195,7 @@ async def execute_run(
     )
     set_tool_schemas(context, tool_schemas)
     record_compaction_metadata(context, last_compact)
+
     run = Run(
         id=context.run_id,
         agent_id=context.agent_id,
@@ -215,6 +205,84 @@ async def execute_run(
         parent_run_id=context.parent_run_id,
     )
     run.metrics.start_at = time.time()
+
+    max_input_tokens_per_call = resolve_max_input_tokens_per_call(
+        options.max_input_tokens_per_call,
+        model,
+    )
+    return (
+        tools_map,
+        tool_schemas,
+        max_input_tokens_per_call,
+        compact_start_seq,
+        user_step,
+        run,
+    )
+
+
+async def _finalize_run(
+    user_input: UserInput,
+    *,
+    context: RunContext,
+    run: Run,
+    options: AgentOptions,
+    hooks: AgentHooks,
+    model: Model,
+    abort_signal: AbortSignal | None,
+) -> RunOutput:
+    """Generate summary, build output, and complete the run."""
+    await maybe_generate_termination_summary(
+        state=context,
+        options=options,
+        model=model,
+        abort_signal=abort_signal,
+    )
+    result = _build_output(context)
+    if hooks.on_after_run:
+        await hooks.on_after_run(result, context)
+    if hooks.on_memory_write and result.response is not None:
+        await hooks.on_memory_write(user_input, result, context)
+    await _complete_run(context, run, result)
+    return result
+
+
+async def execute_run(
+    user_input: UserInput,
+    *,
+    context: RunContext,
+    system_prompt: str,
+    model: Model,
+    tools: tuple[BaseTool, ...],
+    options: AgentOptions | None = None,
+    hooks: AgentHooks | None = None,
+    pending_tool_calls: list[dict] | None = None,
+    abort_signal: AbortSignal | None = None,
+    root_path: str | None = None,
+) -> RunOutput:
+    """Execute a single agent run — the core entry point."""
+    options = options or AgentOptions()
+    hooks = hooks or AgentHooks()
+    context.config = options
+    context.hooks = hooks
+
+    (
+        tools_map,
+        _tool_schemas,
+        max_input_tokens_per_call,
+        compact_start_seq,
+        user_step,
+        run,
+    ) = await _prepare_run_context(
+        user_input,
+        context=context,
+        system_prompt=system_prompt,
+        tools=tools,
+        model=model,
+        options=options,
+        hooks=hooks,
+    )
+    max_context_window = resolve_max_context_window(model)
+
     await _start_run(context, run)
     try:
         await commit_step(context, user_step, append_message=False, track_state=False)
@@ -231,19 +299,15 @@ async def execute_run(
             abort_signal=abort_signal,
             root_path=root_path or settings.root_path,
         )
-        await maybe_generate_termination_summary(
-            state=context,
+        return await _finalize_run(
+            user_input,
+            context=context,
+            run=run,
             options=options,
+            hooks=hooks,
             model=model,
             abort_signal=abort_signal,
         )
-        result = _build_output(context)
-        if hooks.on_after_run:
-            await hooks.on_after_run(result, context)
-        if hooks.on_memory_write and result.response is not None:
-            await hooks.on_memory_write(user_input, result, context)
-        await _complete_run(context, run, result)
-        return result
     except Exception as error:
         await _fail_run(context, run, error)
         raise

--- a/agiwo/agent/trace_writer.py
+++ b/agiwo/agent/trace_writer.py
@@ -183,11 +183,14 @@ class AgentTraceCollector:
 
     PREVIEW_LENGTH = 500
 
+    _SAVE_EVERY_N_STEPS = 5
+
     def __init__(self, store: BaseTraceStorage | None = None) -> None:
         self.store = store
         self._trace: Trace | None = None
         self._run_spans: dict[str, Span] = {}
         self._assistant_cache: OrderedDict[str, StepRecord] = OrderedDict()
+        self._step_count_since_save: int = 0
 
     @property
     def trace_id(self) -> str | None:
@@ -264,7 +267,10 @@ class AgentTraceCollector:
                     fallback,
                 )
             )
-        await self._save_trace()
+        self._step_count_since_save += 1
+        if self._step_count_since_save >= self._SAVE_EVERY_N_STEPS:
+            self._step_count_since_save = 0
+            await self._save_trace()
 
     async def on_run_completed(self, output: RunOutput, *, run_id: str) -> None:
         trace = self._require_trace()

--- a/agiwo/llm/bedrock_anthropic.py
+++ b/agiwo/llm/bedrock_anthropic.py
@@ -1,6 +1,8 @@
 """AWS Bedrock Anthropic model implementation."""
 
+import asyncio
 import json
+import queue as _queue
 from typing import Any, AsyncIterator
 
 try:
@@ -115,20 +117,37 @@ class BedrockAnthropicModel(Model):
 
         try:
             client = self._get_client()
-            response = client.invoke_model_with_response_stream(
+            response = await asyncio.to_thread(
+                client.invoke_model_with_response_stream,
                 modelId=self.id,
                 body=json.dumps(body),
             )
 
             translator = AnthropicStreamTranslator(include_reasoning=False)
 
-            for event in response["body"]:
-                chunk = json.loads(event["chunk"]["bytes"].decode())
+            sync_queue: _queue.SimpleQueue[dict | None] = _queue.SimpleQueue()
+
+            def _read_stream() -> None:
+                try:
+                    for event in response["body"]:
+                        sync_queue.put(json.loads(event["chunk"]["bytes"].decode()))
+                finally:
+                    sync_queue.put(None)
+
+            loop = asyncio.get_running_loop()
+            reader_task = loop.run_in_executor(None, _read_stream)
+
+            while True:
+                chunk_data = await loop.run_in_executor(None, sync_queue.get)
+                if chunk_data is None:
+                    break
                 stream_chunk = translator.process(
-                    normalize_bedrock_anthropic_event(chunk)
+                    normalize_bedrock_anthropic_event(chunk_data)
                 )
                 if stream_chunk is not None:
                     yield stream_chunk
+
+            await reader_task
 
         except ClientError as e:
             logger.error(

--- a/agiwo/memory/searcher.py
+++ b/agiwo/memory/searcher.py
@@ -360,12 +360,17 @@ class HybridSearcher:
 
         return results
 
+    _VECTOR_FALLBACK_MAX = 10_000
+
     def _vector_search_memory(
         self, query_vec: list[float], limit: int
     ) -> dict[str, float]:
         """Fallback vector search in memory (no sqlite-vec)."""
         cursor = self._conn.cursor()
-        cursor.execute("SELECT chunk_id, embedding FROM chunks WHERE embedding != ''")
+        cursor.execute(
+            "SELECT chunk_id, embedding FROM chunks WHERE embedding != '' LIMIT ?",
+            (self._VECTOR_FALLBACK_MAX,),
+        )
 
         results: list[tuple[str, float]] = []
         for row in cursor.fetchall():
@@ -470,23 +475,29 @@ class HybridSearcher:
         self, merged: dict[str, dict[str, float]]
     ) -> dict[str, dict[str, float]]:
         """Apply temporal decay based on file mtime."""
+        if not merged:
+            return merged
+
         cursor = self._conn.cursor()
         now = datetime.now().timestamp()
         half_life_seconds = self._temporal_decay_half_life_days * 24 * 3600
 
+        chunk_ids = list(merged.keys())
+        placeholders = ",".join("?" * len(chunk_ids))
+        cursor.execute(
+            f"""
+            SELECT c.chunk_id, f.mtime
+            FROM chunks c
+            JOIN files f ON c.path = f.path
+            WHERE c.chunk_id IN ({placeholders})
+            """,
+            chunk_ids,
+        )
+        mtime_map = {row[0]: row[1] for row in cursor.fetchall()}
+
         for chunk_id, scores in merged.items():
-            cursor.execute(
-                """
-                SELECT f.mtime
-                FROM chunks c
-                JOIN files f ON c.path = f.path
-                WHERE c.chunk_id = ?
-                """,
-                (chunk_id,),
-            )
-            row = cursor.fetchone()
-            if row:
-                mtime = row[0]
+            mtime = mtime_map.get(chunk_id)
+            if mtime is not None:
                 age_seconds = now - mtime
                 decay = math.exp(-math.log(2) * age_seconds / half_life_seconds)
                 scores["score"] *= decay
@@ -497,27 +508,33 @@ class HybridSearcher:
         self, sorted_results: list[tuple[str, dict[str, float]]]
     ) -> list[SearchResult]:
         """Build SearchResult objects from sorted scores."""
-        cursor = self._conn.cursor()
-        results: list[SearchResult] = []
+        if not sorted_results:
+            return []
 
+        cursor = self._conn.cursor()
+        chunk_ids = [cid for cid, _ in sorted_results]
+        placeholders = ",".join("?" * len(chunk_ids))
+        cursor.execute(
+            f"""
+            SELECT chunk_id, path, start_line, end_line, text
+            FROM chunks
+            WHERE chunk_id IN ({placeholders})
+            """,
+            chunk_ids,
+        )
+        chunk_data = {row[0]: row for row in cursor.fetchall()}
+
+        results: list[SearchResult] = []
         for chunk_id, scores in sorted_results:
-            cursor.execute(
-                """
-                SELECT path, start_line, end_line, text
-                FROM chunks
-                WHERE chunk_id = ?
-                """,
-                (chunk_id,),
-            )
-            row = cursor.fetchone()
+            row = chunk_data.get(chunk_id)
             if row:
                 results.append(
                     SearchResult(
                         chunk_id=chunk_id,
-                        path=row[0],
-                        start_line=row[1],
-                        end_line=row[2],
-                        text=row[3],
+                        path=row[1],
+                        start_line=row[2],
+                        end_line=row[3],
+                        text=row[4],
                         score=scores["score"],
                         vector_score=scores["vector_score"],
                         bm25_score=scores["bm25_score"],

--- a/agiwo/tool/builtin/http_client.py
+++ b/agiwo/tool/builtin/http_client.py
@@ -63,16 +63,16 @@ class AsyncHttpClient:
             default_headers.update(headers)
 
         last_error = None
-        for attempt in range(self._max_retries):
-            try:
-                logger.debug(
-                    "http_request_attempt",
-                    url=url,
-                    attempt=attempt + 1,
-                    max_retries=self._max_retries,
-                )
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            for attempt in range(self._max_retries):
+                try:
+                    logger.debug(
+                        "http_request_attempt",
+                        url=url,
+                        attempt=attempt + 1,
+                        max_retries=self._max_retries,
+                    )
 
-                async with httpx.AsyncClient(timeout=self._timeout) as client:
                     response = await client.post(
                         url,
                         json=data,
@@ -81,36 +81,34 @@ class AsyncHttpClient:
                     response.raise_for_status()
                     result = response.json()
 
-                logger.info(
-                    "http_request_success",
-                    url=url,
-                    status_code=response.status_code,
-                )
-                return result
+                    logger.info(
+                        "http_request_success",
+                        url=url,
+                        status_code=response.status_code,
+                    )
+                    return result
 
-            except httpx.HTTPError as e:
-                last_error = e
-                logger.warning(
-                    "http_request_failed",
-                    url=url,
-                    attempt=attempt + 1,
-                    error=str(e),
-                )
+                except httpx.HTTPError as e:
+                    last_error = e
+                    logger.warning(
+                        "http_request_failed",
+                        url=url,
+                        attempt=attempt + 1,
+                        error=str(e),
+                    )
 
-                # 如果不是最后一次尝试，等待后重试
-                if attempt < self._max_retries - 1:
-                    await asyncio.sleep(2**attempt)  # 指数退避
-                continue
+                    if attempt < self._max_retries - 1:
+                        await asyncio.sleep(2**attempt)
+                    continue
 
-            except Exception as e:
-                logger.error(
-                    "http_request_unexpected_error",
-                    url=url,
-                    error=str(e),
-                )
-                raise
+                except Exception as e:
+                    logger.error(
+                        "http_request_unexpected_error",
+                        url=url,
+                        error=str(e),
+                    )
+                    raise
 
-        # 所有重试都失败
         error_msg = (
             f"HTTP request failed after {self._max_retries} attempts: {last_error}"
         )

--- a/agiwo/tool/builtin/web_reader/content_processor.py
+++ b/agiwo/tool/builtin/web_reader/content_processor.py
@@ -11,6 +11,10 @@ class WebContentProcessor:
         self._max_length = max_length
         self._llm_model = None
 
+    @property
+    def llm_model(self):
+        return self._llm_model
+
     async def process(
         self,
         content: str,
@@ -18,7 +22,10 @@ class WebContentProcessor:
         summarize: bool,
         search_query: str | None,
         abort_signal: AbortSignal | None,
+        llm_model=None,
     ) -> str:
+        if llm_model is not None:
+            self._llm_model = llm_model
         if summarize or len(content) > self._max_length:
             return await self._summarize_content(
                 content,

--- a/agiwo/tool/builtin/web_reader/web_reader_tool.py
+++ b/agiwo/tool/builtin/web_reader/web_reader_tool.py
@@ -169,14 +169,14 @@ class WebReaderTool(BaseTool):
                     start_time=start_time,
                 )
 
-            self._content_processor._llm_model = self._llm_model
             processed_content = await self._content_processor.process(
                 content.raw_text or content.text or "",
                 summarize=summarize,
                 search_query=search_query,
                 abort_signal=abort_signal,
+                llm_model=self._llm_model,
             )
-            self._llm_model = self._content_processor._llm_model
+            self._llm_model = self._content_processor.llm_model
 
             if len(processed_content) > self.max_length:
                 processed_content = truncate_middle(processed_content, self.max_length)

--- a/agiwo/utils/retry.py
+++ b/agiwo/utils/retry.py
@@ -21,10 +21,29 @@ T = TypeVar("T")
 
 logger = get_logger(__name__)
 
-# Common retryable exceptions for LLM APIs
-# We will catch generic Exception for now or specific ones if we import them from openai
-# Ideally we should catch openai.RateLimitError, openai.APIError, openai.Timeout
-RETRYABLE_EXCEPTIONS = (Exception,)
+RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+try:
+    from openai import APIConnectionError as _OAIConn, APITimeoutError as _OAITimeout, RateLimitError as _OAIRate  # noqa: E501
+    RETRYABLE_EXCEPTIONS = (*RETRYABLE_EXCEPTIONS, _OAIConn, _OAITimeout, _OAIRate)
+except ImportError:
+    pass
+
+try:
+    from anthropic import APIConnectionError as _AConn, APITimeoutError as _ATimeout, RateLimitError as _ARate  # noqa: E501
+    RETRYABLE_EXCEPTIONS = (*RETRYABLE_EXCEPTIONS, _AConn, _ATimeout, _ARate)
+except ImportError:
+    pass
+
+try:
+    from httpx import ConnectError as _HConn, ReadTimeout as _HRead
+    RETRYABLE_EXCEPTIONS = (*RETRYABLE_EXCEPTIONS, _HConn, _HRead)
+except ImportError:
+    pass
 
 
 def retry_async(


### PR DESCRIPTION
## Summary

Fixes 8 of 10 high-severity architecture and performance issues:

- **H-1** Bedrock Anthropic: wrap sync boto3 streaming in `asyncio.to_thread` + queue pattern
- **H-3** memory/searcher: batch N+1 queries in `_apply_temporal_decay` and `_build_results`
- **H-4** memory/searcher: add LIMIT to fallback vector search to prevent unbounded memory load
- **H-5** utils/retry: narrow `RETRYABLE_EXCEPTIONS` from `(Exception,)` to specific network errors
- **H-6** agent/run_loop: extract `_prepare_run_context` and `_finalize_run` from `execute_run`
- **H-8** agent/trace_writer: debounced save (every 5 steps instead of every step)
- **H-9** web_reader: pass LLM model via method parameter instead of bidirectional private attributes
- **H-10** http_client: create `httpx.AsyncClient` once outside retry loop

### Deferred (H-2, H-7)
- H-2 (aiosqlite migration) and H-7 (Scheduler class extraction) are high-risk cascading changes that should be addressed in separate, dedicated PRs with test coverage.

## Test plan

- [ ] Verify Bedrock Anthropic streaming still works end-to-end
- [ ] Verify memory search returns same results (temporal decay + result building)
- [ ] Verify retry only catches network errors, not programming bugs
- [ ] Verify trace persistence still works with debounced saving
- [ ] Run `python -c "import agiwo"` to confirm no import errors

Made with [Cursor](https://cursor.com)