### PR TITLE
Fix review follow-ups for console runtime

### DIFF
--- a/console/server/channels/README.md
+++ b/console/server/channels/README.md
@@ -23,6 +23,7 @@ channels/
     ├── connection.py     # 长连接适配
     ├── inbound_handler.py
     ├── message_parser.py
+    ├── sender_resolver.py # 发送者解析器（FeishuSenderResolver）
     ├── message_builder.py
     ├── delivery_service.py
     ├── factory.py

--- a/console/server/channels/feishu/inbound_handler.py
+++ b/console/server/channels/feishu/inbound_handler.py
@@ -100,7 +100,7 @@ class FeishuInboundHandler:
         # Resolve default agent before ACK/command to catch config errors early
         try:
             default_agent = await self._session_service.resolve_default_agent_config()
-            if default_agent is None and self._default_agent_name:
+            if default_agent is None:
                 raise DefaultAgentNameNotFoundError(self._default_agent_name)
         except DefaultAgentNameNotFoundError:
             # Return user-facing error without ACKing
@@ -123,10 +123,8 @@ class FeishuInboundHandler:
     async def _enqueue_message(
         self,
         inbound: InboundMessage,
-        default_agent: AgentConfigRecord | None,
+        default_agent: AgentConfigRecord,
     ) -> None:
-        if default_agent is None:
-            raise DefaultAgentNameNotFoundError(self._default_agent_name)
         chat_context_scope_id = self._build_chat_context_scope_id(inbound)
         context = BatchContext(
             chat_context_scope_id=chat_context_scope_id,
@@ -142,7 +140,7 @@ class FeishuInboundHandler:
     async def _try_handle_command(
         self,
         inbound: InboundMessage,
-        default_agent: AgentConfigRecord | None,
+        default_agent: AgentConfigRecord,
     ) -> dict[str, object] | None:
         parsed = self._command_registry.try_parse(inbound.text)
         if parsed is None:
@@ -182,7 +180,7 @@ class FeishuInboundHandler:
     async def _build_command_context(
         self,
         inbound: InboundMessage,
-        default_agent: AgentConfigRecord | None,
+        default_agent: AgentConfigRecord,
     ) -> CommandContext:
         chat_context_scope_id = self._build_chat_context_scope_id(inbound)
         (
@@ -191,7 +189,6 @@ class FeishuInboundHandler:
         ) = await self._session_service.get_chat_context_and_current_session(
             chat_context_scope_id
         )
-        base_agent_id = default_agent.id if default_agent is not None else ""
         return CommandContext(
             chat_context_scope_id=chat_context_scope_id,
             channel_instance_id=self._channel_instance_id,
@@ -199,7 +196,7 @@ class FeishuInboundHandler:
             chat_type=inbound.chat_type,
             trigger_user_open_id=inbound.sender_id,
             trigger_message_id=inbound.message_id,
-            base_agent_id=base_agent_id,
+            base_agent_id=default_agent.id,
             chat_context=chat_context,
             current_session=current_session,
         )

--- a/console/server/channels/feishu/sender_resolver.py
+++ b/console/server/channels/feishu/sender_resolver.py
@@ -31,8 +31,9 @@ class FeishuSenderResolver:
 
     async def resolve_sender_name(self, sender_open_id: str) -> str:
         now = time.time()
+        self._evict_expired_sender_names(now)
         cached = self._sender_name_cache.get(sender_open_id)
-        if cached is not None and now < cached.expire_at:
+        if cached is not None:
             return cached.display_name
 
         fallback = self._format_sender_name(sender_open_id)
@@ -54,6 +55,15 @@ class FeishuSenderResolver:
             expire_at=now + self._cache_ttl_seconds,
         )
         return display_name
+
+    def _evict_expired_sender_names(self, now: float) -> None:
+        expired_keys = [
+            sender_open_id
+            for sender_open_id, entry in self._sender_name_cache.items()
+            if now >= entry.expire_at
+        ]
+        for sender_open_id in expired_keys:
+            del self._sender_name_cache[sender_open_id]
 
     def _format_sender_name(self, sender_open_id: str) -> str:
         normalized = sender_open_id.strip()

--- a/console/server/config.py
+++ b/console/server/config.py
@@ -54,7 +54,9 @@ class StorageConfig(BaseModel):
     def _normalize_trace_type(cls, value: object) -> str:
         if value == "none":
             return "memory"
-        return value  # type: ignore[return-value]
+        if isinstance(value, str):
+            return value
+        return str(value)
 
 
 class FeishuConfig(BaseModel):

--- a/console/server/models/view.py
+++ b/console/server/models/view.py
@@ -23,7 +23,7 @@ def extract_content_parts(value: object) -> object:
             if isinstance(data, dict) and data.get("__type") == "content_parts":
                 return data.get("parts", [])
             return data
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError:
             return value
     return value
 

--- a/console/server/response_serialization.py
+++ b/console/server/response_serialization.py
@@ -41,25 +41,31 @@ def step_metrics_response_from_sdk(metrics: step.StepMetrics) -> StepMetricsResp
     )
 
 
-def step_response_from_sdk(step: step.StepRecord) -> StepResponse:
+def step_response_from_sdk(step_record: step.StepRecord) -> StepResponse:
     return StepResponse(
-        id=step.id,
-        session_id=step.session_id,
-        run_id=step.run_id,
-        sequence=step.sequence,
-        role=step.role.value,
-        agent_id=step.agent_id,
-        content=step.content,
-        content_for_user=step.content_for_user,
-        reasoning_content=step.reasoning_content,
-        user_input=step.user_input,
-        tool_calls=step.tool_calls if step.tool_calls else None,
-        tool_call_id=step.tool_call_id,
-        name=step.name,
-        metrics=step_metrics_response_from_sdk(step.metrics) if step.metrics else None,
-        created_at=step.created_at.isoformat() if step.created_at else None,
-        parent_run_id=step.parent_run_id,
-        depth=step.depth,
+        id=step_record.id,
+        session_id=step_record.session_id,
+        run_id=step_record.run_id,
+        sequence=step_record.sequence,
+        role=step_record.role.value,
+        agent_id=step_record.agent_id,
+        content=step_record.content,
+        content_for_user=step_record.content_for_user,
+        reasoning_content=step_record.reasoning_content,
+        user_input=step_record.user_input,
+        tool_calls=step_record.tool_calls if step_record.tool_calls else None,
+        tool_call_id=step_record.tool_call_id,
+        name=step_record.name,
+        metrics=(
+            step_metrics_response_from_sdk(step_record.metrics)
+            if step_record.metrics
+            else None
+        ),
+        created_at=step_record.created_at.isoformat()
+        if step_record.created_at
+        else None,
+        parent_run_id=step_record.parent_run_id,
+        depth=step_record.depth,
     )
 
 

--- a/console/server/routers/chat.py
+++ b/console/server/routers/chat.py
@@ -62,7 +62,6 @@ async def chat(
     runtime_service = SessionRuntimeService(
         scheduler=scheduler,
         session_store=runtime.session_store,
-        timeout=600,
     )
     dispatch = await runtime_service.execute(agent, session, body.message)
 
@@ -153,6 +152,14 @@ async def _get_or_create_chat_session(
     assert runtime.session_store is not None
     session = await runtime.session_store.get_session(session_id)
     if session is not None:
+        if session.base_agent_id != agent_id:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Session '{session_id}' belongs to agent "
+                    f"'{session.base_agent_id}', not '{agent_id}'"
+                ),
+            )
         return session
 
     now = datetime.now(timezone.utc)

--- a/console/server/services/agent_registry/models.py
+++ b/console/server/services/agent_registry/models.py
@@ -1,6 +1,6 @@
 """Shared models for agent registry persistence."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -22,8 +22,8 @@ class AgentConfigRecord(BaseModel):
     tools: list[str] = Field(default_factory=list)
     options: dict[str, Any] = Field(default_factory=dict)
     model_params: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=datetime.now)
-    updated_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @model_validator(mode="before")
     @classmethod

--- a/console/server/services/runtime/session_service.py
+++ b/console/server/services/runtime/session_service.py
@@ -218,23 +218,14 @@ class SessionContextService:
         source = await self._store.get_session(chat_context.current_session_id)
         if source is None:
             raise SessionNotFoundError(chat_context.current_session_id)
-        now = datetime.now(timezone.utc)
-        session_id = str(uuid4())
-        session = Session(
-            id=session_id,
-            chat_context_scope_id=chat_context.scope_id,
-            base_agent_id=source.base_agent_id,
-            runtime_agent_id="",
-            scheduler_state_id="",
+        session = self._create_forked_session(
+            chat_context=chat_context,
+            source=source,
+            context_summary=context_summary,
             created_by=created_by,
-            created_at=now,
-            updated_at=now,
-            source_session_id=source.id,
-            source_task_id=source.current_task_id,
-            fork_context_summary=context_summary,
         )
-        chat_context.current_session_id = session_id
-        chat_context.updated_at = now
+        chat_context.current_session_id = session.id
+        chat_context.updated_at = session.updated_at
         await self._store.upsert_chat_context(chat_context)
         await self._store.upsert_session(session)
         return SessionCreateResult(
@@ -255,23 +246,14 @@ class SessionContextService:
         chat_context = await self._store.get_chat_context(source.chat_context_scope_id)
         if chat_context is None:
             raise ChatContextNotFoundError(source.chat_context_scope_id)
-        now = datetime.now(timezone.utc)
-        new_session_id = str(uuid4())
-        session = Session(
-            id=new_session_id,
-            chat_context_scope_id=chat_context.scope_id,
-            base_agent_id=source.base_agent_id,
-            runtime_agent_id="",
-            scheduler_state_id="",
+        session = self._create_forked_session(
+            chat_context=chat_context,
+            source=source,
+            context_summary=context_summary,
             created_by=created_by,
-            created_at=now,
-            updated_at=now,
-            source_session_id=source.id,
-            source_task_id=source.current_task_id,
-            fork_context_summary=context_summary,
         )
-        chat_context.current_session_id = new_session_id
-        chat_context.updated_at = now
+        chat_context.current_session_id = session.id
+        chat_context.updated_at = session.updated_at
         await self._store.upsert_chat_context(chat_context)
         await self._store.upsert_session(session)
         return SessionCreateResult(
@@ -352,6 +334,29 @@ class SessionContextService:
         await self._store.upsert_chat_context(chat_context)
         await self._store.upsert_session(session)
         return SessionCreateResult(chat_context=chat_context, session=session)
+
+    def _create_forked_session(
+        self,
+        *,
+        chat_context: ChannelChatContext,
+        source: Session,
+        context_summary: str,
+        created_by: str,
+    ) -> Session:
+        now = datetime.now(timezone.utc)
+        return Session(
+            id=str(uuid4()),
+            chat_context_scope_id=chat_context.scope_id,
+            base_agent_id=source.base_agent_id,
+            runtime_agent_id="",
+            scheduler_state_id="",
+            created_by=created_by,
+            created_at=now,
+            updated_at=now,
+            source_session_id=source.id,
+            source_task_id=source.current_task_id,
+            fork_context_summary=context_summary,
+        )
 
     async def _ensure_session_base_agent(
         self,

--- a/console/server/services/tool_catalog/tool_catalog.py
+++ b/console/server/services/tool_catalog/tool_catalog.py
@@ -1,12 +1,17 @@
 """Available tool listing for the Console API."""
 
-from agiwo.tool.builtin.registry import BUILTIN_TOOLS
+from agiwo.tool.builtin.registry import BUILTIN_TOOLS, ensure_builtin_tools_loaded
+from agiwo.utils.logging import get_logger
 
 from server.services.agent_registry import AgentRegistry
 from server.services.tool_catalog.tool_references import AGENT_TOOL_PREFIX
 
+logger = get_logger(__name__)
+
 BUILTIN_TOOL_DESCRIPTIONS: dict[str, str] = {
     "bash": "Execute shell commands in a terminal-style sandbox",
+    "bash_process": "Inspect and control background shell processes",
+    "memory_retrieval": "Search shared workspace memory for relevant context",
     "web_search": "Search the web for information",
     "web_reader": "Fetch and extract content from web URLs",
 }
@@ -17,14 +22,20 @@ async def list_available_tools(
     *,
     exclude_agent_id: str | None = None,
 ) -> list[dict[str, str]]:
-    tools: list[dict[str, str]] = [
-        {
-            "name": name,
-            "description": BUILTIN_TOOL_DESCRIPTIONS.get(name, ""),
-            "type": "builtin",
-        }
-        for name in BUILTIN_TOOLS
-    ]
+    ensure_builtin_tools_loaded()
+    tools: list[dict[str, str]] = []
+    for name in BUILTIN_TOOLS:
+        description = BUILTIN_TOOL_DESCRIPTIONS.get(name)
+        if description is None:
+            logger.warning("builtin_tool_description_missing", tool_name=name)
+            description = ""
+        tools.append(
+            {
+                "name": name,
+                "description": description,
+                "type": "builtin",
+            }
+        )
     for agent in await registry.list_agents():
         if exclude_agent_id is not None and agent.id == exclude_agent_id:
             continue

--- a/console/tests/test_agents_api.py
+++ b/console/tests/test_agents_api.py
@@ -121,8 +121,14 @@ async def test_list_available_tools_uses_catalog_for_builtin_and_agent_entries(
     assert response.status_code == 200
     payload = response.json()
     builtin_names = {item["name"] for item in payload if item["type"] == "builtin"}
+    builtin_descriptions = {
+        item["name"]: item["description"]
+        for item in payload
+        if item["type"] == "builtin"
+    }
     agent_names = {item["name"] for item in payload if item["type"] == "agent"}
     assert "web_search" in builtin_names
+    assert builtin_descriptions["bash_process"]
     assert f"agent:{created.id}" in agent_names
 
 

--- a/console/tests/test_chat_api.py
+++ b/console/tests/test_chat_api.py
@@ -1,5 +1,6 @@
 """Integration tests for the Chat API streaming endpoint (scheduler-mediated)."""
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,6 +20,7 @@ from server.dependencies import (
     clear_console_runtime,
     get_console_runtime_from_app,
 )
+from server.models.session import Session
 from server.services.agent_registry import AgentConfigRecord, AgentRegistry
 from server.services.storage_wiring import create_run_step_storage, create_trace_storage
 
@@ -129,13 +131,13 @@ async def test_chat_streams_scheduler_events(
         state_id: str | None,
         session_id: str,
         persistent: bool,
-        timeout: int,
+        timeout: int | None,
     ):
         assert agent is fake_agent
         assert message == "hello"
         assert state_id is None
         assert persistent is True
-        assert timeout == 600
+        assert timeout is None
         return type(
             "RouteResultStub",
             (),
@@ -170,3 +172,52 @@ async def test_chat_agent_not_found(client) -> None:
         json={"message": "hello"},
     )
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_session_bound_to_different_agent(client) -> None:
+    runtime = _runtime(client)
+    monkeypatch = pytest.MonkeyPatch()
+    await runtime.agent_registry.create_agent(
+        AgentConfigRecord(
+            id="agent-1",
+            name="chat-agent-1",
+            model_provider="openai",
+            model_name="gpt-test",
+        )
+    )
+    await runtime.agent_registry.create_agent(
+        AgentConfigRecord(
+            id="agent-2",
+            name="chat-agent-2",
+            model_provider="openai",
+            model_name="gpt-test",
+        )
+    )
+    monkeypatch.setattr(
+        "server.routers.chat.build_agent",
+        AsyncMock(return_value=object()),
+    )
+    assert runtime.session_store is not None
+    now = datetime.now(timezone.utc)
+    await runtime.session_store.upsert_session(
+        Session(
+            id="session-1",
+            chat_context_scope_id="session-1",
+            base_agent_id="agent-1",
+            runtime_agent_id="",
+            scheduler_state_id="",
+            created_by="CONSOLE_CHAT",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    response = await client.post(
+        "/api/chat/agent-2",
+        json={"message": "hello", "session_id": "session-1"},
+    )
+
+    assert response.status_code == 409
+    assert "belongs to agent 'agent-1'" in response.text
+    monkeypatch.undo()

--- a/console/tests/test_config_env.py
+++ b/console/tests/test_config_env.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import pytest
 from pydantic import ValidationError
 
@@ -30,6 +32,23 @@ def test_console_config_reads_uppercase_env(monkeypatch: pytest.MonkeyPatch) -> 
     config = ConsoleConfig()
 
     assert config.channels.feishu.enabled is True
+
+
+def test_console_config_normalizes_legacy_none_trace_type() -> None:
+    config = ConsoleConfig(trace_storage_type="none")
+
+    assert config.storage.trace_type == "memory"
+
+
+def test_agent_config_record_uses_utc_timestamps() -> None:
+    record = AgentConfigRecord(
+        name="tester",
+        model_provider="openai",
+        model_name="gpt-test",
+    )
+
+    assert record.created_at.tzinfo is timezone.utc
+    assert record.updated_at.tzinfo is timezone.utc
 
 
 def test_console_config_rejects_legacy_default_model_provider(

--- a/console/tests/test_feishu_service_components.py
+++ b/console/tests/test_feishu_service_components.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+import time
 
 from agiwo.agent import ContentPart, ContentType
 from server.channels.feishu.commands.base import CommandResult
@@ -20,7 +21,10 @@ from server.channels.feishu.message_parser import (
     FeishuInboundEnvelope,
     FeishuMessageParser,
 )
-from server.channels.feishu.sender_resolver import FeishuSenderResolver
+from server.channels.feishu.sender_resolver import (
+    FeishuSenderResolver,
+    _SenderNameCacheEntry,
+)
 from server.config import ConsoleConfig
 from server.models.session import Attachment, BatchContext, InboundMessage
 
@@ -185,6 +189,21 @@ async def test_sender_resolver_caches_display_name_lookup() -> None:
     assert first == "Alice"
     assert second == "Alice"
     api.get_user_display_name.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_sender_resolver_evicts_expired_entries() -> None:
+    api = SimpleNamespace(get_user_display_name=AsyncMock(return_value="Alice"))
+    resolver = FeishuSenderResolver(api=api, cache_ttl_seconds=1)  # type: ignore[arg-type]
+    resolver._sender_name_cache["stale-user"] = _SenderNameCacheEntry(
+        display_name="Old",
+        expire_at=time.time() - 1,
+    )
+
+    result = await resolver.resolve_sender_name("user-1")
+
+    assert result == "Alice"
+    assert "stale-user" not in resolver._sender_name_cache
 
 
 def test_group_history_store_tracks_recent_group_lines() -> None:

--- a/console/tests/test_remote_workspace_session_service.py
+++ b/console/tests/test_remote_workspace_session_service.py
@@ -196,6 +196,8 @@ async def test_fork_session_by_id() -> None:
     assert result.session.source_task_id == "task-1"
     assert result.session.fork_context_summary == "branching off"
     assert result.chat_context.current_session_id == result.session.id
+    assert result.session.runtime_agent_id == ""
+    assert result.session.scheduler_state_id == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- apply the still-valid review follow-ups in console runtime and Feishu helper code
- add chat session/agent isolation, sender cache eviction, UTC registry timestamps, and fork-session helper deduplication
- update channel docs and add focused tests for the repaired behavior

## Validation
- `cd console && uv run pytest tests/test_chat_api.py tests/test_feishu_service_components.py tests/test_config_env.py tests/test_agents_api.py tests/test_remote_workspace_session_service.py tests/test_models.py tests/test_response_serialization.py -q`
- `uv run pytest tests/agent/test_module_layout.py -q`
- `uv run python scripts/lint.py changed`
- `uv run ruff format --check console/server/response_serialization.py console/tests/test_agents_api.py console/server/routers/chat.py console/server/channels/feishu/inbound_handler.py console/server/channels/feishu/sender_resolver.py console/server/config.py console/server/models/view.py console/server/services/agent_registry/models.py console/server/services/runtime/session_service.py console/server/services/tool_catalog/tool_catalog.py console/tests/test_chat_api.py console/tests/test_config_env.py console/tests/test_feishu_service_components.py console/tests/test_remote_workspace_session_service.py`
