### PR TITLE
refactor(console): simplify agent configuration architecture

### DIFF
--- a/console/.env.example.full
+++ b/console/.env.example.full
@@ -213,25 +213,25 @@ AGIWO_CONSOLE_CORS_ORIGINS=["http://localhost:3000","http://localhost:3001"]
 # =============================================================================
 
 # Bootstrap default agent id.
-AGIWO_CONSOLE_DEFAULT_AGENT_ID=Walaha000
+AGIWO_CONSOLE_DEFAULT_AGENT__ID=Walaha000
 
 # Bootstrap default agent name.
-AGIWO_CONSOLE_DEFAULT_AGENT_NAME=Walaha
+AGIWO_CONSOLE_DEFAULT_AGENT__NAME=Walaha
 
 # Bootstrap default agent description.
-AGIWO_CONSOLE_DEFAULT_AGENT_DESCRIPTION=
+AGIWO_CONSOLE_DEFAULT_AGENT__DESCRIPTION=
 
 # Bootstrap default agent model provider.
-AGIWO_CONSOLE_DEFAULT_AGENT_MODEL_PROVIDER=openai-compatible
+AGIWO_CONSOLE_DEFAULT_AGENT__MODEL_PROVIDER=openai-compatible
 
 # Bootstrap default agent model name.
-AGIWO_CONSOLE_DEFAULT_AGENT_MODEL_NAME=MiniMax-M2.5
+AGIWO_CONSOLE_DEFAULT_AGENT__MODEL_NAME=MiniMax-M2.5
 
 # Bootstrap default agent model params JSON object.
-AGIWO_CONSOLE_DEFAULT_AGENT_MODEL_PARAMS={"api_key_env_name":"MINIMAX_API_KEY","base_url":"https://api.edgefn.net/v1"}
+AGIWO_CONSOLE_DEFAULT_AGENT__MODEL_PARAMS={"api_key_env_name":"MINIMAX_API_KEY","base_url":"https://api.edgefn.net/v1"}
 
 # Bootstrap default agent system prompt.
-AGIWO_CONSOLE_DEFAULT_AGENT_SYSTEM_PROMPT=
+AGIWO_CONSOLE_DEFAULT_AGENT__SYSTEM_PROMPT=
 
 # =============================================================================
 # [I] Console Feishu Channel

--- a/console/server/app.py
+++ b/console/server/app.py
@@ -19,8 +19,8 @@ from server.dependencies import (
 from server.channels.utils import safe_close_all
 from server.channels.feishu import FeishuChannelService
 from server.channels.feishu.store.memory import InMemoryFeishuChannelStore
-from server.services.agent_registry import AgentRegistry, AgentConfigRecord
-from server.services.agent_lifecycle import build_default_agent_options
+from server.services.agent_registry import AgentRegistry
+from server.services.agent_lifecycle import build_default_agent_record
 from server.services.storage_wiring import (
     build_agent_state_storage_config,
     create_run_step_storage,
@@ -37,21 +37,6 @@ from server.routers import (
 from agiwo.utils.logging import get_logger
 
 logger = get_logger("app")
-
-
-def _build_default_agent_config(config: ConsoleConfig) -> AgentConfigRecord:
-    """Build default agent config from ConsoleConfig."""
-    return AgentConfigRecord(
-        id=config.default_agent_id,
-        name=config.default_agent_name,
-        description=config.default_agent_description,
-        model_provider=config.default_agent_model_provider,
-        model_name=config.default_agent_model_name,
-        system_prompt=config.default_agent_system_prompt,
-        tools=config.default_agent_tools,
-        options=build_default_agent_options(),
-        model_params=config.default_agent_model_params,
-    )
 
 
 @asynccontextmanager
@@ -90,11 +75,9 @@ async def lifespan(app: FastAPI):
             config.feishu_default_agent_name
         )
         if base_agent is None:
-            base_agent = _build_default_agent_config(config)
+            base_agent = build_default_agent_record(config.default_agent)
             await agent_registry.create_agent(base_agent)
-            logger.info(
-                "create Default Agent Config", name=config.feishu_default_agent_name
-            )
+            logger.info("create Default Agent Config", name=config.default_agent.name)
 
         feishu_channel_service = FeishuChannelService(
             config=config,

--- a/console/server/config.py
+++ b/console/server/config.py
@@ -7,12 +7,41 @@ Storage/LLM settings are inherited from SDK's AgiwoSettings (AGIWO_ prefix).
 
 from typing import Any, Literal
 
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from agiwo.config.settings import settings as sdk_settings
 from agiwo.llm.config_policy import sanitize_model_params_data
 from agiwo.config.settings import ModelProvider
+
+
+class DefaultAgentTemplate(BaseModel):
+    """Template for the default agent created on first boot."""
+
+    id: str = "default-console-agent"
+    name: str = "Console Agent"
+    description: str = "Default agent for Console channels"
+    model_provider: ModelProvider = "openai-compatible"
+    model_name: str = "codex-5.3"
+    model_params: dict[str, Any] = Field(default_factory=dict)
+    system_prompt: str = ""
+    tools: list[str] = Field(
+        default_factory=lambda: [
+            "bash",
+            "bash_process",
+            "web_search",
+            "web_reader",
+            "memory_retrieval",
+        ]
+    )
+
+    @field_validator("model_params", mode="before")
+    @classmethod
+    def _normalize_model_params(cls, value: object) -> dict[str, Any]:
+        sanitized = sanitize_model_params_data(value)
+        if not isinstance(sanitized, dict):
+            return {}
+        return sanitized
 
 
 class ConsoleConfig(BaseSettings):
@@ -25,6 +54,7 @@ class ConsoleConfig(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="AGIWO_CONSOLE_",
+        env_nested_delimiter="__",
         case_sensitive=False,
         extra="ignore",
     )
@@ -44,22 +74,7 @@ class ConsoleConfig(BaseSettings):
     metadata_storage_type: Literal["memory", "sqlite"] = "sqlite"
 
     # Default Agent Configuration
-    default_agent_id: str = "default-console-agent"
-    default_agent_name: str = "Console Agent"
-    default_agent_description: str = "Default agent for Console channels"
-    default_agent_model_provider: ModelProvider = "openai-compatible"
-    default_agent_model_name: str = "codex-5.3"
-    default_agent_model_params: dict[str, Any] = Field(default_factory=dict)
-    default_agent_system_prompt: str = ""
-    default_agent_tools: list[str] = Field(
-        default_factory=lambda: [
-            "bash",
-            "bash_process",
-            "web_search",
-            "web_reader",
-            "memory_retrieval",
-        ]
-    )
+    default_agent: DefaultAgentTemplate = Field(default_factory=DefaultAgentTemplate)
 
     # Feishu channel
     feishu_enabled: bool = False
@@ -98,11 +113,3 @@ class ConsoleConfig(BaseSettings):
         if value == "none":
             return "memory"
         return value  # type: ignore[return-value]
-
-    @field_validator("default_agent_model_params", mode="before")
-    @classmethod
-    def _normalize_default_agent_model_params(cls, value: object) -> dict[str, Any]:
-        sanitized = sanitize_model_params_data(value)
-        if not isinstance(sanitized, dict):
-            return {}
-        return sanitized

--- a/console/server/routers/chat.py
+++ b/console/server/routers/chat.py
@@ -78,7 +78,7 @@ def _get_session_service(runtime: ConsoleRuntime) -> SessionContextService:
     return SessionContextService(
         store=runtime.session_store,
         agent_registry=runtime.agent_registry,
-        default_agent_name=runtime.config.default_agent_name,
+        default_agent_name=runtime.config.default_agent.name,
     )
 
 

--- a/console/server/services/agent_lifecycle.py
+++ b/console/server/services/agent_lifecycle.py
@@ -7,17 +7,14 @@ Consolidates all Agent construction paths:
 - resume_persistent_agent: wake a persistent agent with new task
 """
 
-from typing import Any
-
-from agiwo.agent import Agent
-from agiwo.agent import AgentConfig, AgentOptions
+from agiwo.agent import Agent, AgentConfig
 from agiwo.llm.base import Model
 from agiwo.tool.base import BaseTool
 from agiwo.llm import create_model_from_dict
 from agiwo.scheduler.models import AgentState
 from agiwo.scheduler.engine import Scheduler
 
-from server.config import ConsoleConfig
+from server.config import ConsoleConfig, DefaultAgentTemplate
 from server.schemas import AgentOptionsInput, ModelParamsInput
 from server.services.agent_registry import AgentConfigRecord, AgentRegistry
 from server.services.storage_wiring import (
@@ -46,9 +43,19 @@ class PersistentAgentValidationError(PersistentAgentResumeError):
 # ── Defaults ──────────────────────────────────────────────────────────
 
 
-def build_default_agent_options() -> dict[str, Any]:
-    """Return the canonical default agent options payload."""
-    return AgentOptionsInput.model_validate({}).model_dump(exclude_none=True)
+def build_default_agent_record(template: DefaultAgentTemplate) -> AgentConfigRecord:
+    """Build an AgentConfigRecord from the default agent template in ConsoleConfig."""
+    return AgentConfigRecord(
+        id=template.id,
+        name=template.name,
+        description=template.description,
+        model_provider=template.model_provider,
+        model_name=template.model_name,
+        system_prompt=template.system_prompt,
+        tools=list(template.tools),
+        options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
+        model_params=dict(template.model_params),
+    )
 
 
 # ── Build ─────────────────────────────────────────────────────────────
@@ -61,17 +68,6 @@ def build_model(config: AgentConfigRecord) -> Model:
         provider=config.model_provider,
         model_name=config.model_name,
         params=model_params.model_dump(exclude_none=True),
-    )
-
-
-def build_agent_options(
-    config: AgentConfigRecord, console_config: ConsoleConfig
-) -> AgentOptions:
-    """Build AgentOptions with storage config matching the console storage backend."""
-    opts = AgentOptionsInput.model_validate(config.options or {})
-    return opts.to_agent_options(
-        run_step_storage=build_run_step_storage_config(console_config),
-        trace_storage=build_trace_storage_config(console_config),
     )
 
 
@@ -94,7 +90,11 @@ async def build_agent(
     _building.add(config.id)
 
     model = build_model(config)
-    options = build_agent_options(config, console_config)
+    opts_input = AgentOptionsInput.model_validate(config.options or {})
+    options = opts_input.to_agent_options(
+        run_step_storage=build_run_step_storage_config(console_config),
+        trace_storage=build_trace_storage_config(console_config),
+    )
 
     async def _build_agent_tool(ref: str) -> BaseTool | None:
         agent_id = ref[len(AGENT_TOOL_PREFIX) :]

--- a/console/tests/test_config_env.py
+++ b/console/tests/test_config_env.py
@@ -4,16 +4,18 @@ from pydantic import ValidationError
 from agiwo.agent import AgentOptions
 from agiwo.config.settings import settings
 from agiwo.llm.openai import OpenAIModel
-from server.app import _build_default_agent_config
-from server.config import ConsoleConfig
+from server.config import ConsoleConfig, DefaultAgentTemplate
 from server.schemas import AgentOptionsInput
 from server.schemas import AgentConfigPayload, AgentConfigReplace
 from server.services.agent_lifecycle import (
-    build_agent_options,
-    build_default_agent_options,
+    build_default_agent_record,
     build_model,
 )
 from server.services.agent_registry import AgentConfigRecord, AgentRegistry
+from server.services.storage_wiring import (
+    build_run_step_storage_config,
+    build_trace_storage_config,
+)
 from server.domain.tool_references import (
     InvalidToolReferenceError,
     parse_tool_references,
@@ -32,7 +34,7 @@ def test_console_config_reads_uppercase_env(monkeypatch: pytest.MonkeyPatch) -> 
 def test_console_config_rejects_legacy_default_model_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("AGIWO_CONSOLE_DEFAULT_AGENT_MODEL_PROVIDER", "generic")
+    monkeypatch.setenv("AGIWO_CONSOLE_DEFAULT_AGENT__MODEL_PROVIDER", "generic")
 
     with pytest.raises(ValidationError):
         ConsoleConfig()
@@ -42,7 +44,7 @@ def test_console_config_rejects_plain_api_key_in_default_model_params(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(
-        "AGIWO_CONSOLE_DEFAULT_AGENT_MODEL_PARAMS",
+        "AGIWO_CONSOLE_DEFAULT_AGENT__MODEL_PARAMS",
         '{"api_key":"sk-plain-text","base_url":"https://api.example.com/v1"}',
     )
 
@@ -50,35 +52,33 @@ def test_console_config_rejects_plain_api_key_in_default_model_params(
         ConsoleConfig()
 
 
-def test_build_agent_options_uses_global_skills_default(
+def test_agent_options_input_uses_global_skills_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "is_skills_enabled", False)
 
-    config = AgentConfigRecord(
-        name="tester",
-        model_provider="openai",
-        model_name="gpt-4o-mini",
-        options={},
-    )
     console_config = ConsoleConfig(
         run_step_storage_type="memory",
         trace_storage_type="memory",
         metadata_storage_type="memory",
     )
-
-    options = build_agent_options(config, console_config)
+    opts = AgentOptionsInput.model_validate({})
+    options = opts.to_agent_options(
+        run_step_storage=build_run_step_storage_config(console_config),
+        trace_storage=build_trace_storage_config(console_config),
+    )
 
     assert options.enable_skill is False
     assert options.skills_dirs is None
 
 
-def test_default_agent_config_uses_shared_option_defaults() -> None:
-    config = ConsoleConfig()
+def test_default_agent_record_uses_shared_option_defaults() -> None:
+    template = DefaultAgentTemplate()
 
-    record = _build_default_agent_config(config)
+    record = build_default_agent_record(template)
 
-    assert record.options == build_default_agent_options()
+    expected = AgentOptionsInput.model_validate({}).model_dump(exclude_none=True)
+    assert record.options == expected
     assert record.options["max_steps"] == AgentOptions().max_steps
 
 
@@ -88,16 +88,18 @@ def test_agent_options_payload_normalizes_single_skills_dirs() -> None:
     assert payload.skills_dirs == ["skills"]
 
 
-def test_build_agent_options_normalizes_skills_dirs_and_maps_all_fields(
+def test_agent_options_input_normalizes_skills_dirs_and_maps_all_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "is_skills_enabled", True)
 
-    config = AgentConfigRecord(
-        name="tester",
-        model_provider="openai",
-        model_name="gpt-4o-mini",
-        options={
+    console_config = ConsoleConfig(
+        run_step_storage_type="memory",
+        trace_storage_type="memory",
+        metadata_storage_type="memory",
+    )
+    opts = AgentOptionsInput.model_validate(
+        {
             "config_root": "/tmp/agent-root",
             "max_steps": 42,
             "run_timeout": 120,
@@ -110,15 +112,12 @@ def test_build_agent_options_normalizes_skills_dirs_and_maps_all_fields(
             "relevant_memory_max_token": 1024,
             "stream_cleanup_timeout": 90.5,
             "compact_prompt": "Compact the context",
-        },
+        }
     )
-    console_config = ConsoleConfig(
-        run_step_storage_type="memory",
-        trace_storage_type="memory",
-        metadata_storage_type="memory",
+    options = opts.to_agent_options(
+        run_step_storage=build_run_step_storage_config(console_config),
+        trace_storage=build_trace_storage_config(console_config),
     )
-
-    options = build_agent_options(config, console_config)
 
     assert options.config_root == "/tmp/agent-root"
     assert options.max_steps == 42


### PR DESCRIPTION
- Replace 8 flat default_agent_* fields with nested DefaultAgentTemplate
- Inline build_agent_options into build_agent
- Delete 3 redundant functions
- 145 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized console default agent configuration structure from multiple separate settings to a unified nested configuration object.
  * Updated environment variable naming convention for default agent settings to support nested configuration format.

* **Breaking Changes**
  * Default agent environment variables now use double underscore delimiters (e.g., `AGIWO_CONSOLE_DEFAULT_AGENT__NAME` instead of `AGIWO_CONSOLE_DEFAULT_AGENT_NAME`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->