### PR TITLE
fix(docs): align documentation with actual codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ async def main() -> None:
     print(result.response)
 
     async for event in agent.run_stream("Give me a one-line summary of recursion."):
-        if event.delta and event.delta.content:
+        if event.type == "step_delta" and event.delta.content:
             print(event.delta.content, end="", flush=True)
 
     await agent.close()

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Welcome to the Agiwo documentation. Agiwo is a streaming-first AI Agent SDK and 
 ## Quick Links
 
 - **[Getting Started](./getting-started.md)** — Installation, first agent, and configuration
-- **[Core Concepts](./concepts/agent.md)** — Understand Agent, Model, Tool, and Scheduler
+- **[Core Concepts](./concepts/model.md)** — Understand Model, Tool, and Scheduler
 
 ## Guides
 
@@ -29,7 +29,6 @@ Welcome to the Agiwo documentation. Agiwo is a streaming-first AI Agent SDK and 
 
 ## API Reference
 
-- **[Agent API](./api/agent.md)** — `Agent`, `AgentConfig`, `RunOutput`, `AgentStreamItem`
-- **[Tool API](./api/tool.md)** — `BaseTool`, `ToolResult`, `ToolContext`
 - **[Model API](./api/model.md)** — `Model`, provider implementations
+- **[Tool API](./api/tool.md)** — `BaseTool`, `ToolResult`, `ToolContext`
 - **[Scheduler API](./api/scheduler.md)** — `Scheduler`, orchestration methods

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -102,29 +102,37 @@ model = BedrockAnthropicModel(id="anthropic.claude-3-sonnet", name="claude-3-son
 # Uses AWS credentials (boto3)
 ```
 
-### `OpenAICompatibleModel`
+## Compatible Endpoints
+
+For OpenAI-compatible or Anthropic-compatible endpoints, use the factory:
+
+### OpenAI-Compatible
 
 ```python
-from agiwo.llm import OpenAICompatibleModel
+from agiwo.llm import create_model_from_dict
 
-model = OpenAICompatibleModel(
-    id="custom-model",
-    name="custom-model",
-    base_url="https://api.example.com/v1",
-    api_key_env_name="MY_API_KEY",
+model = create_model_from_dict(
+    provider="openai-compatible",
+    model_name="custom-model",
+    params={
+        "base_url": "https://api.example.com/v1",
+        "api_key_env_name": "MY_API_KEY",
+    },
 )
 ```
 
-### `AnthropicCompatibleModel`
+### Anthropic-Compatible
 
 ```python
-from agiwo.llm import AnthropicCompatibleModel
+from agiwo.llm import create_model_from_dict
 
-model = AnthropicCompatibleModel(
-    id="custom-model",
-    name="custom-model",
-    base_url="https://api.example.com/v1",
-    api_key_env_name="MY_API_KEY",
+model = create_model_from_dict(
+    provider="anthropic-compatible",
+    model_name="custom-model",
+    params={
+        "base_url": "https://api.example.com/v1",
+        "api_key_env_name": "MY_API_KEY",
+    },
 )
 ```
 
@@ -132,15 +140,34 @@ model = AnthropicCompatibleModel(
 
 ## Model Factory
 
-```python
-from agiwo.llm.factory import create_model
+### `create_model()`
 
-model = create_model(
+```python
+from agiwo.llm.factory import create_model, ModelSpec
+
+model = create_model(ModelSpec(
     provider="openai",
     model_name="gpt-4o",
     temperature=0.5,
     max_output_tokens=8192,
+))
+```
+
+### `create_model_from_dict()`
+
+For use with loose dicts or config files:
+
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai",
+    model_name="gpt-4o",
+    params={
+        "temperature": 0.5,
+        "max_output_tokens": 8192,
+    },
 )
 ```
 
-Supported provider strings: `"openai"`, `"anthropic"`, `"deepseek"`, `"nvidia"`, `"bedrock_anthropic"`, `"openai-compatible"`, `"anthropic-compatible"`.
+Supported provider strings: `"openai"`, `"anthropic"`, `"deepseek"`, `"nvidia"`, `"bedrock-anthropic"`, `"openai-compatible"`, `"anthropic-compatible"`.

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -230,6 +230,8 @@ async def rebind_agent(self, state_id: str, agent: Agent) -> bool
 def get_registered_agent(self, state_id: str) -> Agent | None
 ```
 
+Returns the live Agent instance bound to `state_id`, or `None` if not found.
+
 ## Core Models
 
 ### `SchedulerConfig`

--- a/docs/api/tool.md
+++ b/docs/api/tool.md
@@ -52,6 +52,13 @@ class BaseTool(ABC):
 | `timeout_seconds` | `30` | Execution timeout |
 | `concurrency_safe` | `True` | Can run in parallel with other tools |
 
+### Additional Methods
+
+| Method | Description |
+|--------|-------------|
+| `gate(parameters, context) -> ToolGateDecision` | Preflight safety check before execution |
+| `build_context(run_context, tool_call_id) -> ToolContext` | Builds `ToolContext` from agent run context |
+
 ---
 
 ## `ToolResult`
@@ -155,9 +162,17 @@ class ToolDefinition:
 ## `ToolContext`
 
 ```python
+@dataclass(frozen=True)
 class ToolContext:
-    """Runtime context provided to tool execution."""
-    # Access workspace paths, agent identity, session info, storage
+    session_id: str
+    agent_id: str | None = None
+    agent_name: str | None = None
+    user_id: str | None = None
+    timeout_at: float | None = None
+    depth: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    gate_checked: bool = False
+    tool_call_id: str = ""
 ```
 
 ---
@@ -166,7 +181,7 @@ class ToolContext:
 
 ```python
 class AbortSignal:
-    def is_cancelled(self) -> bool: ...
+    def is_aborted(self) -> bool: ...
 ```
 
 Pass to long-running tools and check periodically for cancellation.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -14,7 +14,7 @@ The Memory system provides hybrid retrieval (BM25 + vector search) over MEMORY/ 
 ```
 Agent
   └─► MemoryRetrievalTool.execute()
-        └─► MemoryIndexStore
+        └─► WorkspaceMemoryService.search()
               ├── sync_files()      # Incremental file scanning
               └── search(query)
                     ├── vector_search()  # Embedding + cosine similarity
@@ -59,21 +59,24 @@ When embedding is unavailable, weights auto-compensate to maintain score range [
 
 ## Configuration
 
-```python
-from agiwo.tool.builtin.config import MemoryConfig
+Memory settings are loaded from global settings (`AGIWO_*` env vars or `AgiwoSettings`):
 
-config = MemoryConfig(
-    embedding_provider="auto",       # "openai" | "auto" | "disabled"
-    embedding_model="text-embedding-3-small",
-    chunk_tokens=400,
-    chunk_overlap_tokens=80,
-    top_k=5,
-    vector_weight=0.7,
-    bm25_weight=0.3,
-    temporal_decay_enabled=False,
-    temporal_decay_half_life_days=30.0,
-    mmr_enabled=False,
-    mmr_lambda=0.5,
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `AGIWO_MEMORY_TOP_K` | `5` | Number of results to return |
+| `AGIWO_MEMORY_CHUNK_TOKENS` | `400` | Chunk size in tokens |
+| `AGIWO_MEMORY_CHUNK_OVERLAP_TOKENS` | `80` | Overlap between chunks |
+| `AGIWO_MEMORY_RELEVANT_MAX_TOKEN` | `2048` | Max tokens for relevant memories |
+
+Per-tool overrides are available via constructor:
+
+```python
+from agiwo.tool.builtin.registry import builtin_tool
+from agiwo.tool.builtin.retrieval_tool.tool import MemoryRetrievalTool
+
+tool = MemoryRetrievalTool(
+    top_k=10,
+    embedding_provider="openai",
 )
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -9,7 +9,7 @@ Console / Feishu → Session application layer → Scheduler → Agent
 The Console and Feishu adapters share the same session-first conversation semantics:
 
 - **Entry adapters** (Console Web, Feishu) handle transport-specific concerns (SSE, long-connection, message parsing)
-- **Session application layer** (`RemoteWorkspaceSessionService`, `RemoteWorkspaceConversationService`) owns session lifecycle, implicit task management, and fork semantics
+- **Session application layer** (`SessionManager`, `SessionContextService` in `console/server/channels/session/`) owns session lifecycle, implicit task management, and fork semantics
 - **Scheduler** mediates all execution — both Console and Feishu route through `scheduler.route_root_input()`
 - **Agent** executes the actual work, with results projected back as SDK execution facts
 

--- a/docs/concepts/model.md
+++ b/docs/concepts/model.md
@@ -107,13 +107,15 @@ model = BedrockAnthropicModel(id="anthropic.claude-3-sonnet", name="claude-3-son
 For any OpenAI-compatible API endpoint:
 
 ```python
-from agiwo.llm import OpenAICompatibleModel
+from agiwo.llm import create_model_from_dict
 
-model = OpenAICompatibleModel(
-    id="my-custom-model",
-    name="my-custom-model",
-    base_url="https://api.example.com/v1",
-    api_key_env_name="MY_API_KEY",
+model = create_model_from_dict(
+    provider="openai-compatible",
+    model_name="my-custom-model",
+    params={
+        "base_url": "https://api.example.com/v1",
+        "api_key_env_name": "MY_API_KEY",
+    },
 )
 ```
 
@@ -122,13 +124,15 @@ model = OpenAICompatibleModel(
 For Anthropic-compatible endpoints:
 
 ```python
-from agiwo.llm import AnthropicCompatibleModel
+from agiwo.llm import create_model_from_dict
 
-model = AnthropicCompatibleModel(
-    id="my-anthropic-model",
-    name="my-anthropic-model",
-    base_url="https://api.example.com/v1",
-    api_key_env_name="MY_API_KEY",
+model = create_model_from_dict(
+    provider="anthropic-compatible",
+    model_name="my-anthropic-model",
+    params={
+        "base_url": "https://api.example.com/v1",
+        "api_key_env_name": "MY_API_KEY",
+    },
 )
 ```
 
@@ -137,12 +141,12 @@ model = AnthropicCompatibleModel(
 Models are typically constructed through the factory for consistency:
 
 ```python
-from agiwo.llm.factory import create_model
+from agiwo.llm import create_model_from_dict
 
-model = create_model(
+model = create_model_from_dict(
     provider="openai",
     model_name="gpt-4o",
-    temperature=0.5,
+    params={"temperature": 0.5},
 )
 ```
 

--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -198,8 +198,6 @@ RuntimeState(
 
 Both Console and Feishu enter through session-first, scheduler-mediated flows:
 
-- Console SSE endpoint (`/api/chat/{agent_id}`) uses `stream_scheduler_events` which calls `scheduler.stream()`
-- Feishu batch execution delegates to `RemoteWorkspaceConversationService` which calls `executor.execute()` → `scheduler.route_root_input()`
-- Session session management APIs (create, switch, fork) use `RemoteWorkspaceSessionService`
-
-Entry adapters translate transport concerns into shared session and conversation services rather than invoking agent runtimes directly.
+- Console SSE endpoint (`/api/chat/{agent_id}`) uses `scheduler.stream()` for streaming events
+- Feishu delegates to the session channel's `SessionContextService` which calls `scheduler.route_root_input()`
+- Session management APIs (create, switch, fork) use `SessionManager` in `console/server/channels/session/`

--- a/docs/concepts/tool.md
+++ b/docs/concepts/tool.md
@@ -87,10 +87,19 @@ class SlowTool(BaseTool):
 
 The `ToolContext` provides runtime information to tool execution:
 
-- Workspace paths
-- Agent identity
-- Session information
-- Storage access
+```python
+@dataclass(frozen=True)
+class ToolContext:
+    session_id: str
+    agent_id: str | None = None
+    agent_name: str | None = None
+    user_id: str | None = None
+    timeout_at: float | None = None
+    depth: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    gate_checked: bool = False
+    tool_call_id: str = ""
+```
 
 ## Builtin Tools
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,14 +182,18 @@ model = DeepseekModel(id="deepseek-chat", name="deepseek-chat")
 
 ### OpenAI-Compatible (custom endpoint)
 
-```python
-from agiwo.llm import OpenAICompatibleModel
+For any OpenAI-compatible API endpoint, use `create_model_from_dict`:
 
-model = OpenAICompatibleModel(
-    id="my-model",
-    name="my-model",
-    base_url="https://api.example.com/v1",
-    api_key_env_name="MY_API_KEY",
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai-compatible",
+    model_name="my-model",
+    params={
+        "base_url": "https://api.example.com/v1",
+        "api_key_env_name": "MY_API_KEY",
+    },
 )
 ```
 

--- a/docs/guides/custom-tools.md
+++ b/docs/guides/custom-tools.md
@@ -88,7 +88,7 @@ Check `abort_signal` for cancellation in long-running tools:
 ```python
 async def execute(self, parameters, context, abort_signal) -> ToolResult:
     for item in large_dataset:
-        if abort_signal and abort_signal.is_cancelled():
+        if abort_signal and abort_signal.is_aborted():
             return ToolResult.aborted(
                 tool_name=self.name,
             )
@@ -111,11 +111,11 @@ The runtime batches concurrent-safe tools together for parallel execution.
 
 ```python
 async def execute(self, parameters, context, abort_signal) -> ToolResult:
-    # Access workspace path
-    workspace = context.workspace_dir
-
     # Access agent identity
     agent_name = context.agent_name
+
+    # Access session metadata
+    session_id = context.session_id
 
     # ...
 ```

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -17,6 +17,7 @@ hooks = AgentHooks(
     on_step=my_on_step_hook,
     on_memory_write=my_memory_write_hook,
     on_memory_retrieve=my_memory_retrieve_hook,
+    on_compaction_failed=my_compaction_failed_hook,
 )
 ```
 
@@ -77,10 +78,20 @@ async def on_memory_write(user_input, result, context) -> None:
     """Called after a successful run to persist external memory."""
     print(f"Persisting memory for run {context.run_id}")
 
-async def on_memory_retrieve(user_input, context) -> list:
-    """Called before execution to fetch memories."""
+async def on_memory_retrieve(user_input, context) -> list[MemoryRecord]:
+    """Called before execution to fetch memories.
+    Return a list of MemoryRecord objects, or empty list."""
+    from agiwo.agent.models.run import MemoryRecord
     print(f"Retrieving memories for run {context.run_id}")
     return []
+```
+
+### Compaction Failure
+
+```python
+async def on_compaction_failed(error, context) -> None:
+    """Called when context compaction fails."""
+    print(f"Compaction failed: {error}")
 ```
 
 ## Using Hooks

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -1,13 +1,12 @@
 # Storage & Observability
 
-Agiwo separates storage into three independent concerns: run/step persistence, session metadata, and trace collection.
+Agiwo separates storage into two independent concerns: run/step persistence and trace collection.
 
 ## Storage Layers
 
 | Layer | Purpose | Interface |
 |-------|---------|-----------|
 | Run/Step Storage | Persist agent run and step records | `RunStepStorage` |
-| Session Storage | Session metadata and compaction state | `SessionStorage` |
 | Trace Storage | Distributed traces for observability | `BaseTraceStorage` |
 
 ## Run/Step Storage
@@ -25,14 +24,6 @@ storage = create_run_step_storage(
 
 # Memory backend (for testing)
 storage = create_run_step_storage(RunStepStorageConfig(storage_type="memory"))
-
-# MongoDB backend
-storage = create_run_step_storage(
-    RunStepStorageConfig(
-        storage_type="mongodb",
-        config={"mongo_uri": "mongodb://...", "db_name": "agiwo"},
-    )
-)
 ```
 
 Pass storage configuration through `AgentConfig.options`:
@@ -62,21 +53,7 @@ agent = Agent(
 
 ## Session Storage
 
-Manages session-level metadata:
-
-```python
-from agiwo.agent import RunStepStorageConfig
-from agiwo.agent.storage.factory import create_session_storage
-
-storage = create_session_storage(
-    RunStepStorageConfig(storage_type="sqlite", config={"db_path": "sessions.db"})
-)
-```
-
-Sessions track:
-- Conversation history metadata
-- Compaction state (when context gets too long)
-- User identity and preferences
+The SDK does not provide a standalone `SessionStorage` abstraction. Session state management is handled by the console server via `SessionManager` in `console/server/channels/session/manager.py`, or by the SDK's in-memory runtime state during agent execution.
 
 ## Trace Storage
 
@@ -94,14 +71,6 @@ trace_storage = create_trace_storage(
 # Memory
 trace_storage = create_trace_storage(TraceStorageConfig(storage_type="memory"))
 
-# MongoDB
-trace_storage = create_trace_storage(
-    TraceStorageConfig(
-        storage_type="mongodb",
-        config={"mongo_uri": "mongodb://...", "db_name": "agiwo"},
-    )
-)
-```
 
 Pass trace configuration through `AgentConfig.options`:
 
@@ -156,7 +125,7 @@ The `subscribe()` method enables real-time trace streaming to the Console UI.
 |---------|----------|-------------|
 | `memory` | Testing, ephemeral workloads | No (lost on restart) |
 | `sqlite` | Single-node deployments, development | Yes |
-| `mongo` | Production, multi-node, high volume | Yes |
+| `sqlite` | Single-node deployments, development | Yes |
 
 ## Configuration
 

--- a/docs/memory/components.md
+++ b/docs/memory/components.md
@@ -1,54 +1,43 @@
 # Memory System — 核心组件详解
 
-## 1. MemoryConfig（配置）
+## 1. 配置
 
-位置：`agiwo/tool/builtin/config.py`
+Memory 配置通过全局 `AgiwoSettings`（`agiwo/config/settings.py`）加载，而非独立的 `MemoryConfig` dataclass。
+
+关键配置项：
+
+| 配置项 | 默认值 | 说明 |
+|---------|--------|------|
+| `memory_top_k` | `5` | 默认返回结果数 |
+| `memory_chunk_tokens` | `400` | 每块最大 token 数 |
+| `memory_chunk_overlap_tokens` | `80` | 相邻块重叠 token 数 |
+| `relevant_memory_max_token` | `2048` | 注入 prompt 的最大记忆 token |
+
+构造 `MemoryRetrievalTool` / `WorkspaceMemoryService` 时可通过参数覆盖：
 
 ```python
-@dataclass
-class MemoryConfig:
-    # Embedding
-    embedding_provider: str = "auto"      # "openai" | "auto" | "disabled"
-    embedding_model: str = ""             # 空则使用 provider 默认模型
-    embedding_api_base: str = ""          # 空则读取 OPENAI_BASE_URL 环境变量
-    embedding_api_key: str = ""           # 空则读取 OPENAI_API_KEY 环境变量
-    embedding_dims: int = 1536            # text-embedding-3-small 默认维度
+from agiwo.tool.builtin.retrieval_tool.tool import MemoryRetrievalTool
 
-    # Chunking
-    chunk_tokens: int = 400               # 每块最大 token 数
-    chunk_overlap_tokens: int = 80        # 相邻块重叠 token 数
-
-    # Search
-    top_k: int = 5                        # 默认返回结果数
-    vector_weight: float = 0.7            # 混合融合向量权重
-    bm25_weight: float = 0.3             # 混合融合 BM25 权重
-
-    # Temporal decay（时间衰减）
-    temporal_decay_enabled: bool = False
-    temporal_decay_half_life_days: float = 30.0
-
-    # MMR 重排
-    mmr_enabled: bool = False
-    mmr_lambda: float = 0.5              # 相关性 vs 多样性平衡系数
+tool = MemoryRetrievalTool(
+    top_k=10,
+    embedding_provider="openai",
+)
 ```
 
-**说明**：
-- `embedding_provider = "auto"` 时，按顺序探测 OpenAI 兼容 API → 降级纯 BM25
-- `embedding_provider = "disabled"` 时，直接使用纯 BM25，不尝试 Embedding
-- `MemoryRetrievalTool` 构造时注入 `MemoryConfig`，不依赖全局 singleton
+`embedding_provider = "auto"` 时尝试使用 OpenAI 兼容 API，降级纯 BM25。不设 embedding 时传入 `"disabled"` 即可。
 
 ---
 
 ## 2. MemoryChunker（文本切割）
 
-位置：`agiwo/tool/builtin/retrieval_tool/chunker.py`
+位置：`agiwo/memory/chunker.py`
 
-**职责**：将单个 Markdown 文件切割为多个重叠 chunk，输出结构如下：
+**职责**：将 Markdown 文件切割为多个重叠 chunk。
 
 ```python
 @dataclass
 class MemoryChunk:
-    chunk_id: str        # sha256(path + start_line)[:16]
+    chunk_id: str        # sha256(f"{path}:{start_line}")[:16]
     path: str            # 相对于 workspace 的文件路径
     start_line: int
     end_line: int
@@ -57,81 +46,50 @@ class MemoryChunk:
 ```
 
 **切割策略**：
-- 按 token 数量切割（使用 `tiktoken` 的 `cl100k_base` 编码，与 OpenAI Embedding 对齐）
-- 优先在段落边界（空行）切割，避免语义割裂
-- 在段落边界找不到合适切点时，回退到句子边界（`. ` / `\n`）
-- `chunk_overlap_tokens`：复用前一块末尾 N 个 token，保持上下文连续性
-
-**为何选择 token-based 而非 char-based**：
-- Embedding API 有 token 上限（text-embedding-3-small：8192）
-- char-based 在中英文混合内容中误差大，token-based 与 API 计费/限制对齐
+- 按 token 数量切割（使用 `tiktoken` 编码，与 OpenAI Embedding 对齐）
+- 超出 `chunk_tokens` 限制时分块，复用前一块末尾 N 个 token 保持上下文连续性
 
 ---
 
-## 3. MemoryEmbedder（向量化）
+## 3. Embedding 层
 
-位置：`agiwo/tool/builtin/retrieval_tool/embedder.py`
+位置：`agiwo/embedding/`
 
-**接口**：
+项目通过 `agiwo/embedding/` 包统一管理 Embedding 能力。
 
 ```python
-class MemoryEmbedder(Protocol):
-    async def embed(self, texts: list[str]) -> list[list[float]]:
-        ...
-    
-    @property
-    def model_id(self) -> str:
-        ...
-    
-    @property
-    def dims(self) -> int:
-        ...
+from agiwo.embedding import EmbeddingModel, EmbeddingFactory
+
+embedder = EmbeddingFactory.create(
+    provider="openai",
+    model="text-embedding-3-small",
+    dimensions=1536,
+    api_key=os.getenv("OPENAI_API_KEY"),
+)
+
+# 批量向量化
+embeddings = await embedder.embed(["text1", "text2"])
 ```
 
-**唯一实现：`OpenAIEmbedder`**
-
-- 复用项目已有的 HTTP Client 风格（`httpx.AsyncClient`）
-- 支持 OpenAI 兼容 API（如 SiliconFlow、DeepSeek、本地 Ollama）
-- 批量请求：单次最多 100 个 chunk，超出则分批发送
-- 失败时抛出 `EmbeddingError`，由 `MemoryIndexStore` 捕获后降级为纯 BM25
-
-**`EmbedderFactory.create(config)`**：
-
-```
-config.embedding_provider == "auto"
-  └─ 尝试创建 OpenAIEmbedder（用配置或环境变量中的 api_key）
-       ├─ 成功 → 返回 OpenAIEmbedder
-       └─ api_key 缺失 → 返回 None（调用方降级 BM25）
-
-config.embedding_provider == "openai"
-  └─ 强制创建 OpenAIEmbedder（api_key 缺失则抛出 ConfigError）
-
-config.embedding_provider == "disabled"
-  └─ 直接返回 None
-```
-
-**Embedding 缓存**（存储在同一 SQLite 中）：
+**Embedding 缓存**（存储在 SQLite 中）：
 
 ```sql
 CREATE TABLE embedding_cache (
-    content_hash TEXT NOT NULL,   -- sha256(text)
+    content_hash TEXT NOT NULL,
     model_id     TEXT NOT NULL,
-    embedding    BLOB NOT NULL,   -- numpy float32 array，pack 为 bytes
+    embedding    BLOB NOT NULL,
     updated_at   INTEGER NOT NULL,
     PRIMARY KEY (content_hash, model_id)
 );
 ```
 
-- 按 `(content_hash, model_id)` 查询，命中直接返回，不调用 API
-- 仅在 chunk 内容变更（`content_hash` 变化）时失效，大幅减少 API 调用
-
 ---
 
 ## 4. MemoryIndexStore（核心存储 + 索引管理）
 
-位置：`agiwo/tool/builtin/retrieval_tool/store.py`
+位置：`agiwo/memory/index_store.py`
 
-**职责**：持有 SQLite 连接，协调 Chunker + Embedder，暴露 `search()` 接口。
+**职责**：持有 SQLite 连接，协调 Chunker，暴露 `sync_files()` 等接口。
 
 ### 4.1 Schema
 
@@ -139,7 +97,7 @@ CREATE TABLE embedding_cache (
 -- 已索引文件记录
 CREATE TABLE files (
     path     TEXT PRIMARY KEY,
-    hash     TEXT NOT NULL,   -- 文件内容 sha256
+    hash     TEXT NOT NULL,
     mtime    INTEGER NOT NULL,
     size     INTEGER NOT NULL
 );
@@ -151,7 +109,7 @@ CREATE TABLE chunks (
     start_line INTEGER NOT NULL,
     end_line   INTEGER NOT NULL,
     content_hash TEXT NOT NULL,
-    model_id   TEXT NOT NULL DEFAULT '',  -- 产生 embedding 的模型，空=BM25-only
+    model_id   TEXT NOT NULL DEFAULT '',
     text       TEXT NOT NULL,
     updated_at INTEGER NOT NULL
 );
@@ -168,68 +126,47 @@ CREATE VIRTUAL TABLE chunks_fts USING fts5(
     text,
     chunk_id UNINDEXED,
     path UNINDEXED,
-    start_line UNINDEXED,
-    end_line UNINDEXED,
     tokenize = "unicode61"
-);
-
--- Embedding 缓存
-CREATE TABLE embedding_cache (
-    content_hash TEXT NOT NULL,
-    model_id     TEXT NOT NULL,
-    embedding    BLOB NOT NULL,
-    updated_at   INTEGER NOT NULL,
-    PRIMARY KEY (content_hash, model_id)
 );
 ```
 
-### 4.2 初始化与懒加载
+### 4.2 初始化
+
+MemoryIndexStore 通过构造函数接受 `workspace_dir` 和 `embedder`：
 
 ```python
 class MemoryIndexStore:
-    def __init__(self, workspace_dir: Path, config: MemoryConfig):
+    def __init__(self, workspace_dir: Path, embedder=None):
         self._workspace_dir = workspace_dir
-        self._memory_dir = workspace_dir / "MEMORY"
         self._db_path = workspace_dir / "memory.db"
-        self._config = config
-        self._conn: sqlite3.Connection | None = None
-        self._embedder: MemoryEmbedder | None = None
-        self._vec_available: bool = False
+        self._embedder = embedder  # EmbeddingModel 实例或 None
 ```
-
-- `_conn` 在第一次 `search()` 时通过 `_ensure_initialized()` 创建，不在构造函数中打开
-- 尝试 `conn.load_extension("vec0")` 检测 sqlite-vec 可用性，失败则 `_vec_available = False`
-- `_embedder` 通过 `EmbedderFactory.create(config)` 创建，失败则为 `None`（纯 BM25 模式）
 
 ### 4.3 增量索引（sync_files）
 
 ```
 sync_files():
-  1. 扫描 MEMORY/*.md（glob，非递归）
+  1. 扫描 MEMORY/*.md
   2. 对每个文件，计算 (mtime, size) 与 files 表比对
   3. 变更文件 → index_file(path)
-  4. 已删除文件 → remove_file(path)（删除 chunks / fts / vec 中对应行）
+  4. 已删除文件 → remove_file(path)
 
 index_file(path):
   1. 读取文件内容，计算 sha256 全文 hash
-  2. Chunker.chunk(content) → list[MemoryChunk]
-  3. 按 content_hash 批量查询 embedding_cache，分离 cache_hit / cache_miss
-  4. 对 cache_miss chunks 批量调用 Embedder.embed()，结果写入 embedding_cache
-  5. 删除该 path 的旧 chunks（chunks / fts / vec）
-  6. 批量 INSERT 新 chunks 到 chunks + fts
-  7. 若 _vec_available，批量 INSERT 到 chunks_vec
-  8. 更新 files 表（path, hash, mtime, size）
+  2. Chunker.chunk_file() → list[MemoryChunk]
+  3. 按 content_hash 批量查询 embedding_cache
+  4. 对 cache_miss chunks 批量调用 embedder.embed()
+  5. 删除该 path 的旧 chunks
+  6. 批量 INSERT 新 chunks
 ```
-
-**关键设计**：步骤 3-4 是增量核心——同一文本内容无论来自哪个文件、哪次索引，只要 `content_hash` 命中缓存，就跳过 API 调用。对于 Agent 频繁 append 的日志文件，只有新增部分产生 API 费用。
 
 ---
 
 ## 5. HybridSearcher（混合检索）
 
-位置：`agiwo/tool/builtin/retrieval_tool/searcher.py`
+位置：`agiwo/memory/searcher.py`
 
-**职责**：给定 query 字符串，返回按相关性排序的 `list[SearchResult]`。
+**职责**：给定 query 字符串，返回 `list[SearchResult]`。
 
 ```python
 @dataclass
@@ -239,88 +176,59 @@ class SearchResult:
     start_line: int
     end_line: int
     text: str
-    score: float          # 最终融合分数 [0, 1]
-    vector_score: float   # 原始向量分数（调试用）
-    bm25_score: float     # 原始 BM25 分数（调试用）
+    score: float
+    vector_score: float
+    bm25_score: float
 ```
 
 **检索流程详见 [data-flow.md](./data-flow.md)。**
 
 ---
 
-## 6. MemoryRetrievalTool（对外入口）
+## 6. WorkspaceMemoryService（业务编排层）
 
-位置：`agiwo/tool/builtin/retrieval_tool/retrieval.py`
+位置：`agiwo/memory/service.py`
 
-**作为标准 `BaseTool` 实现，对 Agent 暴露两个操作：**
+`MemoryRetrievalTool` 实际调用的是 `WorkspaceMemoryService`，而非直接使用 `MemoryIndexStore`。
 
-### Tool 参数设计
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "query": {
-      "type": "string",
-      "description": "Search query to find relevant memories"
-    },
-    "top_k": {
-      "type": "integer",
-      "description": "Number of results to return (default: 5)",
-      "default": 5
-    }
-  },
-  "required": ["query"]
-}
+```python
+class WorkspaceMemoryService:
+    async def search(self, agent_name, agent_id, query, top_k) -> tuple[Workspace | None, list[SearchResult]]:
+        # 1. 解析 workspace 目录
+        # 2. 初始化 MemoryIndexStore
+        # 3. 增量同步 MEMORY/ 目录
+        # 4. 混合检索
+        # 5. 返回结果
 ```
 
-**为何去掉 `summarize` 参数**：原 stub 中有 `summarize` 参数（让 LLM 二次总结结果），这增加了不必要的 LLM 调用且职责混乱。Agent 自身可判断是否需要进一步处理检索结果，Tool 只负责检索。
+---
+
+## 7. MemoryRetrievalTool（对外入口）
+
+位置：`agiwo/tool/builtin/retrieval_tool/tool.py`
+
+内部使用 `WorkspaceMemoryService` 而非 `MemoryIndexStore`。
 
 ### 执行流程
 
 ```python
-async def execute(parameters, context, abort_signal):
-    # 1. 从 context 解析 workspace_dir
-    workspace_dir = resolve_workspace(context, self._config)
-    
-    # 2. 获取/初始化 MemoryIndexStore（按 workspace_dir 缓存）
-    store = await _get_or_create_store(workspace_dir, self._config)
-    
-    # 3. 增量同步 MEMORY/ 目录
-    await store.sync_files()
-    
-    # 4. 混合检索
-    results = await store.search(query, top_k)
-    
-    # 5. 格式化输出给 LLM
-    return ToolResult(content=format_results(results))
+async def execute(self, parameters, context, abort_signal):
+    if abort_signal and abort_signal.is_aborted():
+        return ToolResult.aborted(tool_name=self.name, ...)
+
+    workspace, results = await self._memory_service.search(
+        agent_name=context.agent_name,
+        agent_id=context.agent_id,
+        query=parameters.get("query", ""),
+        top_k=parameters.get("top_k", self._top_k),
+    )
+
+    return ToolResult.success(tool_name=self.name, content=format_results(results))
 ```
-
-### Store 缓存
-
-`MemoryRetrievalTool` 内维护 `dict[str, MemoryIndexStore]`，按 `workspace_dir` 缓存 store 实例（避免每次调用重建 SQLite 连接）。由于 Tool 实例在 Agent 生命周期内唯一，此缓存与 Agent 生命周期对齐，无需额外管理。
-
-### 输出格式
-
-```
-## Memory Search Results for: "xxx"
-
-### [1] MEMORY/2025-01-15.md (lines 12-25)
-Score: 0.87
----
-{chunk text}
-
-### [2] MEMORY/project_alpha_2025-01-08.md (lines 3-18)
-Score: 0.72
----
-{chunk text}
-```
-
-包含文件路径和行号，方便 Agent 精确定位后用 `bash_tool` 读取完整文件。
 
 ---
 
-## 7. Prompt Runtime 集成
+## 8. Prompt 集成
 
 位置：`agiwo/agent/prompt.py`
 
@@ -333,8 +241,6 @@ Before answering anything about prior work, decisions, dates, or preferences:
 call `memory_retrieval` to search MEMORY/ files, then use the returned
 file paths + line numbers to read precise sections if needed.
 ```
-
-同时，`build_system_prompt()` 会在构建 system prompt 时准备 workspace 文档与环境信息；`render_system_prompt()` 再把这些内容和工具/skills 区块拼接成最终 prompt。`MEMORY/` 的近期内容会通过 `<inject-memories>` 约定自动注入，历史记忆仍通过 `memory_retrieval` 工具按需召回。
 
 **双轨机制**：
 - **自动注入**：近期记忆直接在 context 中，Agent 无需显式调用工具即可感知

--- a/docs/memory/data-flow.md
+++ b/docs/memory/data-flow.md
@@ -23,8 +23,9 @@ Agent 决定记录某段知识
 
 ```
 memory_retrieval(query="...")
-  └─► store.sync_files()     ← 增量扫描 + 索引变更文件
-        └─► store.search()   ← 混合检索
+  └─► WorkspaceMemoryService.search()
+        └─► MemoryIndexStore.sync_files()     ← 增量扫描 + 索引变更文件
+              └─► HybridSearcher.search()     ← 混合检索
 ```
 
 **增量扫描逻辑**（`sync_files`）：
@@ -63,9 +64,10 @@ index_file(path):
      c. INSERT cache_miss embeddings → embedding_cache
 
   4. 删除旧索引
+     SELECT chunk_id FROM chunks WHERE path = ?
      DELETE FROM chunks WHERE path = ?
-     DELETE FROM chunks_fts WHERE path = ?
-     DELETE FROM chunks_vec WHERE chunk_id IN (旧 chunk_ids)
+     DELETE FROM chunks_fts WHERE chunk_id IN (...)
+     DELETE FROM chunks_vec WHERE chunk_id IN (...)
 
   5. 批量写入新索引
      INSERT INTO chunks (...)
@@ -159,7 +161,7 @@ has_vec = v_score > 0
 has_bm  = bm_score > 0
 
 if has_vec and has_bm:
-    final = config.vector_weight * v_score + config.bm25_weight * bm_score
+    final = 0.7 * v_score + 0.3 * bm_score  # default weights
 elif has_vec:
     final = v_score   # 仅向量，满权重
 else:

--- a/docs/memory/overview.md
+++ b/docs/memory/overview.md
@@ -9,7 +9,7 @@
 - **按 Agent 隔离**：每个 `agent_name` 对应独立的 `.agiwo/<agent_name>/` workspace，索引库也独立存储
 - **被动索引**：不引入后台守护进程；索引在工具调用时按需触发（增量、懒加载）
 - **Embedding 可降级**：若无可用 Embedding Provider，自动退化为纯 BM25 检索，功能不中断
-- **与现有架构零耦合**：`MemoryRetrievalTool` 是标准 `BaseTool`，`MemoryIndexStore` 独立于 Agent 生命周期
+- **与现有架构零耦合**：`MemoryRetrievalTool` 是标准 `BaseTool`，`WorkspaceMemoryService` 独立于 Agent 生命周期
 
 ---
 
@@ -70,7 +70,7 @@
 | 时间衰减 | 可配置指数衰减 | 可配置指数衰减（保留） |
 | MMR 重排 | 可选 | 可选（保留） |
 | Query Expansion | FTS-Only 时关键词扩展 | 保留（停用词过滤 + 多词 OR 查询） |
-| 配置体系 | resolveMemorySearchConfig() 全局 | `MemoryConfig` dataclass，注入 Tool |
+| 配置体系 | resolveMemorySearchConfig() 全局 | 全局 `AgiwoSettings`，按工具构造函数覆盖 |
 
 **关键简化**：去掉后台 Watcher 和会话同步，改为在 `memory_retrieval` 工具调用入口做增量索引检查。这使系统完全无状态守护进程，符合 Agiwo 的 "no background daemon" 原则。
 
@@ -79,16 +79,22 @@
 ## 文件组织
 
 ```
-agiwo/tool/builtin/retrieval_tool/
+agiwo/memory/
 ├── __init__.py
-├── store.py          # MemoryIndexStore：SQLite 索引 + 检索核心
-├── chunker.py        # Markdown chunk 切割
-├── embedder.py       # Embedding Provider 抽象 + OpenAI 实现
-├── searcher.py       # HybridSearcher：BM25 + Vector + 融合 + MMR
-└── retrieval.py      # MemoryRetrievalTool（BaseTool 实现，对外入口）
+├── chunker.py        # MemoryChunker, MemoryChunk: Markdown chunk 切割
+├── index_store.py    # MemoryIndexStore: SQLite 索引 + 检索
+├── searcher.py       # HybridSearcher, SearchResult: BM25 + Vector
+└── service.py        # WorkspaceMemoryService: 业务编排层
 
-agiwo/tool/builtin/config.py
-└── MemoryConfig      # 新增配置 dataclass
+agiwo/tool/builtin/retrieval_tool/
+└── tool.py           # MemoryRetrievalTool（BaseTool 实现，对外入口）
+
+agiwo/embedding/
+├── __init__.py
+├── base.py           # EmbeddingModel 抽象
+├── factory.py        # EmbeddingFactory
+├── openai.py         # OpenAI Embedding 实现
+└── local.py          # Local Embedding 实现
 ```
 
 ---
@@ -101,8 +107,8 @@ Agent 写记忆
 
 Agent 查记忆
   └─► memory_retrieval(query="...")
-        └─► MemoryIndexStore.search(query)
-              ├─ sync_files()          # 增量扫描 MEMORY/，索引变更文件
+        └─► WorkspaceMemoryService.search()
+              ├─ MemoryIndexStore.sync_files()  # 增量扫描 MEMORY/，索引变更文件
               ├─ HybridSearcher.search()
               │    ├─ vector_search()  # Embedding + cosine
               │    ├─ bm25_search()    # FTS5


### PR DESCRIPTION
## Summary

- Fix 20+ documentation mismatches with the actual codebase
- Replace non-existent `OpenAICompatibleModel`/`AnthropicCompatibleModel` classes with `create_model_from_dict` factory pattern
- Fix `create_model()` signature (takes `ModelSpec`, not kwargs)
- Fix provider string `"bedrock_anthropic"` → `"bedrock-anthropic"`
- Rewrite memory system docs to match actual `agiwo/memory/` + `agiwo/embedding/` layout
- Fix `AbortSignal.is_cancelled()` → `.is_aborted()`
- Remove non-existent `SessionStorage`/`create_session_storage` references
- Complete `ToolContext` field documentation, add `BaseTool.gate()`/`build_context()`
- Add missing `on_compaction_failed` hook documentation
- Fix console integration references to actual `SessionManager`/`SessionContextService`
- Fix `README.md` streaming example event type check

## Test plan

- [ ] Verify all doc links resolve correctly
- [ ] Check code examples in docs can be imported/run
- [ ] Review memory system docs against `agiwo/memory/` actual structure
- [ ] Review model API docs against `agiwo/llm/factory.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool safety gating with new `gate()` method for preflight checks
  * Tool context building with new `build_context()` hook
  * Enhanced `ToolContext` with session, agent, and user identifiers
  * New `on_compaction_failed` hook for compaction error handling

* **Breaking Changes**
  * Renamed `is_cancelled()` to `is_aborted()` on abort signals
  * Unified compatible model creation via factory function

* **Documentation**
  * Simplified storage model (session storage abstraction removed)
  * Clarified scheduler agent retrieval behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->