### PR TITLE
fix: use get_env_skills_dirs() and add AGW044 guard

### DIFF
--- a/agiwo/agent/definition.py
+++ b/agiwo/agent/definition.py
@@ -55,7 +55,7 @@ def build_skill_manager(config: AgentConfig) -> SkillManager | None:
     return SkillManager(
         SkillDiscoveryConfig(
             configured_dirs=normalize_skill_dirs(config.options.skills_dirs),
-            env_dirs=list(get_settings().skills_dirs or []),
+            env_dirs=get_settings().get_env_skills_dirs(),
             root_path=config.options.get_effective_root_path(),
         )
     )

--- a/scripts/repo_guard.py
+++ b/scripts/repo_guard.py
@@ -81,6 +81,13 @@ ALLOWED_FEISHU_SDK_IMPORT_PATHS = {
     Path("console/server/channels/feishu/connection.py"),
     Path("console/server/channels/feishu/sdk_adapter.py"),
 }
+ALLOWED_RAW_SETTINGS_SKILLS_DIRS_PATHS = {
+    Path("agiwo/config/settings.py"),
+}
+ALLOWED_RAW_SETTINGS_SKILLS_DIRS_PREFIXES = (
+    Path("tests"),
+    Path("console/tests"),
+)
 ALLOWED_STEPRECORD_CONSTRUCTOR_PREFIXES = (
     Path("tests"),
     Path("console/tests"),
@@ -366,6 +373,18 @@ def _is_thin_scheduler_wrapper(
         and isinstance(call.func, ast.Attribute)
         and _is_scheduler_facade_delegate(call.func.value)
     )
+
+
+def _is_raw_settings_skills_dirs_access(node: ast.Attribute) -> bool:
+    if node.attr != "skills_dirs":
+        return False
+    if (
+        isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "get_settings"
+    ):
+        return True
+    return isinstance(node.value, ast.Name) and node.value.id == "settings"
 
 
 def _is_console_app_state_access(node: ast.Attribute) -> bool:
@@ -896,6 +915,23 @@ def _detect_attribute_errors(path: Path, node: ast.Attribute) -> list[GuardError
                     "Do not access app.state directly outside console/server/"
                     "dependencies.py; route runtime access through ConsoleRuntime "
                     "dependencies instead."
+                ),
+            )
+        )
+    if (
+        _is_raw_settings_skills_dirs_access(node)
+        and path not in ALLOWED_RAW_SETTINGS_SKILLS_DIRS_PATHS
+        and not _is_allowed_prefix(path, ALLOWED_RAW_SETTINGS_SKILLS_DIRS_PREFIXES)
+    ):
+        errors.append(
+            _make_error(
+                path,
+                node.lineno,
+                "AGW044",
+                (
+                    "Do not access settings.skills_dirs directly; use "
+                    "get_settings().get_env_skills_dirs() to respect "
+                    "explicit-env-only semantics."
                 ),
             )
         )


### PR DESCRIPTION
## Summary

- **definition.py**: `get_settings().skills_dirs` always returns the default `["examples/skills", "skills"]` even when never explicitly configured, causing `SkillDiscoveryConfig.env_dirs` to always be non-empty and bypassing the intended fallback semantics. Replaced with `get_settings().get_env_skills_dirs()` which only returns values when the user explicitly sets `AGIWO_SKILLS_DIRS`.
- **repo_guard.py**: Added `AGW044` guard rule that catches direct `settings.skills_dirs` / `get_settings().skills_dirs` access outside `settings.py` and tests, preventing this class of mistake from recurring.

## Test plan

- [x] `uv run ruff check` passes on changed files
- [x] `uv run ruff format --check` passes on changed files
- [x] `uv run python scripts/repo_guard.py` passes on changed files
- [x] `uv run python scripts/lint.py files` passes (includes import contracts)
- [x] Full `--all` repo guard scan produces no AGW044 false positives
- [x] Unit-tested detection logic: catches `get_settings().skills_dirs` and `settings.skills_dirs`, does NOT flag `get_settings().get_env_skills_dirs()` or `config.options.skills_dirs`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal skill directory configuration handling to use standardized access patterns.

* **Chores**
  * Enhanced code validation checks to enforce consistent configuration access practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->