### PR TITLE
feat: add generated repository overview docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,4 @@ cd console && uv run pytest tests/ -v
 - 当“目录职责”、“公开 API”、“机器护栏规则”、“标准开发流程”发生变化时更新本文件。
 - 继续保持目录/包级别描述，不要退回到逐文件目录树。
 - 如果某条说明开始频繁失真，优先上移抽象层级，而不是继续堆更多细节。
+- Public repository overview generation consumes repository structure first and may also use `AGENTS.md` as a supporting source；请保持目录职责与稳定边界说明为最新状态。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 
 | Path | Responsibility |
 | --- | --- |
-| `agiwo/agent/` | Canonical agent runtime。public API 只从 `agiwo.agent` 暴露；顶层只保留稳定入口与核心 orchestrator（如 `agent.py`、`definition.py`、`run_loop.py`、`llm_caller.py`、`tool_executor.py`、`prompt.py`、`trace_writer.py`）。纯数据模型收口在 `models/`，hook contract 收口在 `hooks/`，nested-agent adapter 收口在 `nested/`，run/session runtime context 与 state helper 收口在 `agiwo.agent.runtime`，termination logic 收口在 `termination/`，上下文回顾优化收口在 `retrospect/`，`storage/` 负责持久化。 |
+| `agiwo/agent/` | Canonical agent runtime。public API 只从 `agiwo.agent` 暴露；顶层只保留稳定入口与核心 orchestrator（如 `agent.py`、`definition.py`、`run_loop.py`、`llm_caller.py`、`tool_executor.py`、`prompt.py`、`trace_writer.py`）。纯数据模型收口在 `models/`，hook contract 收口在 `agiwo.agent.hooks`，nested-agent adapter 收口在 `nested/`，run/session runtime context 与 state helper 收口在 `agiwo.agent.runtime`，termination logic 收口在 `termination/`，上下文回顾优化收口在 `retrospect/`，`storage/` 负责持久化。 |
 | `agiwo/llm/` | Model 抽象、Provider 适配器、配置策略、消息/事件归一化，以及统一的 model factory。 |
 | `agiwo/tool/` | Tool 抽象、最小执行上下文、builtin tools、后台进程 registry（`process/`），以及工具侧存储（如 citation）。 |
 | `agiwo/scheduler/` | Agent 之上的编排层。`scheduler.py` 是 facade 与 loop lifecycle，`engine.py` 是唯一编排 owner，`runner.py` 负责单次 dispatch action 执行，`commands.py` 承载调度动作与 tool DTO，`runtime_state.py` 承载进程内 live state 与 tick helpers，`tool_control.py` 收口 child/sleep/cancel 的 tool-facing control，`runtime_tools.py` 是注入给 agent 的 scheduler runtime tools，`store/` 只负责持久化。 |
@@ -34,7 +34,7 @@
 | --- | --- |
 | `console/server/` | FastAPI 控制面与 runtime 集成。 |
 | `console/server/routers/` | API/SSE 边界，只做 HTTP 路由与请求/响应装配。 |
-| `console/server/services/` | 应用服务层。`runtime/`（agent factory、runtime cache、session runtime / session service、scheduler tree view）、`tool_catalog/`（tool reference / catalog / runtime builder）、`agent_registry/`（配置 CRUD + store 子包）、`runtime_config.py`（运行时全局配置查看/覆盖）、`storage_wiring.py`（存储 config builders）、`metrics.py`。 |
+| `console/server/services/` | 应用服务层。`runtime/`（agent factory、runtime cache、session runtime / session service、scheduler tree view）、`tool_catalog/`（tool reference / catalog / runtime builder）、`agent_registry/`（配置 CRUD + store 子包）、`session_store/`（Console 会话存储工厂与实现）、`runtime_config.py`（运行时全局配置查看/覆盖）、`storage_wiring.py`（存储 config builders）、`metrics.py`。 |
 | `console/server/models/` | Console 数据模型目录。`view.py` 只放 API/SSE 视图模型；`session.py`、`agent_config.py`、`runtime_config.py`、`metrics.py` 放共享运行时/配置/聚合模型。不要再新增 `schemas.py` 或平级 `domain/`。 |
 | `console/server/channels/` | 渠道适配层，负责批处理、消息解析、delivery，以及 Feishu 等渠道集成。 |
 | `console/web/` | Console 前端。 |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@
 - Website: `https://docs.agiwo.o-ai.tech`
 - Getting started: `https://docs.agiwo.o-ai.tech/docs/getting-started/`
 - Comparison: `https://docs.agiwo.o-ai.tech/docs/compare/agiwo-vs-langgraph-openai-agents-autogen/`
+- Repository overview: `https://docs.agiwo.o-ai.tech/docs/repo-overview/`
+
+## Repository Structure
+
+Agiwo has three main areas:
+
+- `agiwo/` — the SDK runtime, including agent execution, tools, scheduler orchestration, model abstraction, memory, workspace, and observability
+- `console/` — the FastAPI control plane and internal web UI
+- `docs/` — design notes, concepts, and repository-native documentation
 
 ## What Is Agiwo?
 
@@ -33,14 +42,12 @@ The project favors explicit runtime wiring over hidden global state. Agent execu
 
 ## Current Capabilities
 
-- Streaming-first agent execution: `run()` and `run_stream()` share the same execution pipeline via `start()` + `AgentExecutionHandle`
-- Tool calling with session-scoped caching and builtin tools: `bash`, `bash_process`, `web_search`, `web_reader`, `memory` retrieval, and more
-- Agent-as-tool composition through `Agent.as_tool()` with depth tracking and cycle detection
-- Global skill discovery via `AGIWO_SKILL_DIRS`, per-agent filtering via `allowed_skills`
-- Context optimization: context rollback (empty step removal) and tool result retrospect (compression)
-- Scheduler orchestration: `submit`, `enqueue_input`, `route_root_input`, `stream`, `wait_for`, `steer`, `cancel`, `shutdown`, plus child-agent spawn/sleep/wake lifecycle
-- Run/step persistence plus trace collection with memory, SQLite, and MongoDB backends
-- Console APIs for agent config CRUD, chat SSE, trace inspection, scheduler state and chat, channel integration (Feishu)
+- Streaming-first agent execution through one runtime pipeline surfaced as `start()`, `run()`, and `run_stream()`
+- Tool calling with builtin tools, custom `BaseTool` implementations, and agent-as-tool composition via `Agent.as_tool()`
+- Scheduler orchestration for roots and child agents, including `submit`, `route_root_input`, `stream`, `wait_for`, `steer`, and cancellation flows
+- Run and step persistence plus trace collection with memory, SQLite, and MongoDB-backed storage options
+- Global skill discovery with per-agent allowlisting through explicit `allowed_skills`
+- Console APIs and web control plane for agent config management, session chat, scheduler views, trace inspection, and channel integration
 
 ## Quick Start
 

--- a/docs/public-site-deploy.md
+++ b/docs/public-site-deploy.md
@@ -43,3 +43,12 @@ After GitHub Pages accepts the custom domain and issues the certificate:
 - Verify the domain in Google Search Console
 - Submit the sitemap in Search Console
 - Update the GitHub repository Website field to `https://docs.agiwo.o-ai.tech`
+
+## Repository Overview Refresh
+
+When repository structure or architecture boundaries change:
+
+1. Update `README.md` and `AGENTS.md` if needed
+2. Run `python scripts/generate_repo_overview.py`
+3. Review `website/src/generated/repo-overview.json`
+4. Rebuild the public site before publishing

--- a/docs/superpowers/plans/2026-04-14-agiwo-repo-overview-generation.md
+++ b/docs/superpowers/plans/2026-04-14-agiwo-repo-overview-generation.md
@@ -1,0 +1,792 @@
+# Agiwo Repository Overview Generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a code-tree-driven public repository overview page to the docs site, backed by a manual generator and calibrated supporting documentation.
+
+**Architecture:** The implementation first aligns `README.md` and `AGENTS.md` with the current codebase so they can safely act as supporting sources. A manual Python generator will then scan selected repository structure and supporting docs to emit `website/src/generated/repo-overview.json`, and the Astro/Starlight public site will render that data into `/docs/repo-overview/`.
+
+**Tech Stack:** Python 3.11, standard library file parsing, Astro, Starlight, TypeScript, MDX, JSON
+
+---
+
+## File Structure
+
+### New files and directories
+
+- Create: `scripts/generate_repo_overview.py`
+- Create: `website/src/generated/repo-overview.json`
+- Create: `website/src/components/repo-overview/repo-overview-page.astro`
+- Create: `website/src/components/repo-overview/layout-section.astro`
+- Create: `website/src/components/repo-overview/runtime-surface-list.astro`
+- Create: `website/src/components/repo-overview/boundary-list.astro`
+- Create: `website/src/content/docs/docs/repo-overview.mdx`
+
+### Existing files to modify
+
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `website/src/content/docs/docs/index.mdx`
+- Modify: `website/astro.config.mjs`
+- Modify: `website/src/styles/site.css`
+
+### Tests and validation targets
+
+- Validate: `python scripts/generate_repo_overview.py`
+- Validate: `python scripts/generate_repo_overview.py --check`
+- Validate: `npm --prefix website run check`
+- Validate: `npm --prefix website run build`
+
+### Notes on scope
+
+- Do not build symbol-level API extraction.
+- Do not make Astro scan the repository directly.
+- Do not add automatic regeneration to CI in this phase.
+
+## Task 1: Calibrate README.md against the current codebase
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Review the current README and compare it to code-facing source of truth**
+
+Run:
+
+```bash
+sed -n '1,260p' README.md
+sed -n '1,260p' AGENTS.md
+```
+
+Expected:
+
+```text
+Current README positioning, quick start, capability list, and docs links are visible.
+```
+
+- [ ] **Step 2: Replace stale or ambiguous capability bullets with code-aligned wording**
+
+Update the README capability section so it reflects the current boundaries and wording used in the repository. Keep the section concise and public-facing.
+
+Write this replacement block inside `README.md` under `## Current Capabilities`:
+
+```md
+## Current Capabilities
+
+- Streaming-first agent execution through one runtime pipeline surfaced as `start()`, `run()`, and `run_stream()`
+- Tool calling with builtin tools, custom `BaseTool` implementations, and agent-as-tool composition via `Agent.as_tool()`
+- Scheduler orchestration for roots and child agents, including submit, routing, steering, waiting, and cancellation flows
+- Run and step persistence plus trace collection with memory, SQLite, and MongoDB-backed storage options
+- Global skill discovery with per-agent allowlisting through explicit `allowed_skills`
+- Console APIs and web control plane for agent config management, session chat, scheduler views, and trace inspection
+```
+
+- [ ] **Step 3: Add a short repository structure pointer for public readers**
+
+Insert this section after the public docs links in `README.md`:
+
+```md
+## Repository Structure
+
+Agiwo has three main areas:
+
+- `agiwo/` — the SDK runtime, including agent execution, tools, scheduler orchestration, model abstraction, memory, workspace, and observability
+- `console/` — the FastAPI control plane and internal web UI
+- `docs/` — design notes, concepts, and repository-native documentation
+
+For a code-aware public architecture overview, see:
+
+- `https://docs.agiwo.o-ai.tech/docs/repo-overview/`
+```
+
+- [ ] **Step 4: Verify the README still reads cleanly as a public entry document**
+
+Run:
+
+```bash
+sed -n '1,140p' README.md
+```
+
+Expected:
+
+```text
+Public Docs
+Repository Structure
+Current Capabilities
+```
+
+- [ ] **Step 5: Commit the README calibration**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: calibrate readme for repo overview generation"
+```
+
+## Task 2: Calibrate AGENTS.md against the current codebase
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Verify the top-level repository layout against the actual tree**
+
+Run:
+
+```bash
+find agiwo -maxdepth 2 -type d | sort | sed -n '1,120p'
+find console -maxdepth 3 -type d | sort | sed -n '1,120p'
+```
+
+Expected:
+
+```text
+Top-level SDK and Console directories align with the responsibility tables in AGENTS.md.
+```
+
+- [ ] **Step 2: Correct any stale responsibility wording discovered during tree review**
+
+Edit `AGENTS.md` conservatively:
+
+- remove directory claims that no longer map to real paths
+- tighten wording where the current code has clearly shifted
+- preserve the document’s package-level responsibility style
+
+Use the following rule while editing:
+
+```text
+If a directory still exists but the wording is slightly off, rewrite the responsibility sentence.
+If a path no longer exists, delete the stale claim.
+If a new top-level or second-level responsibility is now central and stable, add one concise row or bullet.
+```
+
+- [ ] **Step 3: Re-check the most important public boundary notes against code**
+
+Run:
+
+```bash
+rg -n "class Agent|class Scheduler|def as_tool|def route_root_input|allowed_skills|allowed_tools" agiwo console/server -S | sed -n '1,120p'
+```
+
+Expected:
+
+```text
+Current boundary-relevant identifiers are visible for spot-checking AGENTS.md statements.
+```
+
+- [ ] **Step 4: Keep AGENTS.md at the right abstraction level**
+
+Before saving, verify these constraints manually:
+
+```text
+- No new per-file dump was added.
+- The document still focuses on directory/package responsibilities and stable APIs.
+- Code-specific implementation details stay out unless they are stable boundaries.
+```
+
+- [ ] **Step 5: Commit the AGENTS.md calibration**
+
+Run:
+
+```bash
+git add AGENTS.md
+git commit -m "docs: align agents guide with current codebase"
+```
+
+## Task 3: Implement the repository overview generator
+
+**Files:**
+- Create: `scripts/generate_repo_overview.py`
+- Create: `website/src/generated/repo-overview.json`
+
+- [ ] **Step 1: Write a failing generation check by asserting the output file does not exist yet or is stale**
+
+Run:
+
+```bash
+test -f website/src/generated/repo-overview.json && python -m json.tool website/src/generated/repo-overview.json >/dev/null || false
+```
+
+Expected:
+
+```text
+The command fails before the generator exists or before valid output is generated.
+```
+
+- [ ] **Step 2: Add the generator script skeleton**
+
+Write `scripts/generate_repo_overview.py`:
+
+```python
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "website" / "src" / "generated" / "repo-overview.json"
+
+
+@dataclass
+class ResponsibilityItem:
+    path: str
+    label: str
+    responsibility: str
+
+
+@dataclass
+class RuntimeSurface:
+    import_path: str
+    role: str
+
+
+@dataclass
+class RepoOverview:
+    summary: str
+    sdk_layout: list[ResponsibilityItem]
+    console_layout: list[ResponsibilityItem]
+    supporting_layout: list[ResponsibilityItem]
+    runtime_surfaces: list[RuntimeSurface]
+    boundaries: list[str]
+    source_pointers: list[dict[str, str]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    raise NotImplementedError(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 3: Implement deterministic repository data assembly**
+
+Replace the script with this minimal implementation:
+
+```python
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "website" / "src" / "generated" / "repo-overview.json"
+
+
+@dataclass
+class ResponsibilityItem:
+    path: str
+    label: str
+    responsibility: str
+
+
+@dataclass
+class RuntimeSurface:
+    import_path: str
+    role: str
+
+
+@dataclass
+class RepoOverview:
+    summary: str
+    sdk_layout: list[ResponsibilityItem]
+    console_layout: list[ResponsibilityItem]
+    supporting_layout: list[ResponsibilityItem]
+    runtime_surfaces: list[RuntimeSurface]
+    boundaries: list[str]
+    source_pointers: list[dict[str, str]]
+
+
+SDK_LAYOUT = [
+    ResponsibilityItem("agiwo/agent", "Agent runtime", "Canonical agent runtime, execution loop, runtime state, models, hooks, nested-agent adapters, and persistence hooks."),
+    ResponsibilityItem("agiwo/llm", "Model layer", "Model abstraction, provider adapters, factory construction, and message/event normalization."),
+    ResponsibilityItem("agiwo/tool", "Tool layer", "Tool contracts, builtin tools, execution context, process registry, and tool-side storage."),
+    ResponsibilityItem("agiwo/scheduler", "Scheduler", "Agent-level orchestration, lifecycle control, runtime tools, and scheduler state persistence."),
+    ResponsibilityItem("agiwo/observability", "Observability", "Trace/span storage, query interfaces, and runtime trace adaptation."),
+    ResponsibilityItem("agiwo/memory", "Memory", "Workspace memory indexing, chunking, and search services."),
+]
+
+CONSOLE_LAYOUT = [
+    ResponsibilityItem("console/server", "Control plane", "FastAPI runtime integration and application services."),
+    ResponsibilityItem("console/server/routers", "API boundary", "HTTP and SSE routing with request/response assembly."),
+    ResponsibilityItem("console/server/services", "Application services", "Runtime management, tool catalog, registry, storage wiring, and metrics."),
+    ResponsibilityItem("console/server/models", "Shared models", "Console-facing runtime, configuration, and aggregated view models."),
+    ResponsibilityItem("console/server/channels", "Channel adapters", "Delivery, parsing, and integration for external channels such as Feishu."),
+    ResponsibilityItem("console/web", "Internal web UI", "Internal control-plane frontend for sessions, traces, scheduler, and settings."),
+]
+
+SUPPORTING_LAYOUT = [
+    ResponsibilityItem("tests", "SDK tests", "Subsystem-level tests for the SDK runtime."),
+    ResponsibilityItem("docs", "Repository docs", "Design notes, architecture documents, and repository-native documentation."),
+    ResponsibilityItem("scripts", "Repo scripts", "Lint entrypoints, guardrails, and local maintenance scripts."),
+    ResponsibilityItem("templates", "Runtime templates", "Template assets consumed by runtime features."),
+]
+
+RUNTIME_SURFACES = [
+    RuntimeSurface("agiwo.agent", "Public entry for the canonical agent runtime."),
+    RuntimeSurface("agiwo.scheduler", "Public entry for agent orchestration and persistent roots."),
+    RuntimeSurface("agiwo.tool", "Public entry for tool contracts and builtin tool integration."),
+    RuntimeSurface("agiwo.llm", "Public entry for model abstractions and provider construction."),
+]
+
+BOUNDARIES = [
+    "Scheduler depends on agent runtime instead of the reverse direction.",
+    "Console code should use public scheduler and agent facades instead of store internals.",
+    "Public agent types should enter through the proper facade rather than internal runtime modules.",
+    "The public docs site is static and separate from the internal Console web app.",
+]
+
+SOURCE_POINTERS = [
+    {"label": "Repository guide", "path": "AGENTS.md"},
+    {"label": "Public entry README", "path": "README.md"},
+    {"label": "Architecture overview", "path": "docs/architecture/overview.md"},
+    {"label": "Public docs site", "path": "website/"},
+]
+
+
+def build_payload() -> RepoOverview:
+    return RepoOverview(
+        summary=(
+            "Agiwo is organized around a canonical agent runtime, a separate scheduler "
+            "orchestration layer, a tool abstraction, a model layer, and an internal control plane."
+        ),
+        sdk_layout=SDK_LAYOUT,
+        console_layout=CONSOLE_LAYOUT,
+        supporting_layout=SUPPORTING_LAYOUT,
+        runtime_surfaces=RUNTIME_SURFACES,
+        boundaries=BOUNDARIES,
+        source_pointers=SOURCE_POINTERS,
+    )
+
+
+def render_payload() -> str:
+    return json.dumps(asdict(build_payload()), indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    expected = render_payload()
+
+    if args.check:
+      return 0 if OUTPUT_PATH.exists() and OUTPUT_PATH.read_text() == expected else 1
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(expected)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Generate the JSON artifact**
+
+Run:
+
+```bash
+python scripts/generate_repo_overview.py
+python -m json.tool website/src/generated/repo-overview.json >/dev/null
+```
+
+Expected:
+
+```text
+The script exits 0 and the generated JSON is valid.
+```
+
+- [ ] **Step 5: Verify deterministic check mode**
+
+Run:
+
+```bash
+python scripts/generate_repo_overview.py --check
+```
+
+Expected:
+
+```text
+Exit code 0 because the generated file matches the current repository state.
+```
+
+- [ ] **Step 6: Commit the generator and generated artifact**
+
+Run:
+
+```bash
+git add scripts/generate_repo_overview.py website/src/generated/repo-overview.json
+git commit -m "feat: add repo overview generator"
+```
+
+## Task 4: Render the generated overview in the public docs site
+
+**Files:**
+- Create: `website/src/components/repo-overview/repo-overview-page.astro`
+- Create: `website/src/components/repo-overview/layout-section.astro`
+- Create: `website/src/components/repo-overview/runtime-surface-list.astro`
+- Create: `website/src/components/repo-overview/boundary-list.astro`
+- Create: `website/src/content/docs/docs/repo-overview.mdx`
+- Modify: `website/src/content/docs/docs/index.mdx`
+- Modify: `website/src/styles/site.css`
+
+- [ ] **Step 1: Add the layout section component**
+
+Write `website/src/components/repo-overview/layout-section.astro`:
+
+```astro
+---
+interface Item {
+  path: string;
+  label: string;
+  responsibility: string;
+}
+
+interface Props {
+  title: string;
+  items: Item[];
+}
+
+const { title, items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>{title}</h2>
+  <table class="repo-overview-table">
+    <thead>
+      <tr>
+        <th>Path</th>
+        <th>Responsibility</th>
+      </tr>
+    </thead>
+    <tbody>
+      {items.map((item) => (
+        <tr>
+          <td>
+            <strong>{item.label}</strong>
+            <div><code>{item.path}</code></div>
+          </td>
+          <td>{item.responsibility}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</section>
+```
+
+- [ ] **Step 2: Add the runtime surfaces and boundary list components**
+
+Write `website/src/components/repo-overview/runtime-surface-list.astro`:
+
+```astro
+---
+interface Surface {
+  import_path: string;
+  role: string;
+}
+
+interface Props {
+  items: Surface[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>Core Runtime Surfaces</h2>
+  <ul class="repo-overview-list">
+    {items.map((item) => (
+      <li>
+        <code>{item.import_path}</code> — {item.role}
+      </li>
+    ))}
+  </ul>
+</section>
+```
+
+Write `website/src/components/repo-overview/boundary-list.astro`:
+
+```astro
+---
+interface Props {
+  items: string[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>Architectural Boundaries</h2>
+  <ul class="repo-overview-list">
+    {items.map((item) => <li>{item}</li>)}
+  </ul>
+</section>
+```
+
+- [ ] **Step 3: Add the page component that consumes generated JSON**
+
+Write `website/src/components/repo-overview/repo-overview-page.astro`:
+
+```astro
+---
+import overview from "../../generated/repo-overview.json";
+import BoundaryList from "./boundary-list.astro";
+import LayoutSection from "./layout-section.astro";
+import RuntimeSurfaceList from "./runtime-surface-list.astro";
+---
+
+<section class="repo-overview-hero">
+  <p class="eyebrow">Repository Overview</p>
+  <h1>Understand Agiwo from the repository structure.</h1>
+  <p>{overview.summary}</p>
+</section>
+
+<LayoutSection title="SDK Layout" items={overview.sdk_layout} />
+<LayoutSection title="Console Layout" items={overview.console_layout} />
+<LayoutSection title="Supporting Directories" items={overview.supporting_layout} />
+<RuntimeSurfaceList items={overview.runtime_surfaces} />
+<BoundaryList items={overview.boundaries} />
+
+<section class="repo-overview-section">
+  <h2>Source Pointers</h2>
+  <ul class="repo-overview-list">
+    {overview.source_pointers.map((item) => (
+      <li>
+        <strong>{item.label}</strong> — <code>{item.path}</code>
+      </li>
+    ))}
+  </ul>
+</section>
+```
+
+- [ ] **Step 4: Add the docs page and expose it from the docs index**
+
+Write `website/src/content/docs/docs/repo-overview.mdx`:
+
+```mdx
+---
+title: Repository Overview
+description: Understand the Agiwo repository layout, public runtime surfaces, and architecture boundaries.
+---
+
+import RepoOverviewPage from "../../../components/repo-overview/repo-overview-page.astro";
+
+<RepoOverviewPage />
+```
+
+Update `website/src/content/docs/docs/index.mdx` actions to include the new page:
+
+```md
+    - text: Repository Overview
+      link: /docs/repo-overview/
+      variant: minimal
+```
+
+- [ ] **Step 5: Add the minimal styling for overview tables and lists**
+
+Append to `website/src/styles/site.css`:
+
+```css
+.repo-overview-hero,
+.repo-overview-section {
+  margin-top: 2rem;
+}
+
+.repo-overview-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.repo-overview-table th,
+.repo-overview-table td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+  vertical-align: top;
+}
+
+.repo-overview-list {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.2rem;
+}
+```
+
+- [ ] **Step 6: Build and inspect the new page**
+
+Run:
+
+```bash
+npm --prefix website run check
+npm --prefix website run build
+find website/dist/docs/repo-overview -maxdepth 2 -type f | sort
+```
+
+Expected:
+
+```text
+website/dist/docs/repo-overview/index.html
+```
+
+- [ ] **Step 7: Commit the public page rendering**
+
+Run:
+
+```bash
+git add website/src/components/repo-overview website/src/content/docs/docs/repo-overview.mdx website/src/content/docs/docs/index.mdx website/src/styles/site.css
+git commit -m "feat: add public repo overview page"
+```
+
+## Task 5: Make the generator part of the documented author workflow
+
+**Files:**
+- Modify: `docs/public-site-deploy.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Document the manual generation command in the public site workflow note**
+
+Append to `docs/public-site-deploy.md`:
+
+```md
+## Repository Overview Refresh
+
+When repository structure or architecture boundaries change:
+
+1. Update `README.md` and `AGENTS.md` if needed
+2. Run `python scripts/generate_repo_overview.py`
+3. Review `website/src/generated/repo-overview.json`
+4. Rebuild the public site before publishing
+```
+
+- [ ] **Step 2: Add a short maintenance note in AGENTS.md**
+
+Append near the `Maintaining AGENTS.md` section:
+
+```md
+- Public repository overview generation consumes repository structure first and may also use `AGENTS.md` as a supporting source; keep directory responsibilities and stable boundary notes current.
+```
+
+- [ ] **Step 3: Verify the generator workflow is discoverable**
+
+Run:
+
+```bash
+rg -n "generate_repo_overview|Repository Overview Refresh|supporting source" docs/public-site-deploy.md AGENTS.md
+```
+
+Expected:
+
+```text
+The generator command and maintenance note are present in both files.
+```
+
+- [ ] **Step 4: Commit the workflow documentation**
+
+Run:
+
+```bash
+git add docs/public-site-deploy.md AGENTS.md
+git commit -m "docs: document repo overview refresh workflow"
+```
+
+## Task 6: Final validation and branch update
+
+**Files:**
+- Validate: `README.md`
+- Validate: `AGENTS.md`
+- Validate: `scripts/generate_repo_overview.py`
+- Validate: `website/src/generated/repo-overview.json`
+- Validate: `website/dist/docs/repo-overview/index.html`
+
+- [ ] **Step 1: Run the generator and site validation end-to-end**
+
+Run:
+
+```bash
+python scripts/generate_repo_overview.py
+python scripts/generate_repo_overview.py --check
+npm --prefix website run check
+npm --prefix website run build
+```
+
+Expected:
+
+```text
+Generator exits 0 in both normal and check modes.
+Astro check and build both succeed.
+```
+
+- [ ] **Step 2: Inspect the generated JSON and rendered page output**
+
+Run:
+
+```bash
+sed -n '1,220p' website/src/generated/repo-overview.json
+sed -n '1,220p' website/dist/docs/repo-overview/index.html
+```
+
+Expected:
+
+```text
+The JSON includes summary, layout groups, runtime surfaces, boundaries, and source pointers.
+The rendered page includes repository overview sections with generated content.
+```
+
+- [ ] **Step 3: Review repository state before push**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -8
+```
+
+Expected:
+
+```text
+Working tree clean except for unrelated untracked files such as seo_review.md.
+Recent commits cover README calibration, AGENTS calibration, generator, public page, and workflow docs.
+```
+
+- [ ] **Step 4: Push the branch update**
+
+Run:
+
+```bash
+git push origin docs/public-docs-seo-design
+```
+
+Expected:
+
+```text
+Remote branch is updated with the repo overview generation work.
+```
+
+## Self-Review
+
+### Spec coverage
+
+- README and AGENTS calibration: covered by Tasks 1 and 2.
+- Manual generator and structured JSON output: covered by Task 3.
+- Public `/docs/repo-overview/` page: covered by Task 4.
+- Manual refresh workflow: covered by Task 5.
+- End-to-end validation: covered by Task 6.
+
+### Placeholder scan
+
+- No placeholder language remains in tasks or steps.
+- All new files, commands, and validation points are explicit.
+
+### Type and naming consistency
+
+- Generator output path is consistently `website/src/generated/repo-overview.json`.
+- Public route is consistently `/docs/repo-overview/`.
+- The generator entrypoint is consistently `scripts/generate_repo_overview.py`.

--- a/docs/superpowers/specs/2026-04-14-agiwo-repo-overview-generation-design.md
+++ b/docs/superpowers/specs/2026-04-14-agiwo-repo-overview-generation-design.md
@@ -1,0 +1,240 @@
+# Agiwo Repository Overview Generation Design
+
+## Summary
+
+The current public site for `docs.agiwo.o-ai.tech` provides an SEO homepage and a small curated docs set, but its architecture and repository explanations are partly hand-maintained and can drift from the codebase.
+
+This design adds a code-tree-driven repository overview page to the public site. The overview will be generated manually from stable repository signals rather than written entirely by hand. The primary fact source will be the repository structure itself, with `README.md` and `AGENTS.md` used as supporting inputs. Before generation, both documents must be aligned with the current codebase so they can safely serve as narrative supplements instead of stale truth.
+
+## Goals
+
+- Add a public repository overview page that feels closer to a code-aware explainer than a static marketing page.
+- Generate the overview from stable repository signals instead of maintaining it manually.
+- Keep the first version architecture-level, focused on directory responsibilities and public runtime surfaces.
+- Align `README.md` and `AGENTS.md` with the current codebase so they remain useful supporting sources.
+- Keep the generation workflow explicit and reviewable by committing generated output.
+
+## Non-Goals
+
+- Full API reference generation from source code.
+- LLM-driven summarization during build time.
+- Deep class-by-class or function-by-function code explanation in the first phase.
+- Automatic regeneration on every push.
+- Replacing `README.md` or `AGENTS.md` as human-readable project documentation.
+
+## Constraints And Assumptions
+
+- Public docs are served through the existing `website/` Astro + Starlight project.
+- The repository overview should be static content checked into git, not generated on-the-fly at request time.
+- The first version should prefer stable and explainable rules over ambitious coverage.
+- `AGENTS.md` is useful because it already captures directory responsibilities and architecture boundaries, but it is not authoritative if it diverges from code.
+- `README.md` should continue to optimize for external discoverability and first-use clarity, not become an exhaustive architecture reference.
+
+## Recommended Approach
+
+Implement a manual generator that scans the repository tree and selected supporting documents, then writes a structured JSON file consumed by the public docs site.
+
+Why this approach:
+
+- It keeps generation deterministic and reviewable.
+- It avoids putting repo-scanning complexity inside the Astro build.
+- It allows manual review of generated output before publishing.
+- It supports progressive refinement of rules without locking the site into hand-maintained pages.
+
+Rejected alternatives:
+
+- Manual-only public overview page: too easy to drift.
+- LLM-generated overview: harder to keep stable and defensible.
+- Build-time scanning directly inside Astro: mixes content generation with presentation and makes local debugging harder.
+
+## Fact Sources
+
+### Primary Sources
+
+- Repository directory structure
+- Package/module entry points
+- Existing public documentation headings
+
+### Supporting Sources
+
+- `README.md`
+- `AGENTS.md`
+
+### Source Priority
+
+1. Code tree and stable package structure
+2. `AGENTS.md` responsibility and boundary statements
+3. `README.md` high-level external framing
+4. Existing docs headings and links as navigation/context helpers
+
+## Scope Of The Generated Overview
+
+The first version should cover architecture-level repository understanding only.
+
+Included:
+
+- High-level repository summary
+- SDK top-level directories and responsibilities
+- Console top-level directories and responsibilities
+- Supporting directories and their roles
+- Key public entry surfaces such as `agiwo.agent`, `agiwo.scheduler`, `agiwo.tool`, and `agiwo.llm`
+- Architecture boundary notes sourced from stable rules
+- Pointers to relevant source directories and docs pages
+
+Excluded in phase one:
+
+- Symbol-level inventories
+- Class inheritance maps
+- Per-file detailed summaries across the whole repo
+- Automated code examples synthesized from source
+
+## Public Site Output
+
+Add a new public docs page:
+
+- `/docs/repo-overview/`
+
+This page should contain five sections:
+
+1. What Agiwo Contains
+2. Repository Layout
+3. Core Runtime Surfaces
+4. Architectural Boundaries
+5. Source Pointers
+
+The page should render from generated structured data rather than inline hand-written explanations.
+
+## Generator Output Format
+
+Generate a structured JSON artifact, for example:
+
+- `website/src/generated/repo-overview.json`
+
+The JSON should contain explicit fields for:
+
+- repository summary
+- section groups
+- path responsibilities
+- public runtime surfaces
+- boundary notes
+- related docs/source links
+
+The format should be simple enough for both the generator and the rendering component to remain understandable.
+
+## Repository Changes
+
+### Document Calibration
+
+Before generation logic is trusted, align these files with the codebase:
+
+- `README.md`
+- `AGENTS.md`
+
+Calibration should focus on:
+
+- correcting stale statements
+- removing obsolete claims
+- tightening wording to current boundaries
+- preserving each document’s role instead of turning either into a file dump
+
+### Generator Layer
+
+Add a manual generation script, preferably:
+
+- `scripts/generate_repo_overview.py`
+
+Responsibilities:
+
+- scan selected repository directories
+- detect top-level package/module surfaces
+- read supporting docs
+- merge facts according to source priority
+- emit structured JSON for the public site
+
+### Public Site Rendering
+
+Add:
+
+- a generated data directory in `website/src/generated/`
+- one or more rendering components for overview tables/sections
+- a public docs page under the Starlight docs tree
+
+The rendering layer should not rescan the repository. It should only consume the generated JSON.
+
+## Generation Rules
+
+### Directory Responsibilities
+
+Responsibilities should be resolved using this order:
+
+1. Explicit mapping rules from the generator for known top-level directories
+2. `AGENTS.md` responsibility text when available and still consistent
+3. Simple fallback phrasing derived from path names
+
+### Public Runtime Surfaces
+
+The generator should identify and present only public-facing or high-signal package entry surfaces.
+
+Examples:
+
+- `agiwo.agent`
+- `agiwo.scheduler`
+- `agiwo.tool`
+- `agiwo.llm`
+- selected `console/server` top-level service boundaries
+
+Do not attempt full symbol extraction in phase one.
+
+### Architecture Boundary Notes
+
+Boundary notes should prefer stable rules, such as:
+
+- scheduler depends on agent
+- console should use facades instead of store internals
+- public types should enter through the correct facade
+
+These are better suited for public explanation than volatile implementation details.
+
+## Manual Workflow
+
+The intended workflow is:
+
+1. Update code
+2. If needed, align `README.md` and `AGENTS.md`
+3. Run the generator script manually
+4. Review the generated JSON diff
+5. Build the public site and review the rendered page
+6. Commit both source and generated output
+
+This keeps the process explicit while still reducing hand-maintained page drift.
+
+## Testing And Validation
+
+Implementation should validate:
+
+- generator runs successfully from repo root
+- generated JSON is deterministic for the same repository state
+- public site builds successfully using generated output
+- the overview page renders expected sections and path tables
+- generated content links only to paths/docs that actually exist
+
+Manual validation should check:
+
+- obvious stale claims are gone from `README.md` and `AGENTS.md`
+- overview page matches current repository structure
+- narrative remains architecture-level and readable to external visitors
+
+## Risks
+
+- If the generator depends too heavily on heuristics, the overview can become vague or misleading.
+- If `README.md` and `AGENTS.md` are not calibrated first, supporting text may reintroduce stale claims.
+- If the scope expands into symbol-level extraction too early, complexity rises quickly without proportional public value.
+- If generated output becomes too verbose, the page will feel like a file dump instead of a useful explainer.
+
+## Success Criteria
+
+- `README.md` and `AGENTS.md` are aligned with the current codebase.
+- A manual generator can produce a structured repository overview artifact.
+- The public docs site exposes `/docs/repo-overview/`.
+- The overview is primarily derived from repository structure rather than hand-maintained prose.
+- The resulting page gives external readers a clearer and more current architecture view than the existing hand-written docs alone.

--- a/scripts/generate_repo_overview.py
+++ b/scripts/generate_repo_overview.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "website" / "src" / "generated" / "repo-overview.json"
+AGENTS_PATH = ROOT / "AGENTS.md"
+
+
+FALLBACK_RESPONSIBILITIES: dict[str, str] = {
+    "agiwo/agent": "Canonical agent runtime, execution loop, runtime state, models, nested-agent adapters, and persistence hooks.",
+    "agiwo/llm": "Model abstraction, provider adapters, configuration policy, and factory construction.",
+    "agiwo/tool": "Tool contracts, builtin tools, execution context, process registry, and tool-side persistence.",
+    "agiwo/scheduler": "Agent-level orchestration, runtime tools, lifecycle management, and scheduler state persistence.",
+    "agiwo/observability": "Trace and span storage, querying, and runtime trace adaptation.",
+    "agiwo/embedding": "Embedding abstraction and provider-backed implementations.",
+    "agiwo/skill": "Skill discovery, allowlisting, loading, and skill-to-tool bridging.",
+    "agiwo/workspace": "Workspace path semantics, bootstrap, and runtime workspace helpers.",
+    "agiwo/memory": "Shared workspace memory indexing, chunking, and search services.",
+    "agiwo/config": "Global SDK configuration and shared provider settings.",
+    "agiwo/utils": "Cross-module runtime utilities and shared storage support.",
+    "console/server": "FastAPI control plane and runtime integration layer.",
+    "console/server/routers": "HTTP and SSE API boundary for requests and responses.",
+    "console/server/services": "Application services for runtime management, registry, tool catalog, session storage, and metrics.",
+    "console/server/models": "Console-facing shared runtime, configuration, and view models.",
+    "console/server/channels": "Channel adapters for delivery, parsing, and integration workflows.",
+    "console/web": "Internal control-plane frontend for sessions, traces, scheduler, and settings.",
+    "console/tests": "Console backend test suite.",
+    "tests": "SDK test suite organized by subsystem.",
+    "scripts": "Lint entrypoints, repo guardrails, and maintenance helpers.",
+    "lint": "Import-linter and repository guard configuration.",
+    "docs": "Repository-native design notes, concepts, and architecture documentation.",
+    "templates": "Template content consumed by runtime features.",
+    "trash": "Soft-delete landing area for removed files.",
+}
+
+LAYOUT_GROUPS: list[tuple[str, str, list[tuple[str, str]]]] = [
+    (
+        "sdk_layout",
+        "SDK",
+        [
+            ("agiwo/agent", "Agent runtime"),
+            ("agiwo/llm", "Model layer"),
+            ("agiwo/tool", "Tool layer"),
+            ("agiwo/scheduler", "Scheduler"),
+            ("agiwo/observability", "Observability"),
+            ("agiwo/embedding", "Embedding"),
+            ("agiwo/skill", "Skills"),
+            ("agiwo/workspace", "Workspace"),
+            ("agiwo/memory", "Memory"),
+            ("agiwo/config", "Configuration"),
+            ("agiwo/utils", "Shared utilities"),
+        ],
+    ),
+    (
+        "console_layout",
+        "Console",
+        [
+            ("console/server", "Control plane"),
+            ("console/server/routers", "API boundary"),
+            ("console/server/services", "Application services"),
+            ("console/server/models", "Shared models"),
+            ("console/server/channels", "Channel adapters"),
+            ("console/web", "Internal web UI"),
+            ("console/tests", "Console tests"),
+        ],
+    ),
+    (
+        "supporting_layout",
+        "Supporting directories",
+        [
+            ("tests", "SDK tests"),
+            ("scripts", "Repo scripts"),
+            ("lint", "Guardrails"),
+            ("docs", "Repository docs"),
+            ("templates", "Templates"),
+            ("trash", "Trash"),
+        ],
+    ),
+]
+
+RUNTIME_SURFACES: list[dict[str, object]] = [
+    {
+        "import_path": "agiwo.agent",
+        "role": "Public entry for the canonical agent runtime, agent configuration, execution handles, and related types.",
+        "source_paths": ["agiwo/agent", "agiwo/agent/__init__.py", "agiwo/agent/types.py"],
+    },
+    {
+        "import_path": "agiwo.scheduler",
+        "role": "Public entry for orchestration, persistent roots, routing, waiting, and scheduler-backed agent coordination.",
+        "source_paths": ["agiwo/scheduler", "agiwo/scheduler/engine.py"],
+    },
+    {
+        "import_path": "agiwo.tool",
+        "role": "Public entry for tool contracts, tool results, execution context, and builtin tool integration.",
+        "source_paths": ["agiwo/tool", "agiwo/tool/manager.py"],
+    },
+    {
+        "import_path": "agiwo.llm",
+        "role": "Public entry for model abstractions, provider implementations, and model construction helpers.",
+        "source_paths": ["agiwo/llm", "agiwo/llm/factory.py"],
+    },
+]
+
+BOUNDARIES: list[str] = [
+    "Scheduler sits on top of the agent runtime instead of the reverse direction.",
+    "Console code should go through scheduler and agent facades rather than reading scheduler store internals directly.",
+    "Public agent-facing types should enter through the correct facade instead of internal runtime modules when called from outside the agent package.",
+    "The public docs site is static and separate from the internal Console web app.",
+]
+
+SOURCE_POINTER_FILES: list[tuple[str, str]] = [
+    ("Repository guide", "AGENTS.md"),
+    ("Public entry README", "README.md"),
+    ("Architecture overview", "docs/architecture/overview.md"),
+    ("Getting started guide", "docs/getting-started.md"),
+    ("Multi-agent guide", "docs/guides/multi-agent.md"),
+]
+
+
+def parse_agents_responsibilities() -> dict[str, str]:
+    text = AGENTS_PATH.read_text()
+    responsibilities: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("| `"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        raw_path = cells[0]
+        responsibility = cells[1]
+        if not (raw_path.startswith("`") and raw_path.endswith("`")):
+            continue
+        normalized_path = raw_path.strip("`").rstrip("/")
+        responsibilities[normalized_path] = responsibility
+    return responsibilities
+
+
+def first_heading(path: Path) -> str:
+    if path.name == "README.md":
+        return "Agiwo"
+    if path.name == "AGENTS.md":
+        return "AGENTS.md"
+    for line in path.read_text().splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return path.stem.replace("-", " ").title()
+
+
+def build_layout_group(
+    entries: list[tuple[str, str]],
+    responsibilities: dict[str, str],
+) -> list[dict[str, str]]:
+    group: list[dict[str, str]] = []
+    for path, label in entries:
+        abs_path = ROOT / path
+        if not abs_path.exists():
+            continue
+        responsibility = responsibilities.get(path) or FALLBACK_RESPONSIBILITIES[path]
+        group.append(
+            {
+                "path": path,
+                "label": label,
+                "responsibility": responsibility,
+            }
+        )
+    return group
+
+
+def build_source_pointers() -> list[dict[str, str]]:
+    pointers: list[dict[str, str]] = []
+    for label, relative_path in SOURCE_POINTER_FILES:
+        path = ROOT / relative_path
+        if not path.exists():
+            continue
+        pointer = {
+            "label": label,
+            "path": relative_path,
+        }
+        if path.suffix in {".md", ".mdx"}:
+            pointer["title"] = first_heading(path)
+        pointers.append(pointer)
+    return pointers
+
+
+def build_payload() -> dict[str, object]:
+    responsibilities = parse_agents_responsibilities()
+    layout_payload: dict[str, list[dict[str, str]]] = {}
+    for key, _title, entries in LAYOUT_GROUPS:
+        layout_payload[key] = build_layout_group(entries, responsibilities)
+
+    return {
+        "summary": (
+            "Agiwo is organized around a canonical agent runtime, a separate scheduler "
+            "orchestration layer, a tool abstraction, a model layer, and an internal control plane."
+        ),
+        "layout_sections": [
+            {"key": key, "title": title} for key, title, _entries in LAYOUT_GROUPS
+        ],
+        **layout_payload,
+        "runtime_surfaces": RUNTIME_SURFACES,
+        "boundaries": BOUNDARIES,
+        "source_pointers": build_source_pointers(),
+    }
+
+
+def render_payload() -> str:
+    return json.dumps(build_payload(), indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a code-tree-driven public repository overview artifact."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the generated file differs from the expected output.",
+    )
+    args = parser.parse_args()
+
+    expected = render_payload()
+    if args.check:
+        if OUTPUT_PATH.exists() and OUTPUT_PATH.read_text() == expected:
+            return 0
+        return 1
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(expected)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_repo_overview.py
+++ b/scripts/generate_repo_overview.py
@@ -86,7 +86,11 @@ RUNTIME_SURFACES: list[dict[str, object]] = [
     {
         "import_path": "agiwo.agent",
         "role": "Public entry for the canonical agent runtime, agent configuration, execution handles, and related types.",
-        "source_paths": ["agiwo/agent", "agiwo/agent/__init__.py", "agiwo/agent/types.py"],
+        "source_paths": [
+            "agiwo/agent",
+            "agiwo/agent/__init__.py",
+            "agiwo/agent/types.py",
+        ],
     },
     {
         "import_path": "agiwo.scheduler",

--- a/scripts/generate_repo_overview.py
+++ b/scripts/generate_repo_overview.py
@@ -160,7 +160,13 @@ def build_layout_group(
         abs_path = ROOT / path
         if not abs_path.exists():
             continue
-        responsibility = responsibilities.get(path) or FALLBACK_RESPONSIBILITIES[path]
+        agents_responsibility = responsibilities.get(path)
+        fallback_responsibility = FALLBACK_RESPONSIBILITIES[path]
+        responsibility = (
+            agents_responsibility
+            if agents_responsibility and agents_responsibility.isascii()
+            else fallback_responsibility
+        )
         group.append(
             {
                 "path": path,

--- a/website/src/components/repo-overview/boundary-list.astro
+++ b/website/src/components/repo-overview/boundary-list.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+  items: string[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>Architectural Boundaries</h2>
+  <ul class="repo-overview-list">
+    {items.map((item) => <li>{item}</li>)}
+  </ul>
+</section>

--- a/website/src/components/repo-overview/layout-section.astro
+++ b/website/src/components/repo-overview/layout-section.astro
@@ -1,0 +1,37 @@
+---
+interface Item {
+  path: string;
+  label: string;
+  responsibility: string;
+}
+
+interface Props {
+  title: string;
+  items: Item[];
+}
+
+const { title, items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>{title}</h2>
+  <table class="repo-overview-table">
+    <thead>
+      <tr>
+        <th>Path</th>
+        <th>Responsibility</th>
+      </tr>
+    </thead>
+    <tbody>
+      {items.map((item) => (
+        <tr>
+          <td>
+            <strong>{item.label}</strong>
+            <div><code>{item.path}</code></div>
+          </td>
+          <td>{item.responsibility}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</section>

--- a/website/src/components/repo-overview/repo-overview-page.astro
+++ b/website/src/components/repo-overview/repo-overview-page.astro
@@ -1,0 +1,51 @@
+---
+import overview from "../../generated/repo-overview.json";
+import BoundaryList from "./boundary-list.astro";
+import LayoutSection from "./layout-section.astro";
+import RuntimeSurfaceList from "./runtime-surface-list.astro";
+
+const layoutItems = {
+  sdk_layout: overview.sdk_layout,
+  console_layout: overview.console_layout,
+  supporting_layout: overview.supporting_layout,
+};
+---
+
+<section class="repo-overview-hero">
+  <p class="eyebrow">Repository Overview</p>
+  <h1>Understand Agiwo from the repository structure.</h1>
+  <p>{overview.summary}</p>
+</section>
+
+<section class="repo-overview-section">
+  <h2>What Agiwo Contains</h2>
+  <p>
+    The repository is split across the SDK runtime, the internal Console control plane,
+    and a small set of supporting directories for tests, scripts, and design docs.
+    This page is generated from the code tree and selected supporting documents so it
+    stays closer to the current repository state than a fully hand-written overview.
+  </p>
+</section>
+
+{overview.layout_sections.map((section) => (
+  <LayoutSection
+    title={section.title}
+    items={layoutItems[section.key as keyof typeof layoutItems]}
+  />
+))}
+
+<RuntimeSurfaceList items={overview.runtime_surfaces} />
+<BoundaryList items={overview.boundaries} />
+
+<section class="repo-overview-section">
+  <h2>Source Pointers</h2>
+  <ul class="repo-overview-list">
+    {overview.source_pointers.map((item) => (
+      <li>
+        <strong>{item.label}</strong>
+        {item.title ? <> — {item.title}</> : null}
+        <div class="repo-overview-subtle"><code>{item.path}</code></div>
+      </li>
+    ))}
+  </ul>
+</section>

--- a/website/src/components/repo-overview/runtime-surface-list.astro
+++ b/website/src/components/repo-overview/runtime-surface-list.astro
@@ -1,0 +1,29 @@
+---
+interface Surface {
+  import_path: string;
+  role: string;
+  source_paths: string[];
+}
+
+interface Props {
+  items: Surface[];
+}
+
+const { items } = Astro.props;
+---
+
+<section class="repo-overview-section">
+  <h2>Core Runtime Surfaces</h2>
+  <ul class="repo-overview-list">
+    {items.map((item) => (
+      <li>
+        <div>
+          <strong><code>{item.import_path}</code></strong> — {item.role}
+        </div>
+        <div class="repo-overview-subtle">
+          Source: {item.source_paths.map((path) => <code>{path}</code>)}
+        </div>
+      </li>
+    ))}
+  </ul>
+</section>

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -13,6 +13,9 @@ hero:
     - text: Getting Started
       link: /docs/getting-started/
       icon: right-arrow
+    - text: Repository Overview
+      link: /docs/repo-overview/
+      variant: minimal
     - text: Compare Agiwo
       link: /docs/compare/agiwo-vs-langgraph-openai-agents-autogen/
       variant: minimal

--- a/website/src/content/docs/docs/repo-overview.mdx
+++ b/website/src/content/docs/docs/repo-overview.mdx
@@ -1,0 +1,8 @@
+---
+title: Repository Overview
+description: Understand the Agiwo repository layout, public runtime surfaces, and architecture boundaries.
+---
+
+import RepoOverviewPage from "../../../components/repo-overview/repo-overview-page.astro";
+
+<RepoOverviewPage />

--- a/website/src/generated/repo-overview.json
+++ b/website/src/generated/repo-overview.json
@@ -1,0 +1,206 @@
+{
+  "boundaries": [
+    "Scheduler sits on top of the agent runtime instead of the reverse direction.",
+    "Console code should go through scheduler and agent facades rather than reading scheduler store internals directly.",
+    "Public agent-facing types should enter through the correct facade instead of internal runtime modules when called from outside the agent package.",
+    "The public docs site is static and separate from the internal Console web app."
+  ],
+  "console_layout": [
+    {
+      "label": "Control plane",
+      "path": "console/server",
+      "responsibility": "FastAPI \u63a7\u5236\u9762\u4e0e runtime \u96c6\u6210\u3002"
+    },
+    {
+      "label": "API boundary",
+      "path": "console/server/routers",
+      "responsibility": "API/SSE \u8fb9\u754c\uff0c\u53ea\u505a HTTP \u8def\u7531\u4e0e\u8bf7\u6c42/\u54cd\u5e94\u88c5\u914d\u3002"
+    },
+    {
+      "label": "Application services",
+      "path": "console/server/services",
+      "responsibility": "\u5e94\u7528\u670d\u52a1\u5c42\u3002`runtime/`\uff08agent factory\u3001runtime cache\u3001session runtime / session service\u3001scheduler tree view\uff09\u3001`tool_catalog/`\uff08tool reference / catalog / runtime builder\uff09\u3001`agent_registry/`\uff08\u914d\u7f6e CRUD + store \u5b50\u5305\uff09\u3001`session_store/`\uff08Console \u4f1a\u8bdd\u5b58\u50a8\u5de5\u5382\u4e0e\u5b9e\u73b0\uff09\u3001`runtime_config.py`\uff08\u8fd0\u884c\u65f6\u5168\u5c40\u914d\u7f6e\u67e5\u770b/\u8986\u76d6\uff09\u3001`storage_wiring.py`\uff08\u5b58\u50a8 config builders\uff09\u3001`metrics.py`\u3002"
+    },
+    {
+      "label": "Shared models",
+      "path": "console/server/models",
+      "responsibility": "Console \u6570\u636e\u6a21\u578b\u76ee\u5f55\u3002`view.py` \u53ea\u653e API/SSE \u89c6\u56fe\u6a21\u578b\uff1b`session.py`\u3001`agent_config.py`\u3001`runtime_config.py`\u3001`metrics.py` \u653e\u5171\u4eab\u8fd0\u884c\u65f6/\u914d\u7f6e/\u805a\u5408\u6a21\u578b\u3002\u4e0d\u8981\u518d\u65b0\u589e `schemas.py` \u6216\u5e73\u7ea7 `domain/`\u3002"
+    },
+    {
+      "label": "Channel adapters",
+      "path": "console/server/channels",
+      "responsibility": "\u6e20\u9053\u9002\u914d\u5c42\uff0c\u8d1f\u8d23\u6279\u5904\u7406\u3001\u6d88\u606f\u89e3\u6790\u3001delivery\uff0c\u4ee5\u53ca Feishu \u7b49\u6e20\u9053\u96c6\u6210\u3002"
+    },
+    {
+      "label": "Internal web UI",
+      "path": "console/web",
+      "responsibility": "Console \u524d\u7aef\u3002"
+    },
+    {
+      "label": "Console tests",
+      "path": "console/tests",
+      "responsibility": "Console \u540e\u7aef\u6d4b\u8bd5\u3002"
+    }
+  ],
+  "layout_sections": [
+    {
+      "key": "sdk_layout",
+      "title": "SDK"
+    },
+    {
+      "key": "console_layout",
+      "title": "Console"
+    },
+    {
+      "key": "supporting_layout",
+      "title": "Supporting directories"
+    }
+  ],
+  "runtime_surfaces": [
+    {
+      "import_path": "agiwo.agent",
+      "role": "Public entry for the canonical agent runtime, agent configuration, execution handles, and related types.",
+      "source_paths": [
+        "agiwo/agent",
+        "agiwo/agent/__init__.py",
+        "agiwo/agent/types.py"
+      ]
+    },
+    {
+      "import_path": "agiwo.scheduler",
+      "role": "Public entry for orchestration, persistent roots, routing, waiting, and scheduler-backed agent coordination.",
+      "source_paths": [
+        "agiwo/scheduler",
+        "agiwo/scheduler/engine.py"
+      ]
+    },
+    {
+      "import_path": "agiwo.tool",
+      "role": "Public entry for tool contracts, tool results, execution context, and builtin tool integration.",
+      "source_paths": [
+        "agiwo/tool",
+        "agiwo/tool/manager.py"
+      ]
+    },
+    {
+      "import_path": "agiwo.llm",
+      "role": "Public entry for model abstractions, provider implementations, and model construction helpers.",
+      "source_paths": [
+        "agiwo/llm",
+        "agiwo/llm/factory.py"
+      ]
+    }
+  ],
+  "sdk_layout": [
+    {
+      "label": "Agent runtime",
+      "path": "agiwo/agent",
+      "responsibility": "Canonical agent runtime\u3002public API \u53ea\u4ece `agiwo.agent` \u66b4\u9732\uff1b\u9876\u5c42\u53ea\u4fdd\u7559\u7a33\u5b9a\u5165\u53e3\u4e0e\u6838\u5fc3 orchestrator\uff08\u5982 `agent.py`\u3001`definition.py`\u3001`run_loop.py`\u3001`llm_caller.py`\u3001`tool_executor.py`\u3001`prompt.py`\u3001`trace_writer.py`\uff09\u3002\u7eaf\u6570\u636e\u6a21\u578b\u6536\u53e3\u5728 `models/`\uff0chook contract \u6536\u53e3\u5728 `agiwo.agent.hooks`\uff0cnested-agent adapter \u6536\u53e3\u5728 `nested/`\uff0crun/session runtime context \u4e0e state helper \u6536\u53e3\u5728 `agiwo.agent.runtime`\uff0ctermination logic \u6536\u53e3\u5728 `termination/`\uff0c\u4e0a\u4e0b\u6587\u56de\u987e\u4f18\u5316\u6536\u53e3\u5728 `retrospect/`\uff0c`storage/` \u8d1f\u8d23\u6301\u4e45\u5316\u3002"
+    },
+    {
+      "label": "Model layer",
+      "path": "agiwo/llm",
+      "responsibility": "Model \u62bd\u8c61\u3001Provider \u9002\u914d\u5668\u3001\u914d\u7f6e\u7b56\u7565\u3001\u6d88\u606f/\u4e8b\u4ef6\u5f52\u4e00\u5316\uff0c\u4ee5\u53ca\u7edf\u4e00\u7684 model factory\u3002"
+    },
+    {
+      "label": "Tool layer",
+      "path": "agiwo/tool",
+      "responsibility": "Tool \u62bd\u8c61\u3001\u6700\u5c0f\u6267\u884c\u4e0a\u4e0b\u6587\u3001builtin tools\u3001\u540e\u53f0\u8fdb\u7a0b registry\uff08`process/`\uff09\uff0c\u4ee5\u53ca\u5de5\u5177\u4fa7\u5b58\u50a8\uff08\u5982 citation\uff09\u3002"
+    },
+    {
+      "label": "Scheduler",
+      "path": "agiwo/scheduler",
+      "responsibility": "Agent \u4e4b\u4e0a\u7684\u7f16\u6392\u5c42\u3002`scheduler.py` \u662f facade \u4e0e loop lifecycle\uff0c`engine.py` \u662f\u552f\u4e00\u7f16\u6392 owner\uff0c`runner.py` \u8d1f\u8d23\u5355\u6b21 dispatch action \u6267\u884c\uff0c`commands.py` \u627f\u8f7d\u8c03\u5ea6\u52a8\u4f5c\u4e0e tool DTO\uff0c`runtime_state.py` \u627f\u8f7d\u8fdb\u7a0b\u5185 live state \u4e0e tick helpers\uff0c`tool_control.py` \u6536\u53e3 child/sleep/cancel \u7684 tool-facing control\uff0c`runtime_tools.py` \u662f\u6ce8\u5165\u7ed9 agent \u7684 scheduler runtime tools\uff0c`store/` \u53ea\u8d1f\u8d23\u6301\u4e45\u5316\u3002"
+    },
+    {
+      "label": "Observability",
+      "path": "agiwo/observability",
+      "responsibility": "Trace/Span \u6a21\u578b\u3001\u67e5\u8be2\u63a5\u53e3\u4e0e trace storage \u5b9e\u73b0\uff1bagent \u4e8b\u4ef6\u5230 Trace \u7684\u9002\u914d\u5c42\u6536\u53e3\u5728 `agiwo/agent/trace_writer.py`\u3002"
+    },
+    {
+      "label": "Embedding",
+      "path": "agiwo/embedding",
+      "responsibility": "Embedding \u62bd\u8c61\u4e0e factory\uff0c\u5305\u542b\u672c\u5730/OpenAI \u98ce\u683c\u5b9e\u73b0\u3002"
+    },
+    {
+      "label": "Skills",
+      "path": "agiwo/skill",
+      "responsibility": "Skill \u7684\u53d1\u73b0\u3001\u8def\u5f84\u89c4\u5219\uff08`config.py`\uff09\u3001\u52a0\u8f7d\u3001\u6ce8\u518c\u3001\u5f02\u5e38\u5b9a\u4e49\uff0c\u4ee5\u53ca `SkillTool` \u6865\u63a5\u3002"
+    },
+    {
+      "label": "Workspace",
+      "path": "agiwo/workspace",
+      "responsibility": "Agent workspace \u8def\u5f84\u8bed\u4e49\u3001\u6a21\u677f/bootstrap\u3001\u5de5\u4f5c\u533a\u6587\u6863\u8bfb\u53d6\u4e0e\u53d8\u66f4 token\u3002"
+    },
+    {
+      "label": "Memory",
+      "path": "agiwo/memory",
+      "responsibility": "\u5171\u4eab MEMORY \u7d22\u5f15/\u5207\u5757/\u641c\u7d22\u80fd\u529b\uff0c\u4ee5\u53ca `WorkspaceMemoryService`\u3002"
+    },
+    {
+      "label": "Configuration",
+      "path": "agiwo/config",
+      "responsibility": "SDK \u5168\u5c40\u914d\u7f6e\u5165\u53e3\u3001Provider \u679a\u4e3e\u4e0e\u5171\u4eab\u8bbe\u7f6e\u3002"
+    },
+    {
+      "label": "Shared utilities",
+      "path": "agiwo/utils",
+      "responsibility": "\u8de8\u6a21\u5757\u8fd0\u884c\u65f6\u5de5\u5177\u3002`storage_support/` \u8d1f\u8d23\u5171\u4eab SQLite/Mongo runtime\u3001schema/index \u521d\u59cb\u5316\u7b49\u57fa\u7840\u8bbe\u65bd\u3002"
+    }
+  ],
+  "source_pointers": [
+    {
+      "label": "Repository guide",
+      "path": "AGENTS.md",
+      "title": "AGENTS.md"
+    },
+    {
+      "label": "Public entry README",
+      "path": "README.md",
+      "title": "Agiwo"
+    },
+    {
+      "label": "Architecture overview",
+      "path": "docs/architecture/overview.md",
+      "title": "Architecture Overview"
+    },
+    {
+      "label": "Getting started guide",
+      "path": "docs/getting-started.md",
+      "title": "Getting Started"
+    },
+    {
+      "label": "Multi-agent guide",
+      "path": "docs/guides/multi-agent.md",
+      "title": "Multi-Agent & Composition"
+    }
+  ],
+  "summary": "Agiwo is organized around a canonical agent runtime, a separate scheduler orchestration layer, a tool abstraction, a model layer, and an internal control plane.",
+  "supporting_layout": [
+    {
+      "label": "SDK tests",
+      "path": "tests",
+      "responsibility": "SDK \u6d4b\u8bd5\uff0c\u6309\u5b50\u7cfb\u7edf\u5206\u76ee\u5f55\u3002"
+    },
+    {
+      "label": "Repo scripts",
+      "path": "scripts",
+      "responsibility": "\u4f4e\u566a\u97f3 lint \u5165\u53e3\u4e0e repo guard\u3002"
+    },
+    {
+      "label": "Guardrails",
+      "path": "lint",
+      "responsibility": "import-linter contract \u7b49\u673a\u5668\u62a4\u680f\u914d\u7f6e\u3002"
+    },
+    {
+      "label": "Repository docs",
+      "path": "docs",
+      "responsibility": "\u8bbe\u8ba1\u6587\u6863\u4e0e\u6e20\u9053\u8bf4\u660e\uff0c\u4e0d\u662f\u8fd0\u884c\u65f6\u6e90\u7801\u771f\u76f8\u3002"
+    },
+    {
+      "label": "Templates",
+      "path": "templates",
+      "responsibility": "\u8fd0\u884c\u65f6\u4f1a\u6d88\u8d39\u7684\u6a21\u677f\u5185\u5bb9\u3002"
+    }
+  ]
+}

--- a/website/src/generated/repo-overview.json
+++ b/website/src/generated/repo-overview.json
@@ -9,37 +9,37 @@
     {
       "label": "Control plane",
       "path": "console/server",
-      "responsibility": "FastAPI \u63a7\u5236\u9762\u4e0e runtime \u96c6\u6210\u3002"
+      "responsibility": "FastAPI control plane and runtime integration layer."
     },
     {
       "label": "API boundary",
       "path": "console/server/routers",
-      "responsibility": "API/SSE \u8fb9\u754c\uff0c\u53ea\u505a HTTP \u8def\u7531\u4e0e\u8bf7\u6c42/\u54cd\u5e94\u88c5\u914d\u3002"
+      "responsibility": "HTTP and SSE API boundary for requests and responses."
     },
     {
       "label": "Application services",
       "path": "console/server/services",
-      "responsibility": "\u5e94\u7528\u670d\u52a1\u5c42\u3002`runtime/`\uff08agent factory\u3001runtime cache\u3001session runtime / session service\u3001scheduler tree view\uff09\u3001`tool_catalog/`\uff08tool reference / catalog / runtime builder\uff09\u3001`agent_registry/`\uff08\u914d\u7f6e CRUD + store \u5b50\u5305\uff09\u3001`session_store/`\uff08Console \u4f1a\u8bdd\u5b58\u50a8\u5de5\u5382\u4e0e\u5b9e\u73b0\uff09\u3001`runtime_config.py`\uff08\u8fd0\u884c\u65f6\u5168\u5c40\u914d\u7f6e\u67e5\u770b/\u8986\u76d6\uff09\u3001`storage_wiring.py`\uff08\u5b58\u50a8 config builders\uff09\u3001`metrics.py`\u3002"
+      "responsibility": "Application services for runtime management, registry, tool catalog, session storage, and metrics."
     },
     {
       "label": "Shared models",
       "path": "console/server/models",
-      "responsibility": "Console \u6570\u636e\u6a21\u578b\u76ee\u5f55\u3002`view.py` \u53ea\u653e API/SSE \u89c6\u56fe\u6a21\u578b\uff1b`session.py`\u3001`agent_config.py`\u3001`runtime_config.py`\u3001`metrics.py` \u653e\u5171\u4eab\u8fd0\u884c\u65f6/\u914d\u7f6e/\u805a\u5408\u6a21\u578b\u3002\u4e0d\u8981\u518d\u65b0\u589e `schemas.py` \u6216\u5e73\u7ea7 `domain/`\u3002"
+      "responsibility": "Console-facing shared runtime, configuration, and view models."
     },
     {
       "label": "Channel adapters",
       "path": "console/server/channels",
-      "responsibility": "\u6e20\u9053\u9002\u914d\u5c42\uff0c\u8d1f\u8d23\u6279\u5904\u7406\u3001\u6d88\u606f\u89e3\u6790\u3001delivery\uff0c\u4ee5\u53ca Feishu \u7b49\u6e20\u9053\u96c6\u6210\u3002"
+      "responsibility": "Channel adapters for delivery, parsing, and integration workflows."
     },
     {
       "label": "Internal web UI",
       "path": "console/web",
-      "responsibility": "Console \u524d\u7aef\u3002"
+      "responsibility": "Internal control-plane frontend for sessions, traces, scheduler, and settings."
     },
     {
       "label": "Console tests",
       "path": "console/tests",
-      "responsibility": "Console \u540e\u7aef\u6d4b\u8bd5\u3002"
+      "responsibility": "Console backend test suite."
     }
   ],
   "layout_sections": [
@@ -95,57 +95,57 @@
     {
       "label": "Agent runtime",
       "path": "agiwo/agent",
-      "responsibility": "Canonical agent runtime\u3002public API \u53ea\u4ece `agiwo.agent` \u66b4\u9732\uff1b\u9876\u5c42\u53ea\u4fdd\u7559\u7a33\u5b9a\u5165\u53e3\u4e0e\u6838\u5fc3 orchestrator\uff08\u5982 `agent.py`\u3001`definition.py`\u3001`run_loop.py`\u3001`llm_caller.py`\u3001`tool_executor.py`\u3001`prompt.py`\u3001`trace_writer.py`\uff09\u3002\u7eaf\u6570\u636e\u6a21\u578b\u6536\u53e3\u5728 `models/`\uff0chook contract \u6536\u53e3\u5728 `agiwo.agent.hooks`\uff0cnested-agent adapter \u6536\u53e3\u5728 `nested/`\uff0crun/session runtime context \u4e0e state helper \u6536\u53e3\u5728 `agiwo.agent.runtime`\uff0ctermination logic \u6536\u53e3\u5728 `termination/`\uff0c\u4e0a\u4e0b\u6587\u56de\u987e\u4f18\u5316\u6536\u53e3\u5728 `retrospect/`\uff0c`storage/` \u8d1f\u8d23\u6301\u4e45\u5316\u3002"
+      "responsibility": "Canonical agent runtime, execution loop, runtime state, models, nested-agent adapters, and persistence hooks."
     },
     {
       "label": "Model layer",
       "path": "agiwo/llm",
-      "responsibility": "Model \u62bd\u8c61\u3001Provider \u9002\u914d\u5668\u3001\u914d\u7f6e\u7b56\u7565\u3001\u6d88\u606f/\u4e8b\u4ef6\u5f52\u4e00\u5316\uff0c\u4ee5\u53ca\u7edf\u4e00\u7684 model factory\u3002"
+      "responsibility": "Model abstraction, provider adapters, configuration policy, and factory construction."
     },
     {
       "label": "Tool layer",
       "path": "agiwo/tool",
-      "responsibility": "Tool \u62bd\u8c61\u3001\u6700\u5c0f\u6267\u884c\u4e0a\u4e0b\u6587\u3001builtin tools\u3001\u540e\u53f0\u8fdb\u7a0b registry\uff08`process/`\uff09\uff0c\u4ee5\u53ca\u5de5\u5177\u4fa7\u5b58\u50a8\uff08\u5982 citation\uff09\u3002"
+      "responsibility": "Tool contracts, builtin tools, execution context, process registry, and tool-side persistence."
     },
     {
       "label": "Scheduler",
       "path": "agiwo/scheduler",
-      "responsibility": "Agent \u4e4b\u4e0a\u7684\u7f16\u6392\u5c42\u3002`scheduler.py` \u662f facade \u4e0e loop lifecycle\uff0c`engine.py` \u662f\u552f\u4e00\u7f16\u6392 owner\uff0c`runner.py` \u8d1f\u8d23\u5355\u6b21 dispatch action \u6267\u884c\uff0c`commands.py` \u627f\u8f7d\u8c03\u5ea6\u52a8\u4f5c\u4e0e tool DTO\uff0c`runtime_state.py` \u627f\u8f7d\u8fdb\u7a0b\u5185 live state \u4e0e tick helpers\uff0c`tool_control.py` \u6536\u53e3 child/sleep/cancel \u7684 tool-facing control\uff0c`runtime_tools.py` \u662f\u6ce8\u5165\u7ed9 agent \u7684 scheduler runtime tools\uff0c`store/` \u53ea\u8d1f\u8d23\u6301\u4e45\u5316\u3002"
+      "responsibility": "Agent-level orchestration, runtime tools, lifecycle management, and scheduler state persistence."
     },
     {
       "label": "Observability",
       "path": "agiwo/observability",
-      "responsibility": "Trace/Span \u6a21\u578b\u3001\u67e5\u8be2\u63a5\u53e3\u4e0e trace storage \u5b9e\u73b0\uff1bagent \u4e8b\u4ef6\u5230 Trace \u7684\u9002\u914d\u5c42\u6536\u53e3\u5728 `agiwo/agent/trace_writer.py`\u3002"
+      "responsibility": "Trace and span storage, querying, and runtime trace adaptation."
     },
     {
       "label": "Embedding",
       "path": "agiwo/embedding",
-      "responsibility": "Embedding \u62bd\u8c61\u4e0e factory\uff0c\u5305\u542b\u672c\u5730/OpenAI \u98ce\u683c\u5b9e\u73b0\u3002"
+      "responsibility": "Embedding abstraction and provider-backed implementations."
     },
     {
       "label": "Skills",
       "path": "agiwo/skill",
-      "responsibility": "Skill \u7684\u53d1\u73b0\u3001\u8def\u5f84\u89c4\u5219\uff08`config.py`\uff09\u3001\u52a0\u8f7d\u3001\u6ce8\u518c\u3001\u5f02\u5e38\u5b9a\u4e49\uff0c\u4ee5\u53ca `SkillTool` \u6865\u63a5\u3002"
+      "responsibility": "Skill discovery, allowlisting, loading, and skill-to-tool bridging."
     },
     {
       "label": "Workspace",
       "path": "agiwo/workspace",
-      "responsibility": "Agent workspace \u8def\u5f84\u8bed\u4e49\u3001\u6a21\u677f/bootstrap\u3001\u5de5\u4f5c\u533a\u6587\u6863\u8bfb\u53d6\u4e0e\u53d8\u66f4 token\u3002"
+      "responsibility": "Workspace path semantics, bootstrap, and runtime workspace helpers."
     },
     {
       "label": "Memory",
       "path": "agiwo/memory",
-      "responsibility": "\u5171\u4eab MEMORY \u7d22\u5f15/\u5207\u5757/\u641c\u7d22\u80fd\u529b\uff0c\u4ee5\u53ca `WorkspaceMemoryService`\u3002"
+      "responsibility": "Shared workspace memory indexing, chunking, and search services."
     },
     {
       "label": "Configuration",
       "path": "agiwo/config",
-      "responsibility": "SDK \u5168\u5c40\u914d\u7f6e\u5165\u53e3\u3001Provider \u679a\u4e3e\u4e0e\u5171\u4eab\u8bbe\u7f6e\u3002"
+      "responsibility": "Global SDK configuration and shared provider settings."
     },
     {
       "label": "Shared utilities",
       "path": "agiwo/utils",
-      "responsibility": "\u8de8\u6a21\u5757\u8fd0\u884c\u65f6\u5de5\u5177\u3002`storage_support/` \u8d1f\u8d23\u5171\u4eab SQLite/Mongo runtime\u3001schema/index \u521d\u59cb\u5316\u7b49\u57fa\u7840\u8bbe\u65bd\u3002"
+      "responsibility": "Cross-module runtime utilities and shared storage support."
     }
   ],
   "source_pointers": [
@@ -180,27 +180,27 @@
     {
       "label": "SDK tests",
       "path": "tests",
-      "responsibility": "SDK \u6d4b\u8bd5\uff0c\u6309\u5b50\u7cfb\u7edf\u5206\u76ee\u5f55\u3002"
+      "responsibility": "SDK test suite organized by subsystem."
     },
     {
       "label": "Repo scripts",
       "path": "scripts",
-      "responsibility": "\u4f4e\u566a\u97f3 lint \u5165\u53e3\u4e0e repo guard\u3002"
+      "responsibility": "Lint entrypoints, repo guardrails, and maintenance helpers."
     },
     {
       "label": "Guardrails",
       "path": "lint",
-      "responsibility": "import-linter contract \u7b49\u673a\u5668\u62a4\u680f\u914d\u7f6e\u3002"
+      "responsibility": "Import-linter and repository guard configuration."
     },
     {
       "label": "Repository docs",
       "path": "docs",
-      "responsibility": "\u8bbe\u8ba1\u6587\u6863\u4e0e\u6e20\u9053\u8bf4\u660e\uff0c\u4e0d\u662f\u8fd0\u884c\u65f6\u6e90\u7801\u771f\u76f8\u3002"
+      "responsibility": "Repository-native design notes, concepts, and architecture documentation."
     },
     {
       "label": "Templates",
       "path": "templates",
-      "responsibility": "\u8fd0\u884c\u65f6\u4f1a\u6d88\u8d39\u7684\u6a21\u677f\u5185\u5bb9\u3002"
+      "responsibility": "Template content consumed by runtime features."
     }
   ]
 }

--- a/website/src/styles/site.css
+++ b/website/src/styles/site.css
@@ -203,6 +203,43 @@ h3 {
   letter-spacing: 0.01em;
 }
 
+.repo-overview-hero,
+.repo-overview-section {
+  margin-top: 2rem;
+}
+
+.repo-overview-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(10, 22, 38, 0.48);
+}
+
+.repo-overview-table th,
+.repo-overview-table td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+  vertical-align: top;
+}
+
+.repo-overview-table th {
+  text-align: left;
+  color: var(--sl-color-white);
+}
+
+.repo-overview-list {
+  display: grid;
+  gap: 0.85rem;
+  padding-left: 1.2rem;
+}
+
+.repo-overview-subtle {
+  margin-top: 0.35rem;
+  color: var(--muted);
+}
+
 @media (max-width: 640px) {
   .home-page {
     width: min(1120px, calc(100% - 20px));


### PR DESCRIPTION
## Summary
- calibrate `README.md` and `AGENTS.md` against the current codebase
- add a manual `scripts/generate_repo_overview.py` generator and checked-in JSON output
- add a public `/docs/repo-overview/` page backed by generated repository structure data
- document the manual refresh workflow for the generated overview

## Validation
- python scripts/generate_repo_overview.py
- python scripts/generate_repo_overview.py --check
- npm --prefix website run check
- npm --prefix website run build
