### PR TITLE
fix: load public docs homepage styles

### DIFF
--- a/website/src/layouts/MarketingLayout.astro
+++ b/website/src/layouts/MarketingLayout.astro
@@ -1,4 +1,6 @@
 ---
+import "../styles/site.css";
+
 interface Props {
   title: string;
   description: string;


### PR DESCRIPTION
## Summary
- load the public site stylesheet in the marketing layout
- fix the deployed homepage rendering as unstyled HTML

## Validation
- npm --prefix website run check
- npm --prefix website run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stylesheet application for the marketing layout to ensure consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->