### PR TITLE
fix: use stable config.id as agent identity to preserve conversation history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@
 
 - `Agent` 是具体类，不是 ABC。
 - 公开构造入口是 `Agent(AgentConfig(...), *, model=..., tools=..., hooks=..., id=...)`；`AgentConfig` 只承载纯配置，不放 live object。
+- **`id` 必须稳定**：`Agent.id` 是 `(session_id, agent_id)` 存储键的一部分，决定了对话历史能否被正确加载。在 Console 等需要跨请求复用会话的场景中，每次构造 `Agent` 时 **必须** 传入稳定的 `id`（如 registry `config.id`），否则 `_generate_default_id` 会产生随机后缀，导致后续请求查不到先前的 steps，表现为"对话历史丢失"。
 - 对外执行原语是 `start(...)` 返回 live execution handle；`run(...)` / `run_stream(...)` 只是便利封装。child 运行配置通过 `create_child_agent(...)` 或单独构造 `Agent` 实例来收敛，不再保留公开 `derive_child_spec(...)` / `ChildAgentSpec` 路径。
 - `run(...)` 只支持 root run；嵌套 agent 执行是内部协议，由 `nested/agent_tool.py` 中的 `AgentTool` 通过 `Agent.run_child(...)` 进入，不再暴露公开 `context` 参数。
 - live execution handle 持有 `run_id/session_id`、`stream()/wait()/steer()/cancel()`；`steer()` 不属于 `Agent` 模板对象。
@@ -136,6 +137,7 @@
 - Feishu store 实现收口到 `console/server/channels/feishu/store/` 包：`__init__.py`（protocol + factory）、`memory.py`（内存实现）、`sqlite.py`（SQLite 实现）。
 - Feishu 模块合并约定：`message_parser.py` 包含 envelope 类型 + sender 解析 + 解析 facade；`message_builder.py` 包含 attachment 解析 + UserMessage 构建；`connection.py` 包含 SDK 适配层 + WebSocket 连接管理。
 - Console 工具的展示、解析、组装都必须经过 `ConsoleToolCatalog`。
+- **`build_agent` 必须传入稳定 `id`**：`build_agent()` 构造 Agent 时必须使用 `id=id or config.id`，确保同一个 agent config 在不同请求中拿到相同的 `agent_id`。若遗漏此 fallback，每次 HTTP 请求都会产生随机 agent id，导致 `run_step_storage.get_steps(session_id, agent_id)` 查不到历史步骤，对话上下文无法延续。`repo_guard.py` 中有对应的 `AGW043` 检查。
 - Agent 配置写入保持 full replace；不要回到 partial merge / patch DTO 语义。
 - `storage_wiring.py` 同时包含 storage config builders 和 `NotifyingTraceStorage`（Console 侧 trace pub/sub）。
 - Agent registry 收口到 `console/server/services/agent_registry/` 包：`registry.py`（CRUD 服务）、`models.py`（AgentConfigRecord）、`store/`（protocol + factory + memory/mongo/sqlite 实现）。

--- a/console/server/routers/scheduler.py
+++ b/console/server/routers/scheduler.py
@@ -217,7 +217,10 @@ async def create_persistent_agent(
             status_code=404, detail=f"Agent config '{config_id}' not found"
         )
 
-    agent = await build_agent(config, runtime.config, runtime.agent_registry)
+    instance_id = f"{config.id}--{uuid4()}"
+    agent = await build_agent(
+        config, runtime.config, runtime.agent_registry, id=instance_id
+    )
     state_id = await scheduler.submit(
         agent,
         body.initial_task or "",

--- a/console/server/services/agent_lifecycle.py
+++ b/console/server/services/agent_lifecycle.py
@@ -123,7 +123,7 @@ async def build_agent(
         agent_config,
         model=model,
         tools=tools or None,
-        id=id,
+        id=id or config.id,
     )
 
 

--- a/scripts/repo_guard.py
+++ b/scripts/repo_guard.py
@@ -1339,6 +1339,31 @@ def _detect_agent_lifecycle_tool_text_errors(
     return errors
 
 
+def _detect_agent_lifecycle_stable_id_errors(
+    path: Path,
+    content: str,
+) -> list[GuardError]:
+    if path != Path("console/server/services/agent_lifecycle.py"):
+        return []
+    if not re.search(r"\bAgent\s*\(", content):
+        return []
+    if re.search(r"id\s*=\s*id\s+or\s+config\.id", content):
+        return []
+    line = _find_first_match_line(content, r"\bAgent\s*\(") or 1
+    return [
+        _make_error(
+            path,
+            line,
+            "AGW043",
+            (
+                "build_agent must construct Agent with `id=id or config.id` to "
+                "guarantee stable agent identity across HTTP requests; a random "
+                "default id breaks conversation history continuity."
+            ),
+        )
+    ]
+
+
 def _detect_agent_runtime_text_errors(path: Path, content: str) -> list[GuardError]:
     if not (
         path.as_posix().startswith("agiwo/")
@@ -1423,6 +1448,7 @@ def _detect_text_guard_errors(path: Path, content: str) -> list[GuardError]:
     errors.extend(_detect_feishu_sdk_text_errors(path, content))
     errors.extend(_detect_agent_runtime_text_errors(path, content))
     errors.extend(_detect_console_tool_catalog_text_errors(path, content))
+    errors.extend(_detect_agent_lifecycle_stable_id_errors(path, content))
     return errors
 
 


### PR DESCRIPTION
## Summary

- **Root cause**: `build_agent()` constructed `Agent` with `id=None`, causing `_generate_default_id()` to produce a random suffix (e.g., `my-agent-a1b2c3`) on every HTTP request. Since `run_step_storage.get_steps()` queries by `(session_id, agent_id)`, subsequent requests with a different random `agent_id` could never find previous steps — conversation history appeared empty.
- **Fix**: Default agent id to `config.id` in `build_agent()` so the same agent config always produces the same `agent_id` across requests, enabling `get_steps()` to find prior conversation steps.
- **Persistent agents**: The `create_persistent_agent` endpoint intentionally creates multiple instances from the same config template, so it now explicitly generates a unique `instance_id` (`config.id--uuid4()`) to avoid state conflicts.
- **Guard**: Added `AGW043` repo_guard check to prevent regression — fires if `build_agent` in `agent_lifecycle.py` constructs `Agent(...)` without the `id=id or config.id` fallback.
- **Docs**: Updated AGENTS.md to document the stable `id` requirement in both the Agent and Console sections.

## Test plan

- [x] All 4 CI lint steps pass (ruff check, ruff format, import-linter, repo_guard)
- [x] Console tests: 155 passed (including the previously failing `test_create_persistent_agent_generates_unique_state_ids_without_session_id`)
- [x] SDK tests: 372 passed, 1 pre-existing failure unrelated to this change (`test_transport_serialization_removed_from_sdk_layer`)
- [x] AGW043 guard verified: catches the old broken pattern (`id=id`) and passes the fixed pattern (`id=id or config.id`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation detailing agent identity stability requirements for proper conversation session management.

* **Bug Fixes**
  * Enhanced agent instance tracking to ensure conversation history persists correctly across server requests.
  * Integrated automated validation checks to enforce consistent agent configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->