### PR TITLE
Align scheduler run-result semantics before v1

### DIFF
--- a/agiwo/scheduler/_stream.py
+++ b/agiwo/scheduler/_stream.py
@@ -25,12 +25,6 @@ def build_stream(
     close_on_root_run_end: bool,
 ) -> AsyncIterator[AgentStreamItem]:
     async def iterator() -> AsyncIterator[AgentStreamItem]:
-        open_stream_channel(
-            sched._rt.stream_channels,
-            state_id,
-            include_child_events=include_child_events,
-            close_on_root_run_end=close_on_root_run_end,
-        )
         try:
             async for item in consume_stream_channel(
                 sched._rt.stream_channels,
@@ -59,7 +53,17 @@ async def route_with_stream(
         raise RuntimeError(
             f"stream subscriber already active for root '{root_state_id}'"
         )
-    state_id = await operation()
+    open_stream_channel(
+        sched._rt.stream_channels,
+        root_state_id,
+        include_child_events=include_child_events,
+        close_on_root_run_end=close_on_root_run_end,
+    )
+    try:
+        state_id = await operation()
+    except Exception:
+        close_stream_channel(sched._rt.stream_channels, root_state_id)
+        raise
     return RouteResult(
         action=action,
         state_id=state_id,

--- a/agiwo/scheduler/engine.py
+++ b/agiwo/scheduler/engine.py
@@ -442,18 +442,24 @@ class Scheduler:
             while True:
                 state = await self._store.get_state(state_id)
                 if state is not None:
-                    if state.status in (
-                        AgentStateStatus.IDLE,
-                        AgentStateStatus.COMPLETED,
-                    ):
-                        return RunOutput(
-                            response=state.result_summary,
-                            termination_reason=TerminationReason.COMPLETED,
+                    if state.last_run_result is not None and (
+                        state.status
+                        in (
+                            AgentStateStatus.IDLE,
+                            AgentStateStatus.COMPLETED,
+                            AgentStateStatus.FAILED,
                         )
-                    if state.status == AgentStateStatus.FAILED:
+                    ):
+                        last_run_result = state.last_run_result
                         return RunOutput(
-                            error=state.result_summary,
-                            termination_reason=TerminationReason.ERROR,
+                            run_id=last_run_result.run_id,
+                            response=(
+                                last_run_result.summary
+                                if last_run_result.error is None
+                                else None
+                            ),
+                            error=last_run_result.error,
+                            termination_reason=last_run_result.termination_reason,
                         )
 
                 remaining = None

--- a/agiwo/scheduler/models.py
+++ b/agiwo/scheduler/models.py
@@ -14,7 +14,7 @@ from enum import Enum
 from types import MappingProxyType
 from typing import Any
 
-from agiwo.agent import UserInput
+from agiwo.agent import TerminationReason, UserInput
 from agiwo.skill.allowlist import (
     normalize_allowed_skills,
     validate_expanded_allowed_skills,
@@ -206,6 +206,17 @@ _UNSET = _UnsetType()
 
 
 @dataclass(frozen=True, slots=True)
+class SchedulerRunResult:
+    """Most recent completed agent-cycle result owned by the scheduler."""
+
+    run_id: str | None
+    termination_reason: TerminationReason
+    summary: str | None = None
+    error: str | None = None
+    completed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True, slots=True)
 class AgentState:
     """
     Persistent state snapshot of a scheduled agent.
@@ -234,6 +245,7 @@ class AgentState:
     rollback_count: int = 0
     no_progress: bool = False
     explain: str | None = None
+    last_run_result: SchedulerRunResult | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -317,6 +329,7 @@ class AgentState:
             ),
             explain=self.explain if explain is _UNSET else explain,
             wake_count=self.wake_count if wake_count is _UNSET else wake_count,
+            last_run_result=None,
             no_progress=False,
         )
 

--- a/agiwo/scheduler/runner.py
+++ b/agiwo/scheduler/runner.py
@@ -25,6 +25,7 @@ from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
     PendingEvent,
+    SchedulerRunResult,
     SchedulerEventType,
     WakeType,
 )
@@ -357,6 +358,21 @@ class SchedulerRunner:
             )
         return fallback
 
+    @staticmethod
+    def _build_last_run_result(
+        *,
+        termination_reason: TerminationReason,
+        run_id: str | None,
+        summary: str | None = None,
+        error: str | None = None,
+    ) -> SchedulerRunResult:
+        return SchedulerRunResult(
+            run_id=run_id,
+            termination_reason=termination_reason,
+            summary=summary,
+            error=error,
+        )
+
     async def _fanout_stream_item(
         self, state: AgentState, item: AgentStreamItem
     ) -> None:
@@ -374,7 +390,11 @@ class SchedulerRunner:
         if parent_signal is None or not parent_signal.is_aborted():
             return False
 
-        await self._fail_state(state.id, "Parent cancelled")
+        await self._fail_state(
+            state.id,
+            "Parent cancelled",
+            termination_reason=TerminationReason.CANCELLED,
+        )
         await self._emit_event_to_parent(
             state,
             SchedulerEventType.CHILD_FAILED,
@@ -412,7 +432,7 @@ class SchedulerRunner:
         if await self._handle_periodic_output(action, current_state, text, output):
             return
 
-        await self._complete_state(current_state, text)
+        await self._complete_state(current_state, output, text)
 
     async def _emit_event_to_parent(
         self,
@@ -474,11 +494,25 @@ class SchedulerRunner:
         self._ctx.notify_state_change(state.id)
         self._ctx.nudge()
 
-    async def _fail_state(self, state_id: str, reason: str) -> None:
+    async def _fail_state(
+        self,
+        state_id: str,
+        reason: str,
+        *,
+        termination_reason: TerminationReason = TerminationReason.ERROR,
+    ) -> None:
         current_state = await self._ctx.store.get_state(state_id)
         if current_state is None:
             return
-        await self._save_state(current_state.with_failed(reason))
+        await self._save_state(
+            current_state.with_failed(reason).with_updates(
+                last_run_result=self._build_last_run_result(
+                    termination_reason=termination_reason,
+                    run_id=None,
+                    error=reason,
+                )
+            )
+        )
 
     async def _cleanup_after_run(self, state: AgentState) -> None:
         self._ctx.rt.dispatched.discard(state.id)
@@ -576,12 +610,22 @@ class SchedulerRunner:
             )
             return True
 
-        await self._save_state(state.with_failed("Shutdown before completion"))
+        error = "Shutdown before completion"
+        await self._save_state(
+            state.with_failed(error).with_updates(
+                last_run_result=self._build_last_run_result(
+                    termination_reason=TerminationReason.ERROR,
+                    run_id=None,
+                    summary=text,
+                    error=error,
+                )
+            )
+        )
         if state.is_child:
             await self._emit_event_to_parent(
                 state,
                 SchedulerEventType.CHILD_FAILED,
-                {"reason": "Shutdown before completion"},
+                {"reason": error},
             )
         return True
 
@@ -595,7 +639,16 @@ class SchedulerRunner:
             return False
 
         reason = output.error or text or output.termination_reason.value
-        await self._save_state(state.with_failed(reason))
+        await self._save_state(
+            state.with_failed(reason).with_updates(
+                last_run_result=self._build_last_run_result(
+                    termination_reason=output.termination_reason,
+                    run_id=output.run_id,
+                    summary=text,
+                    error=reason,
+                )
+            )
+        )
         if state.is_child:
             await self._emit_event_to_parent(
                 state,
@@ -676,13 +729,27 @@ class SchedulerRunner:
     async def _complete_state(
         self,
         state: AgentState,
+        output: RunOutput,
         text: str | None,
     ) -> None:
+        last_run_result = self._build_last_run_result(
+            termination_reason=TerminationReason.COMPLETED,
+            run_id=output.run_id,
+            summary=text,
+        )
         if state.is_root and state.is_persistent:
-            await self._save_state(state.with_idle(result_summary=text))
+            await self._save_state(
+                state.with_idle(result_summary=text).with_updates(
+                    last_run_result=last_run_result
+                )
+            )
             return
 
-        await self._save_state(state.with_completed(result_summary=text))
+        await self._save_state(
+            state.with_completed(result_summary=text).with_updates(
+                last_run_result=last_run_result
+            )
+        )
         if state.is_child:
             await self._emit_event_to_parent(
                 state,

--- a/agiwo/scheduler/store/codec.py
+++ b/agiwo/scheduler/store/codec.py
@@ -6,9 +6,10 @@ This module owns persistence-facing serialization for scheduler domain types.
 from datetime import datetime
 from typing import Any
 
-from agiwo.agent import UserInput, UserMessage
+from agiwo.agent import TerminationReason, UserInput, UserMessage
 from agiwo.scheduler.models import (
     ChildAgentConfigOverrides,
+    SchedulerRunResult,
     TimeUnit,
     WaitMode,
     WakeCondition,
@@ -58,6 +59,34 @@ def deserialize_child_agent_config_overrides(
         allowed_skills=data.get("allowed_skills"),
         allowed_tools=data.get("allowed_tools"),
         fork=data.get("fork", False),
+    )
+
+
+def serialize_scheduler_run_result_for_store(
+    result: SchedulerRunResult | None,
+) -> dict[str, Any] | None:
+    if result is None:
+        return None
+    return {
+        "run_id": result.run_id,
+        "termination_reason": result.termination_reason.value,
+        "summary": result.summary,
+        "error": result.error,
+        "completed_at": result.completed_at.isoformat(),
+    }
+
+
+def deserialize_scheduler_run_result_for_store(
+    data: dict[str, Any] | None,
+) -> SchedulerRunResult | None:
+    if not data:
+        return None
+    return SchedulerRunResult(
+        run_id=data.get("run_id"),
+        termination_reason=TerminationReason(str(data["termination_reason"])),
+        summary=data.get("summary"),
+        error=data.get("error"),
+        completed_at=datetime.fromisoformat(str(data["completed_at"])),
     )
 
 
@@ -111,9 +140,11 @@ def deserialize_wake_condition_for_store(data: dict[str, Any]) -> WakeCondition:
 
 __all__ = [
     "deserialize_child_agent_config_overrides",
+    "deserialize_scheduler_run_result_for_store",
     "deserialize_user_input_for_store",
     "deserialize_wake_condition_for_store",
     "serialize_child_agent_config_overrides",
+    "serialize_scheduler_run_result_for_store",
     "serialize_user_input_for_store",
     "serialize_wake_condition_for_store",
 ]

--- a/agiwo/scheduler/store/sqlite.py
+++ b/agiwo/scheduler/store/sqlite.py
@@ -16,8 +16,10 @@ from agiwo.scheduler.models import (
 )
 from agiwo.scheduler.store.base import AgentStateStorage
 from agiwo.scheduler.store.codec import (
+    deserialize_scheduler_run_result_for_store,
     deserialize_user_input_for_store,
     deserialize_wake_condition_for_store,
+    serialize_scheduler_run_result_for_store,
     serialize_user_input_for_store,
     serialize_wake_condition_for_store,
 )
@@ -69,6 +71,11 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                     wakeup_at TEXT,
                     wake_timeout_at TEXT,
                     result_summary TEXT,
+                    last_run_id TEXT,
+                    last_run_termination_reason TEXT,
+                    last_run_summary TEXT,
+                    last_run_error TEXT,
+                    last_run_completed_at TEXT,
                     signal_propagated INTEGER DEFAULT 0,
                     is_persistent INTEGER DEFAULT 0,
                     depth INTEGER DEFAULT 0,
@@ -120,6 +127,18 @@ class SQLiteAgentStateStorage(AgentStateStorage):
         if row["config_overrides"]:
             config_overrides = json.loads(row["config_overrides"])
 
+        last_run_result = deserialize_scheduler_run_result_for_store(
+            {
+                "run_id": row["last_run_id"],
+                "termination_reason": row["last_run_termination_reason"],
+                "summary": row["last_run_summary"],
+                "error": row["last_run_error"],
+                "completed_at": row["last_run_completed_at"],
+            }
+            if row["last_run_termination_reason"]
+            else None
+        )
+
         return AgentState(
             id=row["id"],
             session_id=row["session_id"],
@@ -141,6 +160,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
             wake_count=row.get("wake_count", 0) or 0,
             rollback_count=row.get("rollback_count", 0) or 0,
             explain=row.get("explain"),
+            last_run_result=last_run_result,
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
         )
@@ -186,15 +206,18 @@ class SQLiteAgentStateStorage(AgentStateStorage):
     async def save_state(self, state: AgentState) -> None:
         conn = await self._get_conn()
         wake_values = self._wake_condition_values(state.wake_condition)
+        last_run_values = self._last_run_result_values(state.last_run_result)
         await conn.execute(
             """
             INSERT OR REPLACE INTO agent_states
                 (id, session_id, parent_id, status, task, pending_input, config_overrides,
                  wake_type, wake_time_value, wake_time_unit, wake_wait_for, wake_wait_mode,
                  wake_completed_ids, wakeup_at, wake_timeout_at, result_summary,
+                 last_run_id, last_run_termination_reason, last_run_summary, last_run_error,
+                 last_run_completed_at,
                  signal_propagated, is_persistent, depth, wake_count, rollback_count,
                  agent_config_id, explain, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 state.id,
@@ -210,6 +233,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                 json.dumps(thaw_value(state.config_overrides)),
                 *wake_values,
                 state.result_summary,
+                *last_run_values,
                 1 if state.signal_propagated else 0,
                 1 if state.is_persistent else 0,
                 state.depth,
@@ -222,6 +246,18 @@ class SQLiteAgentStateStorage(AgentStateStorage):
             ),
         )
         await conn.commit()
+
+    def _last_run_result_values(self, last_run_result) -> list[object]:
+        payload = serialize_scheduler_run_result_for_store(last_run_result)
+        if payload is None:
+            return [None, None, None, None, None]
+        return [
+            payload.get("run_id"),
+            payload["termination_reason"],
+            payload.get("summary"),
+            payload.get("error"),
+            payload["completed_at"],
+        ]
 
     async def get_state(self, state_id: str) -> AgentState | None:
         conn = await self._get_conn()

--- a/console/server/models/view.py
+++ b/console/server/models/view.py
@@ -167,6 +167,14 @@ class WakeConditionResponse(BaseModel):
     timeout_at: str | None = None
 
 
+class SchedulerRunResultResponse(BaseModel):
+    run_id: str | None = None
+    termination_reason: str
+    summary: str | None = None
+    error: str | None = None
+    completed_at: str | None = None
+
+
 class AgentStateBase(BaseModel):
     id: str
     root_state_id: str | None = None
@@ -175,6 +183,7 @@ class AgentStateBase(BaseModel):
     parent_id: str | None = None
     wake_condition: WakeConditionResponse | None = None
     result_summary: str | None = None
+    last_run_result: SchedulerRunResultResponse | None = None
     agent_config_id: str | None = None
     is_persistent: bool = False
     depth: int = 0

--- a/console/server/models/view.py
+++ b/console/server/models/view.py
@@ -253,6 +253,7 @@ class SchedulerTreeNodeResponse(BaseModel):
     pending_event_count: int = 0
     last_error: str | None = None
     result_summary: str | None = None
+    last_run_result: SchedulerRunResultResponse | None = None
 
 
 class SchedulerTreeResponse(BaseModel):

--- a/console/server/response_serialization.py
+++ b/console/server/response_serialization.py
@@ -321,6 +321,9 @@ def scheduler_tree_response_from_record(
                 pending_event_count=node.pending_event_count,
                 last_error=node.last_error,
                 result_summary=node.result_summary,
+                last_run_result=scheduler_run_result_response_from_sdk(
+                    node.last_run_result
+                ),
             )
             for node in tree.nodes
         ],

--- a/console/server/response_serialization.py
+++ b/console/server/response_serialization.py
@@ -8,7 +8,12 @@ from agiwo.agent import AgentStreamItem, StepCompletedEvent
 from agiwo.agent.models import step
 from agiwo.agent.models.run import Run
 from agiwo.observability.trace import Trace
-from agiwo.scheduler.models import AgentState, PendingEvent, WakeCondition
+from agiwo.scheduler.models import (
+    AgentState,
+    PendingEvent,
+    SchedulerRunResult,
+    WakeCondition,
+)
 from server.models.metrics import RunMetricsSummary
 from server.models.session import (
     ChannelChatContext,
@@ -24,6 +29,7 @@ from server.models.view import (
     RunMetricsResponse,
     RunResponse,
     SchedulerTreeNodeResponse,
+    SchedulerRunResultResponse,
     SchedulerTreeResponse,
     SchedulerTreeStatsResponse,
     SessionDetailResponse,
@@ -207,6 +213,24 @@ def _wake_condition_response_from_sdk(
     )
 
 
+def scheduler_run_result_response_from_sdk(
+    result: SchedulerRunResult | None,
+) -> SchedulerRunResultResponse | None:
+    if result is None:
+        return None
+    return SchedulerRunResultResponse(
+        run_id=result.run_id,
+        termination_reason=result.termination_reason.value,
+        summary=result.summary,
+        error=result.error,
+        completed_at=(
+            result.completed_at.isoformat()
+            if getattr(result, "completed_at", None) is not None
+            else None
+        ),
+    )
+
+
 def agent_state_response_from_sdk(
     state: AgentState,
     *,
@@ -226,6 +250,7 @@ def agent_state_response_from_sdk(
             else None
         ),
         result_summary=state.result_summary,
+        last_run_result=scheduler_run_result_response_from_sdk(state.last_run_result),
         agent_config_id=state.agent_config_id,
         is_persistent=state.is_persistent,
         depth=state.depth,
@@ -255,6 +280,7 @@ def agent_state_list_item_from_sdk(
         parent_id=state.parent_id,
         wake_condition=None,
         result_summary=state.result_summary,
+        last_run_result=scheduler_run_result_response_from_sdk(state.last_run_result),
         agent_config_id=state.agent_config_id,
         is_persistent=state.is_persistent,
         depth=state.depth,

--- a/console/server/routers/sessions.py
+++ b/console/server/routers/sessions.py
@@ -13,6 +13,7 @@ from server.dependencies import (
 )
 from server.response_serialization import (
     run_response_from_sdk,
+    scheduler_run_result_response_from_sdk,
     session_detail_response_from_record,
     session_summary_response_from_record,
     step_response_from_sdk,
@@ -146,7 +147,7 @@ async def send_session_input(
             return
 
         state = await runtime_service.get_state(session.id)
-        if state is not None and state.result_summary:
+        if state is not None and state.last_run_result is not None:
             yield {
                 "event": "scheduler_ack",
                 "data": json.dumps(
@@ -154,7 +155,9 @@ async def send_session_input(
                         "type": "scheduler_ack",
                         "session_id": session.id,
                         "state_id": session.id,
-                        "result_summary": state.result_summary,
+                        "last_run_result": scheduler_run_result_response_from_sdk(
+                            state.last_run_result
+                        ).model_dump(),
                     },
                     default=str,
                 ),

--- a/console/server/services/runtime/agent_factory.py
+++ b/console/server/services/runtime/agent_factory.py
@@ -65,6 +65,11 @@ def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecor
     # Expand default tools using ToolManager
     tool_manager = get_global_tool_manager()
     default_tools = tool_manager.list_default_tool_names()
+    allowed_tools = (
+        default_tools
+        if template.allowed_tools is None
+        else list(template.allowed_tools)
+    )
     return AgentConfigRecord(
         id=template.id,
         name=template.name,
@@ -72,7 +77,7 @@ def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecor
         model_provider=template.model_provider,
         model_name=template.model_name,
         system_prompt=template.system_prompt,
-        allowed_tools=template.allowed_tools or default_tools,
+        allowed_tools=allowed_tools,
         allowed_skills=allowed_skills,
         options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
         model_params=dict(template.model_params),

--- a/console/server/services/runtime/agent_runtime_cache.py
+++ b/console/server/services/runtime/agent_runtime_cache.py
@@ -23,7 +23,8 @@ ConfigSnapshot = tuple[
     str,
     str,
     str,
-    tuple[str, ...],  # allowed_tools
+    tuple[str, ...] | None,  # allowed_tools
+    tuple[str, ...] | None,  # allowed_skills
     tuple[tuple[str, Any], ...],
     tuple[tuple[str, Any], ...],
 ]
@@ -36,7 +37,8 @@ def _config_snapshot(config: AgentConfigRecord) -> ConfigSnapshot:
         config.model_provider,
         config.model_name,
         config.system_prompt,
-        tuple(config.allowed_tools or ()),
+        tuple(config.allowed_tools) if config.allowed_tools is not None else None,
+        tuple(config.allowed_skills) if config.allowed_skills is not None else None,
         tuple(sorted(config.options.items())),
         tuple(sorted(config.model_params.items())),
     )

--- a/console/server/services/runtime/scheduler_tree_view_service.py
+++ b/console/server/services/runtime/scheduler_tree_view_service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from agiwo.scheduler.engine import Scheduler
-from agiwo.scheduler.models import AgentState, AgentStateStatus
+from agiwo.scheduler.models import AgentState, AgentStateStatus, SchedulerRunResult
 
 from server.models.session import ChannelChatSessionStore
 
@@ -56,6 +56,7 @@ class SchedulerTreeNodeRecord:
     pending_event_count: int
     last_error: str | None
     result_summary: str | None
+    last_run_result: SchedulerRunResult | None
 
 
 @dataclass(slots=True)
@@ -79,19 +80,38 @@ def _state_sort_key(state: AgentState) -> tuple[datetime, str]:
 def _is_cancelled_state(state: AgentState) -> bool:
     if state.status != AgentStateStatus.FAILED:
         return False
-    summary = (state.result_summary or "").lower()
+    if (
+        state.last_run_result is not None
+        and state.last_run_result.termination_reason.value == "cancelled"
+    ):
+        return True
+    summary = (
+        state.last_run_result.summary
+        if state.last_run_result is not None and state.last_run_result.summary
+        else state.result_summary or ""
+    ).lower()
     return "cancelled" in summary or "canceled" in summary
 
 
 def _last_error(state: AgentState) -> str | None:
     if state.explain:
         return state.explain
+    if state.last_run_result is not None and state.last_run_result.error:
+        return state.last_run_result.error
     if state.status == AgentStateStatus.FAILED:
-        return state.result_summary
+        if state.result_summary:
+            return state.result_summary
+        if state.last_run_result is not None:
+            return state.last_run_result.summary
     return None
 
 
 def _completed_at(state: AgentState) -> datetime | None:
+    if (
+        state.last_run_result is not None
+        and state.last_run_result.completed_at is not None
+    ):
+        return state.last_run_result.completed_at
     if state.status in (AgentStateStatus.COMPLETED, AgentStateStatus.FAILED):
         return state.updated_at
     return None
@@ -183,6 +203,7 @@ class SchedulerTreeViewService:
                 pending_event_count=pending_counts.get(state.id, 0),
                 last_error=_last_error(state),
                 result_summary=state.result_summary,
+                last_run_result=state.last_run_result,
             )
             for state in collected
         ]

--- a/console/tests/test_agent_runtime_components.py
+++ b/console/tests/test_agent_runtime_components.py
@@ -311,7 +311,7 @@ async def test_agent_runtime_cache_defers_refresh_while_state_active(
     existing_agent = FakeAgent("sess-1")
     pool._cache["sess-1"] = CachedAgent(
         agent=existing_agent,
-        config_snapshot=("stale", "", "", "", "", (), (), ()),
+        config_snapshot=("stale", "", "", "", "", None, None, (), ()),
     )
     session = Session(
         id="sess-1",
@@ -327,6 +327,55 @@ async def test_agent_runtime_cache_defers_refresh_while_state_active(
     assert agent is existing_agent
     assert replacement_agent.closed is True
     scheduler.rebind_agent.assert_awaited_once_with("sess-1", replacement_agent)
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_cache_refreshes_when_allowed_skills_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = FakeChannelChatSessionStore()
+    first_config = AgentConfigRecord.model_construct(
+        id="base-agent",
+        name="base",
+        model_provider="openai",
+        model_name="gpt-test",
+        allowed_skills=["alpha"],
+    )
+    second_config = first_config.model_copy(update={"allowed_skills": ["beta"]})
+    registry = SimpleNamespace(
+        get_agent=AsyncMock(side_effect=[first_config, second_config])
+    )
+    scheduler = SimpleNamespace(rebind_agent=AsyncMock(return_value=True))
+    first_agent = FakeAgent("sess-1-a")
+    second_agent = FakeAgent("sess-1-b")
+
+    monkeypatch.setattr(
+        "server.services.runtime.agent_runtime_cache.build_agent",
+        AsyncMock(side_effect=[first_agent, second_agent]),
+    )
+
+    pool = AgentRuntimeCache(
+        scheduler=scheduler,
+        agent_registry=registry,
+        console_config=ConsoleConfig(),
+        session_store=store,
+    )
+    session = Session(
+        id="sess-1",
+        chat_context_scope_id=None,
+        base_agent_id="base-agent",
+        created_by="AUTO",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    initial = await pool.get_or_create_runtime_agent(session)
+    refreshed = await pool.get_or_create_runtime_agent(session)
+
+    assert initial is first_agent
+    assert refreshed is second_agent
+    assert first_agent.closed is True
+    scheduler.rebind_agent.assert_awaited_once_with("sess-1", second_agent)
 
 
 @pytest.mark.asyncio

--- a/console/tests/test_chat_api.py
+++ b/console/tests/test_chat_api.py
@@ -14,7 +14,13 @@ from agiwo.agent import (
     TerminationReason,
 )
 from agiwo.scheduler.engine import Scheduler
-from agiwo.scheduler.models import AgentStateStorageConfig, SchedulerConfig
+from agiwo.scheduler.models import (
+    AgentState,
+    AgentStateStatus,
+    AgentStateStorageConfig,
+    SchedulerConfig,
+    SchedulerRunResult,
+)
 
 from server.app import create_app
 from server.services.session_store import InMemorySessionStore
@@ -350,6 +356,83 @@ async def test_session_input_continues_stream_after_root_sleeping(
     assert sum(1 for line in lines if line == "event: run_started") == 2
     assert sum(1 for line in lines if line == "event: run_completed") == 2
     assert any("run-2" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_session_input_fallback_uses_last_run_result(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(client)
+    await runtime.agent_registry.create_agent(
+        AgentConfigRecord(
+            id="agent-1",
+            name="agent-one",
+            model_provider="openai",
+            model_name="gpt-test",
+        )
+    )
+    create_resp = await client.post("/api/agents/agent-1/sessions")
+    session_id = create_resp.json()["session_id"]
+
+    class FakeAgent:
+        def __init__(self, agent_id: str) -> None:
+            self.id = agent_id
+
+        async def close(self) -> None:
+            pass
+
+    fake_agent = FakeAgent(session_id)
+    assert runtime.agent_runtime_cache is not None
+    monkeypatch.setattr(
+        runtime.agent_runtime_cache,
+        "get_or_create_runtime_agent",
+        AsyncMock(return_value=fake_agent),
+    )
+
+    scheduler = runtime.scheduler
+    assert scheduler is not None
+    await scheduler._store.save_state(
+        AgentState(
+            id=session_id,
+            session_id=session_id,
+            status=AgentStateStatus.IDLE,
+            task="hello",
+            is_persistent=True,
+            last_run_result=SchedulerRunResult(
+                run_id="run-1",
+                termination_reason=TerminationReason.TIMEOUT,
+                error="took too long",
+            ),
+        )
+    )
+
+    async def fake_route_root_input(*args, **kwargs):
+        del args, kwargs
+        return type(
+            "RouteResultStub",
+            (),
+            {
+                "action": "steered",
+                "state_id": session_id,
+                "stream": None,
+            },
+        )()
+
+    monkeypatch.setattr(scheduler, "route_root_input", fake_route_root_input)
+
+    async with client.stream(
+        "POST",
+        f"/api/sessions/{session_id}/input",
+        json={"message": "hello"},
+    ) as response:
+        assert response.status_code == 200
+        lines = [line async for line in response.aiter_lines()]
+
+    payload_lines = [line for line in lines if line.startswith("data: ")]
+    assert payload_lines
+    assert '"last_run_result"' in payload_lines[0]
+    assert '"termination_reason": "timeout"' in payload_lines[0]
 
 
 @pytest.mark.asyncio

--- a/console/tests/test_config_env.py
+++ b/console/tests/test_config_env.py
@@ -202,6 +202,18 @@ def test_default_agent_record_uses_shared_option_defaults() -> None:
     assert record.allowed_skills is None
 
 
+def test_default_agent_record_preserves_empty_allowed_tools() -> None:
+    template = DefaultAgentConfig(
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+        allowed_tools=[],
+    )
+
+    record = build_default_agent_record(template)
+
+    assert record.allowed_tools == []
+
+
 def test_console_default_agent_config_normalizes_allowed_skills() -> None:
     config = ConsoleConfig(
         default_agent={

--- a/console/tests/test_response_serialization.py
+++ b/console/tests/test_response_serialization.py
@@ -7,9 +7,10 @@ from agiwo.agent import (
     StepCompletedEvent,
     StepMetrics,
     StepRecord,
+    TerminationReason,
     UserMessage,
 )
-from agiwo.scheduler.models import AgentState, AgentStateStatus
+from agiwo.scheduler.models import AgentState, AgentStateStatus, SchedulerRunResult
 from agiwo.llm.config_policy import sanitize_model_params_data
 
 from server.models.agent_config import (
@@ -97,6 +98,26 @@ def test_scheduler_state_response_normalizes_serialized_user_input() -> None:
     assert payload["task"][0]["text"] == "queued"
     assert payload["pending_input"][0]["type"] == "text"
     assert payload["pending_input"][0]["text"] == "wake me"
+
+
+def test_scheduler_state_response_includes_last_run_result() -> None:
+    state = AgentState(
+        id="agent-1",
+        session_id="sess-1",
+        status=AgentStateStatus.IDLE,
+        task="done",
+        last_run_result=SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.COMPLETED,
+            summary="finished",
+        ),
+    )
+
+    payload = agent_state_response_from_sdk(state).model_dump()
+
+    assert payload["last_run_result"]["run_id"] == "run-1"
+    assert payload["last_run_result"]["termination_reason"] == "completed"
+    assert payload["last_run_result"]["summary"] == "finished"
 
 
 def test_agent_config_view_model_and_registry_share_normalization_policy() -> None:

--- a/console/tests/test_scheduler_api.py
+++ b/console/tests/test_scheduler_api.py
@@ -190,6 +190,12 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             parent_id="root-tree",
             depth=1,
             result_summary="Cancelled by operator",
+            last_run_result=SchedulerRunResult(
+                run_id="run-cancelled",
+                termination_reason=TerminationReason.CANCELLED,
+                summary="Cancelled by operator",
+                completed_at=base_time.replace(minute=2),
+            ),
             created_at=base_time.replace(minute=2),
             updated_at=base_time.replace(minute=2),
         ),
@@ -201,6 +207,13 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             parent_id="root-tree",
             depth=1,
             result_summary="Tool crashed",
+            last_run_result=SchedulerRunResult(
+                run_id="run-failed",
+                termination_reason=TerminationReason.ERROR,
+                summary="Tool crashed",
+                error="Tool crashed",
+                completed_at=base_time.replace(minute=3),
+            ),
             created_at=base_time.replace(minute=3),
             updated_at=base_time.replace(minute=3),
         ),
@@ -212,6 +225,12 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             parent_id="child-running",
             depth=2,
             result_summary="Grandchild finished",
+            last_run_result=SchedulerRunResult(
+                run_id="run-grandchild",
+                termination_reason=TerminationReason.COMPLETED,
+                summary="Grandchild finished",
+                completed_at=base_time.replace(minute=4),
+            ),
             created_at=base_time.replace(minute=4),
             updated_at=base_time.replace(minute=4),
         ),
@@ -416,6 +435,11 @@ class TestSchedulerTree:
         assert node_map["grandchild-completed"]["pending_event_count"] == 1
         assert node_map["child-cancelled"]["root_state_id"] == "root-tree"
         assert node_map["child-cancelled"]["last_error"] == "Cancelled by operator"
+        assert (
+            node_map["child-cancelled"]["last_run_result"]["termination_reason"]
+            == "cancelled"
+        )
+        assert node_map["child-failed"]["last_run_result"]["error"] == "Tool crashed"
         assert "pending_events" not in node_map["child-running"]
 
     @pytest.mark.asyncio

--- a/console/tests/test_scheduler_api.py
+++ b/console/tests/test_scheduler_api.py
@@ -17,12 +17,14 @@ from agiwo.scheduler.models import (
     AgentStateStatus,
     AgentStateStorageConfig,
     PendingEvent,
+    SchedulerRunResult,
     SchedulerConfig,
     SchedulerEventType,
     WakeCondition,
     WakeType,
     TimeUnit,
 )
+from agiwo.agent import TerminationReason
 from agiwo.scheduler.engine import Scheduler
 
 from server.app import create_app
@@ -113,6 +115,11 @@ async def _seed_states(client: AsyncClient) -> None:
             task="Research topic A",
             parent_id="parent-1",
             result_summary="Topic A is about X.",
+            last_run_result=SchedulerRunResult(
+                run_id="run-child-1",
+                termination_reason=TerminationReason.COMPLETED,
+                summary="Topic A is about X.",
+            ),
             signal_propagated=True,
         ),
         AgentState(
@@ -314,6 +321,7 @@ class TestGetAgentState:
         assert data["wake_condition"]["type"] == "waitset"
         assert data["wake_condition"]["wait_for"] == ["child-1", "child-2"]
         assert data["wake_condition"]["completed_ids"] == ["child-1"]
+        assert data["last_run_result"] is None
 
     @pytest.mark.asyncio
     async def test_get_with_delay_wake(self, client):
@@ -333,6 +341,15 @@ class TestGetAgentState:
         resp = await client.get("/api/scheduler/states/child-2")
         assert resp.status_code == 200
         assert resp.json()["root_state_id"] == "parent-1"
+
+    @pytest.mark.asyncio
+    async def test_get_completed_child_exposes_last_run_result(self, client):
+        await _seed_states(client)
+        resp = await client.get("/api/scheduler/states/child-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["last_run_result"]["run_id"] == "run-child-1"
+        assert data["last_run_result"]["termination_reason"] == "completed"
 
     @pytest.mark.asyncio
     async def test_get_nonexistent(self, client):

--- a/console/tests/test_sessions_api.py
+++ b/console/tests/test_sessions_api.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from agiwo.agent import TerminationReason
 from agiwo.agent.models.run import Run, RunMetrics, RunStatus
 from agiwo.agent.models.step import MessageRole, StepMetrics, StepRecord
 from agiwo.scheduler.engine import Scheduler
@@ -12,6 +13,7 @@ from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
     AgentStateStorageConfig,
+    SchedulerRunResult,
     SchedulerConfig,
 )
 
@@ -277,6 +279,11 @@ async def test_get_session_detail_returns_summary_session_and_root_scheduler_sta
             status=AgentStateStatus.WAITING,
             task="wait for child",
             result_summary="waiting",
+            last_run_result=SchedulerRunResult(
+                run_id="run-last",
+                termination_reason=TerminationReason.TIMEOUT,
+                error="took too long",
+            ),
         )
     )
 
@@ -290,6 +297,10 @@ async def test_get_session_detail_returns_summary_session_and_root_scheduler_sta
     assert "scheduler_state_id" not in payload["session"]
     assert payload["scheduler_state"]["id"] == "session-a"
     assert payload["scheduler_state"]["status"] == "waiting"
+    assert payload["scheduler_state"]["last_run_result"]["run_id"] == "run-last"
+    assert (
+        payload["scheduler_state"]["last_run_result"]["termination_reason"] == "timeout"
+    )
 
 
 @pytest.mark.asyncio

--- a/console/web/src/app/agents/[id]/scheduler-chat/page.tsx
+++ b/console/web/src/app/agents/[id]/scheduler-chat/page.tsx
@@ -50,6 +50,8 @@ import {
   getHighestMessageSequence,
   messagesFromSteps,
 } from "@/lib/chat-types";
+import { getSchedulerRunResultView } from "@/lib/scheduler-run-result";
+import { formatLocalDateTime } from "@/lib/time";
 import { formatWakeConditionSummary } from "@/lib/wake-condition";
 
 type OrchestrationStatus =
@@ -94,6 +96,9 @@ function statusFromSchedulerState(
 ): OrchestrationStatus {
   if (!state) {
     return fallback;
+  }
+  if (state.last_run_result?.termination_reason === "cancelled") {
+    return "cancelled";
   }
   switch (state.status) {
     case "running":
@@ -549,8 +554,6 @@ function SchedulerChatPageContent() {
     return () => {
       cancelled = true;
     };
-    // Note: handleSessionCreatedRef is stable; handleSessionCreated intentionally excluded
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent, agentId, sessionId]);
 
   const handleSessionSwitch = async (targetSessionId: string) => {
@@ -791,19 +794,41 @@ function SchedulerChatPageContent() {
               Root State
             </div>
             {rootState ? (
-              <>
-                <UserInputCompact input={rootState.task} maxLength={140} />
-                {rootState.wake_condition && (
-                  <p className="text-xs text-zinc-500">
-                    {formatWakeConditionSummary(rootState.wake_condition)}
-                  </p>
-                )}
-                {rootState.result_summary && (
-                  <p className="text-xs text-zinc-400 whitespace-pre-wrap">
-                    {rootState.result_summary}
-                  </p>
-                )}
-              </>
+              (() => {
+                const rootResult = getSchedulerRunResultView(
+                  rootState.last_run_result,
+                  rootState.result_summary,
+                );
+                return (
+                  <>
+                    <UserInputCompact input={rootState.task} maxLength={140} />
+                    {rootState.wake_condition && (
+                      <p className="text-xs text-zinc-500">
+                        {formatWakeConditionSummary(rootState.wake_condition)}
+                      </p>
+                    )}
+                    {rootResult && (
+                      <div className="space-y-1 text-xs">
+                        <div className="flex flex-wrap items-center gap-2 text-zinc-500">
+                          {rootResult.reasonLabel && (
+                            <span className="rounded-full border border-zinc-700 px-2 py-0.5 text-zinc-300">
+                              {rootResult.reasonLabel}
+                            </span>
+                          )}
+                          {rootResult.completedAt && (
+                            <span>{formatLocalDateTime(rootResult.completedAt)}</span>
+                          )}
+                        </div>
+                        {rootResult.message && (
+                          <p className="text-zinc-400 whitespace-pre-wrap">
+                            {rootResult.message}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </>
+                );
+              })()
             ) : (
               <p className="text-xs text-zinc-600">No active root state</p>
             )}
@@ -878,41 +903,62 @@ function SchedulerChatPageContent() {
                   </button>
 
                   {expandedChildren.has(child.id) && (
-                    <div className="px-3 pb-3 border-t border-zinc-800">
-                      {child.result_summary && (
-                        <div className="mt-2 text-xs text-zinc-400 whitespace-pre-wrap max-h-32 overflow-auto">
-                          <span className="text-zinc-500 font-medium">Result: </span>
-                          {child.result_summary.slice(0, 500)}
-                        </div>
-                      )}
-                      {(childMessages[child.id] || []).length > 0 && (
-                        <div className="mt-2 space-y-2 max-h-48 overflow-auto">
-                          {(childMessages[child.id] || []).map((message) => (
-                            <div key={message.id} className="text-[11px]">
-                              <span
-                                className={`font-medium ${
-                                  message.role === "assistant"
-                                    ? "text-green-400"
-                                    : message.role === "tool"
-                                      ? "text-amber-400"
-                                      : "text-zinc-400"
-                                }`}
-                              >
-                                {message.role}
-                                {message.name ? ` — ${message.name}` : ""}:
-                              </span>{" "}
-                              <span className="text-zinc-400 whitespace-pre-wrap">
-                                {(message.text || "").slice(0, 300)}
-                                {(message.text || "").length > 300 ? "..." : ""}
-                              </span>
-                              {message.isStreaming && (
-                                <Loader2 className="inline w-2.5 h-2.5 ml-1 animate-spin text-zinc-500" />
+                    (() => {
+                      const childResult = getSchedulerRunResultView(
+                        child.last_run_result,
+                        child.result_summary,
+                      );
+                      return (
+                        <div className="px-3 pb-3 border-t border-zinc-800">
+                          {childResult && (
+                            <div className="mt-2 space-y-1 text-xs">
+                              <div className="flex flex-wrap items-center gap-2 text-zinc-500">
+                                {childResult.reasonLabel && (
+                                  <span className="rounded-full border border-zinc-700 px-2 py-0.5 text-zinc-300">
+                                    {childResult.reasonLabel}
+                                  </span>
+                                )}
+                                {childResult.completedAt && (
+                                  <span>{formatLocalDateTime(childResult.completedAt)}</span>
+                                )}
+                              </div>
+                              {childResult.message && (
+                                <div className="text-zinc-400 whitespace-pre-wrap max-h-32 overflow-auto">
+                                  {childResult.message.slice(0, 500)}
+                                </div>
                               )}
                             </div>
-                          ))}
+                          )}
+                          {(childMessages[child.id] || []).length > 0 && (
+                            <div className="mt-2 space-y-2 max-h-48 overflow-auto">
+                              {(childMessages[child.id] || []).map((message) => (
+                                <div key={message.id} className="text-[11px]">
+                                  <span
+                                    className={`font-medium ${
+                                      message.role === "assistant"
+                                        ? "text-green-400"
+                                        : message.role === "tool"
+                                          ? "text-amber-400"
+                                          : "text-zinc-400"
+                                    }`}
+                                  >
+                                    {message.role}
+                                    {message.name ? ` — ${message.name}` : ""}:
+                                  </span>{" "}
+                                  <span className="text-zinc-400 whitespace-pre-wrap">
+                                    {(message.text || "").slice(0, 300)}
+                                    {(message.text || "").length > 300 ? "..." : ""}
+                                  </span>
+                                  {message.isStreaming && (
+                                    <Loader2 className="inline w-2.5 h-2.5 ml-1 animate-spin text-zinc-500" />
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </div>
+                      );
+                    })()
                   )}
                 </div>
               ))

--- a/console/web/src/app/agents/page.tsx
+++ b/console/web/src/app/agents/page.tsx
@@ -141,18 +141,18 @@ export default function AgentsPage() {
                 </p>
               )}
 
-              {agent.tools && agent.tools.length > 0 && (
+              {agent.allowed_tools && agent.allowed_tools.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mt-3">
-                  {agent.tools.slice(0, 6).map((t) => (
+                  {agent.allowed_tools.slice(0, 6).map((toolName) => (
                     <PillBadge
-                      key={t}
-                      variant={t.startsWith("agent:") ? "info" : "default"}
+                      key={toolName}
+                      variant={toolName.startsWith("agent:") ? "info" : "default"}
                     >
-                      {t.startsWith("agent:") ? t.slice(6) : t}
+                      {toolName.startsWith("agent:") ? toolName.slice(6) : toolName}
                     </PillBadge>
                   ))}
-                  {agent.tools.length > 6 && (
-                    <PillBadge variant="default">+{agent.tools.length - 6}</PillBadge>
+                  {agent.allowed_tools.length > 6 && (
+                    <PillBadge variant="default">+{agent.allowed_tools.length - 6}</PillBadge>
                   )}
                 </div>
               )}

--- a/console/web/src/app/scheduler/[id]/page.tsx
+++ b/console/web/src/app/scheduler/[id]/page.tsx
@@ -35,6 +35,7 @@ import {
   formatUsd,
   normalizeRunMetricsSummary,
 } from "@/lib/metrics";
+import { getSchedulerRunResultView, type SchedulerRunResultTone } from "@/lib/scheduler-run-result";
 import { formatLocalDateTime } from "@/lib/time";
 import {
   formatWakeConditionTimer,
@@ -123,6 +124,19 @@ function DetailChip({
       <div className="mt-1 break-all text-sm text-ink-soft">{value}</div>
     </div>
   );
+}
+
+function runResultToneClass(tone: SchedulerRunResultTone): string {
+  switch (tone) {
+    case "success":
+      return "bg-success/15 text-success";
+    case "warning":
+      return "bg-warning/15 text-warning";
+    case "danger":
+      return "bg-danger/15 text-danger";
+    default:
+      return "bg-panel-strong text-ink-soft";
+  }
 }
 
 /**
@@ -242,6 +256,10 @@ function ChildrenTable({ items }: { items: AgentStateListItem[] }) {
         <tbody className="divide-y divide-line">
           {items.map((c) => {
             const metrics = normalizeRunMetricsSummary(c.metrics);
+            const resultView = getSchedulerRunResultView(
+              c.last_run_result,
+              c.result_summary,
+            );
             return (
               <tr key={c.id} className="transition-colors hover:bg-panel-muted">
                 <td className="px-4 py-2.5">
@@ -262,7 +280,22 @@ function ChildrenTable({ items }: { items: AgentStateListItem[] }) {
                   {formatTokenCount(metrics.input_tokens)} / {formatTokenCount(metrics.output_tokens)} / {formatTokenCount(metrics.total_tokens)}
                 </td>
                 <td className="max-w-xs truncate px-4 py-2.5 text-xs text-ink-muted">
-                  {c.result_summary || "-"}
+                  {resultView ? (
+                    <div className="space-y-1">
+                      {resultView.reasonLabel && (
+                        <span
+                          className={`inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium ${runResultToneClass(resultView.tone)}`}
+                        >
+                          {resultView.reasonLabel}
+                        </span>
+                      )}
+                      <div className="truncate text-ink-muted">
+                        {resultView.message || "-"}
+                      </div>
+                    </div>
+                  ) : (
+                    "-"
+                  )}
                 </td>
               </tr>
             );
@@ -536,6 +569,14 @@ export default function SchedulerDetailPage() {
     Boolean(taskContext.source) ||
     attachmentCount > 0 ||
     taskContextEntries.length > 0;
+  const resultView = getSchedulerRunResultView(
+    state.last_run_result,
+    state.result_summary,
+  );
+  const configuredTools =
+    agentConfig?.allowed_tools === null
+      ? "default"
+      : String(agentConfig?.allowed_tools?.length ?? 0);
 
   return (
     <div className="p-6 max-w-5xl mx-auto space-y-6">
@@ -672,7 +713,15 @@ export default function SchedulerDetailPage() {
               <DetailChip label="Temperature" value={agentConfig.model_params?.temperature ?? "-"} />
               <DetailChip label="Max Output" value={agentConfig.model_params?.max_output_tokens ?? "-"} />
               <DetailChip label="Context Window" value={agentConfig.model_params?.max_context_window ?? "-"} />
-              <DetailChip label="Tools" value={agentConfig.tools.length} />
+              <DetailChip label="Tools" value={configuredTools} />
+              <DetailChip
+                label="Skills"
+                value={
+                  agentConfig.allowed_skills === null
+                    ? "all"
+                    : String(agentConfig.allowed_skills.length)
+                }
+              />
               {agentConfig.model_params?.base_url && (
                 <DetailChip label="Base URL" value={agentConfig.model_params.base_url} />
               )}
@@ -705,16 +754,52 @@ export default function SchedulerDetailPage() {
         </div>
       </SectionCard>
 
-      {state.result_summary && (
+      {resultView && (
         <SectionCard
-          title="Result Summary"
+          title="Last Run Result"
           className="p-4"
           headerClassName="mb-2"
           titleClassName="text-sm font-medium"
         >
-          <p className="text-sm whitespace-pre-wrap text-ink-soft">
-            {state.result_summary}
-          </p>
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-3">
+              {resultView.reasonLabel && (
+                <DetailChip
+                  label="Termination"
+                  value={
+                    <span
+                      className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${runResultToneClass(resultView.tone)}`}
+                    >
+                      {resultView.reasonLabel}
+                    </span>
+                  }
+                  tone="accent"
+                />
+              )}
+              {resultView.completedAt && (
+                <DetailChip
+                  label="Completed"
+                  value={formatLocalDateTime(resultView.completedAt)}
+                />
+              )}
+              {resultView.runId && (
+                <DetailChip
+                  label="Run ID"
+                  value={<MonoText>{resultView.runId}</MonoText>}
+                />
+              )}
+            </div>
+            {resultView.error && (
+              <div className="rounded-lg border border-danger/30 bg-danger/10 p-3 text-sm whitespace-pre-wrap text-danger">
+                {resultView.error}
+              </div>
+            )}
+            {resultView.summary && resultView.summary !== resultView.error && (
+              <p className="text-sm whitespace-pre-wrap text-ink-soft">
+                {resultView.summary}
+              </p>
+            )}
+          </div>
         </SectionCard>
       )}
 

--- a/console/web/src/app/scheduler/page.tsx
+++ b/console/web/src/app/scheduler/page.tsx
@@ -157,7 +157,7 @@ function SchedulerPageContent() {
     if (hasLoadedRef.current) {
       void loadData();
     }
-  }, [filter, offset, pageSize]);
+  }, [loadData]);
 
   useEffect(() => {
     if (hasLoadedRef.current) {
@@ -165,7 +165,7 @@ function SchedulerPageContent() {
     }
     hasLoadedRef.current = true;
     void loadData();
-  }, []);
+  }, [loadData]);
 
   useEffect(() => {
     if (!autoRefresh || !isPageVisible) {

--- a/console/web/src/app/sessions/[id]/page.tsx
+++ b/console/web/src/app/sessions/[id]/page.tsx
@@ -34,6 +34,8 @@ import {
   normalizeRunMetricsSummary,
   parseGenericMetrics,
 } from "@/lib/metrics";
+import { getSchedulerRunResultView } from "@/lib/scheduler-run-result";
+import { formatLocalDateTime } from "@/lib/time";
 
 function StepCardOriginalToggle({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
@@ -224,6 +226,10 @@ export default function SessionDetailPage() {
   }
 
   const runTotals = normalizeRunMetricsSummary(detail?.summary.metrics);
+  const schedulerResult = getSchedulerRunResultView(
+    detail?.scheduler_state?.last_run_result,
+    detail?.scheduler_state?.result_summary,
+  );
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -294,7 +300,7 @@ export default function SessionDetailPage() {
             }
           />
 
-          <div className="grid gap-3 md:grid-cols-3">
+          <div className="grid gap-3 md:grid-cols-4">
             <MetricCard
               label="Base Agent"
               value={<MonoText>{detail.summary.base_agent_id || "-"}</MonoText>}
@@ -307,7 +313,45 @@ export default function SessionDetailPage() {
               label="Scheduler Status"
               value={detail.summary.root_state_status || "Not started"}
             />
+            <MetricCard
+              label="Last Run"
+              value={schedulerResult?.reasonLabel || (schedulerResult ? "Summary" : "-")}
+            />
           </div>
+
+          {schedulerResult && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4 space-y-3">
+              <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-zinc-500">
+                <Workflow className="h-3.5 w-3.5" />
+                Scheduler Run Result
+              </div>
+              <div className="flex flex-wrap gap-3 text-xs text-zinc-500">
+                {schedulerResult.reasonLabel && (
+                  <span className="rounded-full border border-zinc-700 px-2 py-1 text-zinc-200">
+                    {schedulerResult.reasonLabel}
+                  </span>
+                )}
+                {schedulerResult.completedAt && (
+                  <span>Completed {formatLocalDateTime(schedulerResult.completedAt)}</span>
+                )}
+                {schedulerResult.runId && (
+                  <span>
+                    Run <MonoText>{schedulerResult.runId}</MonoText>
+                  </span>
+                )}
+              </div>
+              {schedulerResult.error && (
+                <div className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm whitespace-pre-wrap text-red-300">
+                  {schedulerResult.error}
+                </div>
+              )}
+              {schedulerResult.summary && schedulerResult.summary !== schedulerResult.error && (
+                <p className="text-sm whitespace-pre-wrap text-zinc-300">
+                  {schedulerResult.summary}
+                </p>
+              )}
+            </div>
+          )}
 
           <div className="rounded-lg border border-zinc-800 overflow-x-auto">
             <table className="w-full text-sm">

--- a/console/web/src/components/scheduler-tree/node-inspector.tsx
+++ b/console/web/src/components/scheduler-tree/node-inspector.tsx
@@ -6,6 +6,7 @@ import { SectionCard } from "@/components/section-card";
 import { EmptyStateMessage, ErrorStateMessage } from "@/components/state-message";
 import { UserInputDetail } from "@/components/user-input-detail";
 import type { AgentStateDetail, PendingEventItem, SchedulerTreeNode } from "@/lib/api";
+import { getSchedulerRunResultView } from "@/lib/scheduler-run-result";
 import { formatLocalDateTime } from "@/lib/time";
 import { formatWakeConditionSummary } from "@/lib/wake-condition";
 
@@ -42,6 +43,11 @@ export function NodeInspector({
       </SectionCard>
     );
   }
+
+  const resultView = getSchedulerRunResultView(
+    detail?.last_run_result ?? node.last_run_result,
+    detail?.result_summary ?? node.last_error ?? node.result_summary,
+  );
 
   return (
     <SectionCard title="Inspector" bodyClassName="p-4 space-y-4">
@@ -92,13 +98,37 @@ export function NodeInspector({
         </div>
       )}
 
-      {(node.result_summary || node.last_error) && (
+      {resultView && (
         <div className="space-y-2">
           <div className="text-xs uppercase tracking-wide text-zinc-500">
-            Result / Error
+            Last Run Result
           </div>
-          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 text-sm text-zinc-200 whitespace-pre-wrap">
-            {node.last_error ?? node.result_summary}
+          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 space-y-3">
+            <div className="flex flex-wrap gap-3 text-xs text-zinc-500">
+              {resultView.reasonLabel && (
+                <span className="rounded-full border border-zinc-700 px-2 py-1 text-zinc-200">
+                  {resultView.reasonLabel}
+                </span>
+              )}
+              {resultView.completedAt && (
+                <span>Completed {formatLocalDateTime(resultView.completedAt)}</span>
+              )}
+              {resultView.runId && (
+                <span>
+                  Run <MonoText>{resultView.runId}</MonoText>
+                </span>
+              )}
+            </div>
+            {resultView.error && (
+              <div className="text-sm text-red-300 whitespace-pre-wrap">
+                {resultView.error}
+              </div>
+            )}
+            {resultView.summary && resultView.summary !== resultView.error && (
+              <div className="text-sm text-zinc-200 whitespace-pre-wrap">
+                {resultView.summary}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/console/web/src/components/scheduler-tree/scheduler-tree-workspace.test.tsx
+++ b/console/web/src/components/scheduler-tree/scheduler-tree-workspace.test.tsx
@@ -61,6 +61,7 @@ const tree = {
       pending_event_count: 1,
       last_error: null,
       result_summary: null,
+      last_run_result: null,
     },
     {
       state_id: "child-1",
@@ -79,6 +80,13 @@ const tree = {
       pending_event_count: 0,
       last_error: null,
       result_summary: "done",
+      last_run_result: {
+        run_id: "run-child-1",
+        termination_reason: "completed",
+        summary: "done",
+        error: null,
+        completed_at: "2026-04-02T00:00:03Z",
+      },
     },
   ],
 } as const;
@@ -94,6 +102,7 @@ const rootDetail = {
   config_overrides: {},
   wake_condition: null,
   result_summary: null,
+  last_run_result: null,
   signal_propagated: false,
   agent_config_id: null,
   is_persistent: true,
@@ -145,6 +154,13 @@ describe("SchedulerTreeWorkspace", () => {
       parent_id: "root-1",
       is_persistent: false,
       result_summary: "done",
+      last_run_result: {
+        run_id: "run-child-1",
+        termination_reason: "completed",
+        summary: "done",
+        error: null,
+        completed_at: "2026-04-02T00:00:03Z",
+      },
     });
     apiMocks.getPendingEvents.mockResolvedValue([]);
     const onSelectedStateIdChange = vi.fn();

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -613,6 +613,14 @@ export interface WakeConditionResponse {
   timeout_at: string | null;
 }
 
+export interface SchedulerRunResult {
+  run_id: string | null;
+  termination_reason: string;
+  summary: string | null;
+  error: string | null;
+  completed_at: string | null;
+}
+
 export interface AgentStateListItem {
   id: string;
   root_state_id: string | null;
@@ -621,6 +629,7 @@ export interface AgentStateListItem {
   parent_id: string | null;
   wake_condition: WakeConditionResponse | null;
   result_summary: string | null;
+  last_run_result: SchedulerRunResult | null;
   agent_config_id: string | null;
   is_persistent: boolean;
   depth: number;
@@ -641,6 +650,7 @@ export interface AgentStateDetail {
   config_overrides: Record<string, unknown>;
   wake_condition: WakeConditionResponse | null;
   result_summary: string | null;
+  last_run_result: SchedulerRunResult | null;
   signal_propagated: boolean;
   agent_config_id: string | null;
   is_persistent: boolean;
@@ -690,6 +700,7 @@ export interface SchedulerTreeNode {
   pending_event_count: number;
   last_error: string | null;
   result_summary: string | null;
+  last_run_result: SchedulerRunResult | null;
 }
 
 export interface SchedulerTree {

--- a/console/web/src/lib/scheduler-run-result.test.ts
+++ b/console/web/src/lib/scheduler-run-result.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  formatSchedulerTerminationReason,
+  getSchedulerRunResultTone,
+  getSchedulerRunResultView,
+} from "./scheduler-run-result";
+
+describe("scheduler-run-result helpers", () => {
+  test("formats known termination reasons and derives tone", () => {
+    expect(formatSchedulerTerminationReason("cancelled")).toBe("Cancelled");
+    expect(
+      getSchedulerRunResultTone({
+        run_id: "run-1",
+        termination_reason: "timeout",
+        summary: "Timed out",
+        error: null,
+        completed_at: "2026-04-14T00:00:00Z",
+      }),
+    ).toBe("warning");
+  });
+
+  test("falls back to legacy summary when no structured result exists", () => {
+    expect(getSchedulerRunResultView(null, "legacy summary")).toEqual({
+      reasonLabel: null,
+      tone: "neutral",
+      summary: "legacy summary",
+      error: null,
+      message: "legacy summary",
+      completedAt: null,
+      runId: null,
+    });
+  });
+
+  test("prefers explicit error over summary for message rendering", () => {
+    expect(
+      getSchedulerRunResultView(
+        {
+          run_id: "run-2",
+          termination_reason: "error",
+          summary: "step failed",
+          error: "tool crashed",
+          completed_at: "2026-04-14T00:00:00Z",
+        },
+        "legacy summary",
+      ),
+    ).toMatchObject({
+      reasonLabel: "Errored",
+      tone: "danger",
+      summary: "step failed",
+      error: "tool crashed",
+      message: "tool crashed",
+    });
+  });
+});

--- a/console/web/src/lib/scheduler-run-result.ts
+++ b/console/web/src/lib/scheduler-run-result.ts
@@ -1,0 +1,78 @@
+import type { SchedulerRunResult } from "./api";
+
+export type SchedulerRunResultTone = "success" | "warning" | "danger" | "neutral";
+
+const TERMINATION_REASON_LABELS: Record<string, string> = {
+  cancelled: "Cancelled",
+  completed: "Completed",
+  error: "Errored",
+  failed: "Failed",
+  max_turns: "Max turns reached",
+  no_progress: "No progress",
+  sleeping: "Sleeping",
+  timeout: "Timed out",
+};
+
+export type SchedulerRunResultView = {
+  reasonLabel: string | null;
+  tone: SchedulerRunResultTone;
+  summary: string | null;
+  error: string | null;
+  message: string | null;
+  completedAt: string | null;
+  runId: string | null;
+};
+
+export function formatSchedulerTerminationReason(reason: string | null | undefined): string {
+  if (!reason) {
+    return "Unknown";
+  }
+  const label = TERMINATION_REASON_LABELS[reason];
+  if (label) {
+    return label;
+  }
+  return reason
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function getSchedulerRunResultTone(
+  result: SchedulerRunResult | null | undefined,
+): SchedulerRunResultTone {
+  const reason = result?.termination_reason;
+  if (reason === "completed") {
+    return "success";
+  }
+  if (reason === "cancelled" || reason === "timeout" || reason === "sleeping") {
+    return "warning";
+  }
+  if (reason) {
+    return "danger";
+  }
+  return "neutral";
+}
+
+export function getSchedulerRunResultView(
+  result: SchedulerRunResult | null | undefined,
+  fallbackSummary?: string | null,
+): SchedulerRunResultView | null {
+  const summary = result?.summary ?? fallbackSummary ?? null;
+  const error = result?.error ?? null;
+  const message = error ?? summary;
+
+  if (!result && !message) {
+    return null;
+  }
+
+  return {
+    reasonLabel: result ? formatSchedulerTerminationReason(result.termination_reason) : null,
+    tone: getSchedulerRunResultTone(result),
+    summary,
+    error,
+    message,
+    completedAt: result?.completed_at ?? null,
+    runId: result?.run_id ?? null,
+  };
+}

--- a/console/web/src/lib/scheduler-tree.test.ts
+++ b/console/web/src/lib/scheduler-tree.test.ts
@@ -39,6 +39,7 @@ const tree: SchedulerTree = {
       pending_event_count: 1,
       last_error: null,
       result_summary: null,
+      last_run_result: null,
     },
     {
       state_id: "child-1",
@@ -57,6 +58,7 @@ const tree: SchedulerTree = {
       pending_event_count: 2,
       last_error: null,
       result_summary: null,
+      last_run_result: null,
     },
     {
       state_id: "child-2",
@@ -75,6 +77,13 @@ const tree: SchedulerTree = {
       pending_event_count: 0,
       last_error: "Cancelled by operator",
       result_summary: "Cancelled by operator",
+      last_run_result: {
+        run_id: "run-cancelled",
+        termination_reason: "cancelled",
+        summary: "Cancelled by operator",
+        error: null,
+        completed_at: "2026-04-02T00:02:05Z",
+      },
     },
     {
       state_id: "grandchild-1",
@@ -93,6 +102,13 @@ const tree: SchedulerTree = {
       pending_event_count: 0,
       last_error: null,
       result_summary: "done",
+      last_run_result: {
+        run_id: "run-completed",
+        termination_reason: "completed",
+        summary: "done",
+        error: null,
+        completed_at: "2026-04-02T00:03:05Z",
+      },
     },
   ],
 };

--- a/docs/superpowers/plans/2026-04-14-scheduler-semantics-alignment.md
+++ b/docs/superpowers/plans/2026-04-14-scheduler-semantics-alignment.md
@@ -1,0 +1,806 @@
+# Scheduler Semantics Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make scheduler run outcomes explicit and durable, remove root stream subscription races, align Console default-agent/tool/skill permission semantics, and expose `last_run_result` through Console APIs.
+
+**Architecture:** The implementation keeps scheduler lifecycle in `AgentState.status` and adds a scheduler-owned `last_run_result` record for the most recent agent-cycle outcome. Scheduler runner and engine become responsible for writing and reading that outcome, scheduler stores persist it, and Console serializers/API models expose it directly. The stream race fix is handled independently by opening the root stream channel before submit/enqueue/steer operations can emit events.
+
+**Tech Stack:** Python 3.11+, dataclasses, FastAPI/Pydantic, SQLite (`aiosqlite`), pytest, ruff
+
+---
+
+## File Map
+
+- `agiwo/scheduler/models.py`
+  - Add `SchedulerRunResult`
+  - Add `AgentState.last_run_result`
+  - Add state helpers for clearing/writing the last run result
+- `agiwo/scheduler/store/codec.py`
+  - Add store encode/decode helpers for `SchedulerRunResult`
+- `agiwo/scheduler/store/memory.py`
+  - Ensure in-memory storage preserves `last_run_result`
+- `agiwo/scheduler/store/sqlite.py`
+  - Persist `last_run_result` columns
+  - Decode rows into `SchedulerRunResult`
+- `agiwo/scheduler/runner.py`
+  - Write `last_run_result` on completed/failed terminal cycle ends
+  - Clear old result on cycle start
+  - Keep `SLEEPING` out of durable terminal results
+- `agiwo/scheduler/engine.py`
+  - Make `wait_for()` return `RunOutput` from `last_run_result`
+- `agiwo/scheduler/_stream.py`
+  - Open root stream channel before the routing operation begins
+- `console/server/models/view.py`
+  - Add API view model for `last_run_result`
+- `console/server/response_serialization.py`
+  - Serialize `last_run_result` into scheduler/session API payloads
+- `console/server/services/runtime/agent_factory.py`
+  - Treat `allowed_tools=None` and `allowed_tools=[]` differently
+- `console/server/services/runtime/agent_runtime_cache.py`
+  - Include `allowed_skills` in runtime cache invalidation snapshots
+- `console/server/routers/sessions.py`
+  - Use `last_run_result` in the SSE fallback acknowledgment path
+- `tests/scheduler/test_models.py`
+  - Model/helper tests for `SchedulerRunResult` and state transitions
+- `tests/scheduler/test_store.py`
+  - Memory and SQLite round-trip coverage
+- `tests/scheduler/test_scheduler.py`
+  - Scheduler result semantics and stream race coverage
+- `console/tests/test_response_serialization.py`
+  - Console serializer coverage for `last_run_result`
+- `console/tests/test_sessions_api.py`
+  - Session detail/API and SSE fallback coverage
+- `console/tests/test_scheduler_api.py`
+  - Scheduler API payload coverage
+- `console/tests/test_config_env.py`
+  - Default-agent `allowed_tools=[]` semantics
+- `console/tests/test_agent_runtime_components.py`
+  - Runtime cache invalidation on `allowed_skills`
+
+### Task 1: Add Scheduler Run Result Model and State Helpers
+
+**Files:**
+- Modify: `agiwo/scheduler/models.py`
+- Test: `tests/scheduler/test_models.py`
+
+- [ ] **Step 1: Write the failing model tests**
+
+```python
+from agiwo.agent import TerminationReason
+from agiwo.scheduler.models import (
+    AgentState,
+    AgentStateStatus,
+    SchedulerRunResult,
+)
+
+
+def test_agent_state_with_running_clears_last_run_result() -> None:
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.IDLE,
+        task="hello",
+        is_persistent=True,
+        last_run_result=SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.COMPLETED,
+            summary="done",
+        ),
+    )
+
+    updated = state.with_running(task="next task")
+
+    assert updated.status == AgentStateStatus.RUNNING
+    assert updated.last_run_result is None
+
+
+def test_agent_state_with_idle_preserves_written_last_run_result() -> None:
+    result = SchedulerRunResult(
+        run_id="run-2",
+        termination_reason=TerminationReason.CANCELLED,
+        error="cancelled by user",
+    )
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.RUNNING,
+        task="hello",
+    )
+
+    updated = state.with_idle(result_summary="cancelled").with_updates(
+        last_run_result=result
+    )
+
+    assert updated.status == AgentStateStatus.IDLE
+    assert updated.last_run_result == result
+```
+
+- [ ] **Step 2: Run the model tests to confirm the field/helper gap**
+
+Run: `uv run pytest tests/scheduler/test_models.py -v`
+Expected: FAIL with `ImportError`/`TypeError` because `SchedulerRunResult` and `last_run_result` do not exist yet.
+
+- [ ] **Step 3: Add the scheduler run-result model and state field**
+
+```python
+@dataclass(frozen=True, slots=True)
+class SchedulerRunResult:
+    run_id: str | None
+    termination_reason: TerminationReason
+    summary: str | None = None
+    error: str | None = None
+    completed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True, slots=True)
+class AgentState:
+    id: str
+    session_id: str
+    status: AgentStateStatus
+    task: UserInput
+    pending_input: UserInput | None = None
+    wake_condition: WakeCondition | None = None
+    result_summary: str | None = None
+    explain: str | None = None
+    last_run_result: SchedulerRunResult | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def with_running(
+        self,
+        *,
+        task: UserInput | _UnsetType = _UNSET,
+        pending_input: UserInput | None | _UnsetType = _UNSET,
+    ) -> "AgentState":
+        return self.with_updates(
+            status=AgentStateStatus.RUNNING,
+            task=self.task if task is _UNSET else task,
+            pending_input=self.pending_input if pending_input is _UNSET else pending_input,
+            last_run_result=None,
+            no_progress=False,
+        )
+```
+
+- [ ] **Step 4: Re-run the targeted model tests**
+
+Run: `uv run pytest tests/scheduler/test_models.py -v`
+Expected: PASS for the new `last_run_result` tests and no regressions in existing model tests.
+
+- [ ] **Step 5: Commit the model boundary**
+
+```bash
+git add agiwo/scheduler/models.py tests/scheduler/test_models.py
+git commit -m "feat: add scheduler last run result model"
+```
+
+### Task 2: Persist `last_run_result` in Scheduler Stores
+
+**Files:**
+- Modify: `agiwo/scheduler/store/codec.py`
+- Modify: `agiwo/scheduler/store/sqlite.py`
+- Test: `tests/scheduler/test_store.py`
+
+- [ ] **Step 1: Write failing store round-trip tests**
+
+```python
+from agiwo.agent import TerminationReason
+from agiwo.scheduler.models import (
+    AgentState,
+    AgentStateStatus,
+    SchedulerRunResult,
+)
+from agiwo.scheduler.store.memory import InMemoryAgentStateStorage
+from agiwo.scheduler.store.sqlite import SQLiteAgentStateStorage
+
+
+@pytest.mark.asyncio
+async def test_memory_store_round_trips_last_run_result() -> None:
+    store = InMemoryAgentStateStorage()
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.IDLE,
+        task="hello",
+        last_run_result=SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.COMPLETED,
+            summary="done",
+        ),
+    )
+
+    await store.save_state(state)
+    loaded = await store.get_state("root")
+
+    assert loaded is not None
+    assert loaded.last_run_result is not None
+    assert loaded.last_run_result.termination_reason == TerminationReason.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_round_trips_last_run_result(tmp_path) -> None:
+    store = SQLiteAgentStateStorage(str(tmp_path / "scheduler.db"))
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.FAILED,
+        task="hello",
+        last_run_result=SchedulerRunResult(
+            run_id="run-2",
+            termination_reason=TerminationReason.ERROR,
+            error="boom",
+        ),
+    )
+
+    await store.save_state(state)
+    loaded = await store.get_state("root")
+
+    assert loaded is not None
+    assert loaded.last_run_result is not None
+    assert loaded.last_run_result.error == "boom"
+```
+
+- [ ] **Step 2: Run the store tests and verify they fail on missing persistence**
+
+Run: `uv run pytest tests/scheduler/test_store.py -v`
+Expected: FAIL because `last_run_result` is not serialized or loaded by the store layer.
+
+- [ ] **Step 3: Add codec helpers and SQLite columns**
+
+```python
+def serialize_scheduler_run_result_for_store(
+    result: SchedulerRunResult | None,
+) -> dict[str, Any] | None:
+    if result is None:
+        return None
+    return {
+        "run_id": result.run_id,
+        "termination_reason": result.termination_reason.value,
+        "summary": result.summary,
+        "error": result.error,
+        "completed_at": result.completed_at.isoformat(),
+    }
+
+
+def deserialize_scheduler_run_result_for_store(
+    data: dict[str, Any] | None,
+) -> SchedulerRunResult | None:
+    if not data:
+        return None
+    return SchedulerRunResult(
+        run_id=data.get("run_id"),
+        termination_reason=TerminationReason(data["termination_reason"]),
+        summary=data.get("summary"),
+        error=data.get("error"),
+        completed_at=datetime.fromisoformat(data["completed_at"]),
+    )
+```
+
+```sql
+ALTER TABLE shape for new installs in `CREATE TABLE IF NOT EXISTS agent_states`:
+last_run_id TEXT,
+last_run_termination_reason TEXT,
+last_run_summary TEXT,
+last_run_error TEXT,
+last_run_completed_at TEXT,
+```
+
+```python
+last_run = deserialize_scheduler_run_result_for_store(
+    {
+        "run_id": row["last_run_id"],
+        "termination_reason": row["last_run_termination_reason"],
+        "summary": row["last_run_summary"],
+        "error": row["last_run_error"],
+        "completed_at": row["last_run_completed_at"],
+    }
+    if row["last_run_termination_reason"]
+    else None
+)
+```
+
+- [ ] **Step 4: Re-run the store tests**
+
+Run: `uv run pytest tests/scheduler/test_store.py -v`
+Expected: PASS, with both in-memory and SQLite stores preserving `last_run_result`.
+
+- [ ] **Step 5: Commit store persistence**
+
+```bash
+git add agiwo/scheduler/store/codec.py agiwo/scheduler/store/sqlite.py tests/scheduler/test_store.py
+git commit -m "feat: persist scheduler last run results"
+```
+
+### Task 3: Make Runner and `wait_for()` Use `last_run_result`
+
+**Files:**
+- Modify: `agiwo/scheduler/runner.py`
+- Modify: `agiwo/scheduler/engine.py`
+- Test: `tests/scheduler/test_scheduler.py`
+
+- [ ] **Step 1: Write failing scheduler semantics tests**
+
+```python
+@pytest.mark.asyncio
+async def test_wait_for_returns_cancelled_from_last_run_result() -> None:
+    async with Scheduler(_fast_config()) as scheduler:
+        state = AgentState(
+            id="root",
+            session_id="sess-1",
+            status=AgentStateStatus.FAILED,
+            task="hello",
+            last_run_result=SchedulerRunResult(
+                run_id="run-1",
+                termination_reason=TerminationReason.CANCELLED,
+                error="cancelled by user",
+            ),
+        )
+        await scheduler._store.save_state(state)
+
+        result = await scheduler.wait_for("root", timeout=_TEST_RUN_TIMEOUT)
+
+        assert result.termination_reason == TerminationReason.CANCELLED
+        assert result.error == "cancelled by user"
+
+
+@pytest.mark.asyncio
+async def test_persistent_root_queued_keeps_previous_last_run_result() -> None:
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.IDLE,
+        task="hello",
+        is_persistent=True,
+        last_run_result=SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.COMPLETED,
+            summary="done",
+        ),
+    )
+
+    queued = state.with_queued(pending_input="next")
+
+    assert queued.last_run_result is not None
+    assert queued.last_run_result.summary == "done"
+```
+
+- [ ] **Step 2: Run the targeted scheduler tests**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py -v`
+Expected: FAIL because `wait_for()` still infers outcome from `status`, and runner paths do not write `last_run_result`.
+
+- [ ] **Step 3: Update runner terminal writes and `wait_for()` reads**
+
+```python
+def _build_last_run_result(output: RunOutput) -> SchedulerRunResult:
+    return SchedulerRunResult(
+        run_id=output.run_id,
+        termination_reason=output.termination_reason,
+        summary=output.response,
+        error=output.error,
+    )
+
+
+async def _handle_failed_output(
+    self,
+    state: AgentState,
+    output: RunOutput,
+    text: str | None,
+) -> bool:
+    if output.termination_reason not in _FAILED_TERMINATIONS:
+        return False
+    last_run_result = SchedulerRunResult(
+        run_id=output.run_id,
+        termination_reason=output.termination_reason,
+        summary=text,
+        error=reason,
+    )
+    await self._save_state(
+        state.with_failed(reason).with_updates(last_run_result=last_run_result)
+    )
+```
+
+```python
+async def wait_for(self, state_id: str, timeout: float | None = None) -> RunOutput:
+    while True:
+        state = await self._store.get_state(state_id)
+        if state is not None and state.last_run_result is not None:
+            last = state.last_run_result
+            return RunOutput(
+                run_id=last.run_id,
+                response=last.summary if last.error is None else None,
+                error=last.error,
+                termination_reason=last.termination_reason,
+            )
+        await asyncio.wait_for(event.wait(), timeout=remaining)
+```
+
+- [ ] **Step 4: Re-run the scheduler tests**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py -v`
+Expected: PASS for the new `last_run_result` semantics and existing scheduler lifecycle coverage.
+
+- [ ] **Step 5: Commit scheduler result semantics**
+
+```bash
+git add agiwo/scheduler/runner.py agiwo/scheduler/engine.py tests/scheduler/test_scheduler.py
+git commit -m "feat: align scheduler wait semantics with last run results"
+```
+
+### Task 4: Fix Root Stream Subscription Race
+
+**Files:**
+- Modify: `agiwo/scheduler/_stream.py`
+- Test: `tests/scheduler/test_scheduler.py`
+
+- [ ] **Step 1: Write the failing fast-run stream test**
+
+```python
+@pytest.mark.asyncio
+async def test_route_with_stream_opens_channel_before_fast_root_run() -> None:
+    async with Scheduler(_fast_config()) as scheduler:
+        model = MockModel([_simple_completion("hello")])
+        agent = _make_agent(name="test", model=model, id="root")
+
+        result = await scheduler.route_root_input(
+            "hello",
+            agent=agent,
+            state_id="root",
+            session_id="sess-1",
+            persistent=True,
+            stream_mode="run_end",
+        )
+
+        events = []
+        assert result.stream is not None
+        async for item in result.stream:
+            events.append(item.type)
+
+        assert "run_started" in events
+        assert "run_completed" in events
+```
+
+- [ ] **Step 2: Run the specific stream-race test**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py::test_route_with_stream_opens_channel_before_fast_root_run -v`
+Expected: FAIL intermittently or deterministically because the stream channel is opened after the routing operation.
+
+- [ ] **Step 3: Move stream-channel creation ahead of the operation**
+
+```python
+async def route_with_stream(
+    sched: "Scheduler",
+    *,
+    root_state_id: str,
+    action: str,
+    timeout: float | None,
+    include_child_events: bool,
+    close_on_root_run_end: bool,
+    operation: Callable[[], Awaitable[str]],
+) -> RouteResult:
+    if root_state_id in sched._rt.stream_channels:
+        raise RuntimeError(f"stream subscriber already active for root '{root_state_id}'")
+
+    open_stream_channel(
+        sched._rt.stream_channels,
+        root_state_id,
+        include_child_events=include_child_events,
+        close_on_root_run_end=close_on_root_run_end,
+    )
+    try:
+        state_id = await operation()
+    except Exception:
+        close_stream_channel(sched._rt.stream_channels, root_state_id)
+        raise
+
+    return RouteResult(
+        action=action,
+        state_id=state_id,
+        stream=build_stream(
+            sched,
+            root_state_id,
+            timeout=timeout,
+            include_child_events=include_child_events,
+            close_on_root_run_end=close_on_root_run_end,
+        ),
+    )
+```
+
+- [ ] **Step 4: Re-run the stream test**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py::test_route_with_stream_opens_channel_before_fast_root_run -v`
+Expected: PASS, with `run_started` and `run_completed` always observed.
+
+- [ ] **Step 5: Commit the race fix**
+
+```bash
+git add agiwo/scheduler/_stream.py tests/scheduler/test_scheduler.py
+git commit -m "fix: open scheduler stream channels before dispatch"
+```
+
+### Task 5: Expose `last_run_result` in Console Models and Responses
+
+**Files:**
+- Modify: `console/server/models/view.py`
+- Modify: `console/server/response_serialization.py`
+- Modify: `console/server/routers/sessions.py`
+- Test: `console/tests/test_response_serialization.py`
+- Test: `console/tests/test_scheduler_api.py`
+- Test: `console/tests/test_sessions_api.py`
+
+- [ ] **Step 1: Write failing Console response tests**
+
+```python
+def test_agent_state_response_includes_last_run_result() -> None:
+    state = AgentState(
+        id="root",
+        session_id="sess-1",
+        status=AgentStateStatus.IDLE,
+        task="hello",
+        last_run_result=SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.COMPLETED,
+            summary="done",
+        ),
+    )
+
+    payload = agent_state_response_from_sdk(state).model_dump()
+
+    assert payload["last_run_result"]["run_id"] == "run-1"
+    assert payload["last_run_result"]["termination_reason"] == "completed"
+
+
+def test_session_input_fallback_uses_last_run_result(client, runtime_app) -> None:
+    response = client.post(
+        "/api/sessions/sess-1/input",
+        json={"message": "continue"},
+    )
+    body = response.text
+    assert "last_run_result" in body
+```
+
+- [ ] **Step 2: Run the Console response tests**
+
+Run: `cd console && uv run pytest tests/test_response_serialization.py tests/test_scheduler_api.py tests/test_sessions_api.py -v`
+Expected: FAIL because the view models and SSE fallback path do not expose `last_run_result`.
+
+- [ ] **Step 3: Add the view model and serializer fields**
+
+```python
+class SchedulerRunResultResponse(BaseModel):
+    run_id: str | None = None
+    termination_reason: str
+    summary: str | None = None
+    error: str | None = None
+    completed_at: str | None = None
+
+
+class AgentStateBase(BaseModel):
+    id: str
+    root_state_id: str | None = None
+    status: str
+    task: UserInput
+    result_summary: str | None = None
+    last_run_result: SchedulerRunResultResponse | None = None
+```
+
+```python
+def scheduler_run_result_response_from_sdk(
+    result: SchedulerRunResult | None,
+) -> SchedulerRunResultResponse | None:
+    if result is None:
+        return None
+    return SchedulerRunResultResponse(
+        run_id=result.run_id,
+        termination_reason=result.termination_reason.value,
+        summary=result.summary,
+        error=result.error,
+        completed_at=result.completed_at.isoformat(),
+    )
+```
+
+- [ ] **Step 4: Re-run the Console response tests**
+
+Run: `cd console && uv run pytest tests/test_response_serialization.py tests/test_scheduler_api.py tests/test_sessions_api.py -v`
+Expected: PASS, with `last_run_result` present in scheduler/session responses and SSE fallback payloads.
+
+- [ ] **Step 5: Commit the Console response surface**
+
+```bash
+git add console/server/models/view.py console/server/response_serialization.py console/server/routers/sessions.py console/tests/test_response_serialization.py console/tests/test_scheduler_api.py console/tests/test_sessions_api.py
+git commit -m "feat: expose scheduler last run results in console APIs"
+```
+
+### Task 6: Align Console Permission Semantics and Cache Invalidation
+
+**Files:**
+- Modify: `console/server/services/runtime/agent_factory.py`
+- Modify: `console/server/services/runtime/agent_runtime_cache.py`
+- Test: `console/tests/test_config_env.py`
+- Test: `console/tests/test_agent_runtime_components.py`
+
+- [ ] **Step 1: Write failing permission/cache tests**
+
+```python
+def test_build_default_agent_record_preserves_empty_allowed_tools() -> None:
+    template = DefaultAgentConfig(
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+        allowed_tools=[],
+    )
+
+    record = build_default_agent_record(template)
+
+    assert record.allowed_tools == []
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_cache_refreshes_when_allowed_skills_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = AgentConfigRecord(
+        id="base-agent",
+        name="base",
+        model_provider="openai",
+        model_name="gpt-test",
+        allowed_skills=["alpha"],
+    )
+    second = first.model_copy(update={"allowed_skills": ["beta"]})
+    registry = SimpleNamespace(get_agent=AsyncMock(side_effect=[first, second]))
+    scheduler = SimpleNamespace(rebind_agent=AsyncMock(return_value=True))
+    built_agents = [FakeAgent("sess-1-a"), FakeAgent("sess-1-b")]
+    monkeypatch.setattr(
+        "server.services.runtime.agent_runtime_cache.build_agent",
+        AsyncMock(side_effect=built_agents),
+    )
+    cache = AgentRuntimeCache(
+        scheduler=scheduler,
+        agent_registry=registry,
+        console_config=ConsoleConfig(),
+        session_store=FakeChannelChatSessionStore(),
+    )
+    session = Session(
+        id="sess-1",
+        chat_context_scope_id=None,
+        base_agent_id="base-agent",
+        created_by="test",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    agent_a = await cache.get_or_create_runtime_agent(session)
+    agent_b = await cache.get_or_create_runtime_agent(session)
+    assert agent_a is built_agents[0]
+    assert agent_b is built_agents[1]
+```
+
+- [ ] **Step 2: Run the permission/cache tests**
+
+Run: `cd console && uv run pytest tests/test_config_env.py tests/test_agent_runtime_components.py -v`
+Expected: FAIL because `allowed_tools=[]` is treated as falsy and runtime cache snapshots ignore `allowed_skills`.
+
+- [ ] **Step 3: Implement the semantic fixes**
+
+```python
+def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecord:
+    allowed_skills = get_global_skill_manager().expand_allowed_skills(
+        template.allowed_skills
+    )
+    tool_manager = get_global_tool_manager()
+    default_tools = tool_manager.list_default_tool_names()
+    resolved_allowed_tools = (
+        default_tools if template.allowed_tools is None else list(template.allowed_tools)
+    )
+    return AgentConfigRecord(
+        id=template.id,
+        name=template.name,
+        description=template.description,
+        model_provider=template.model_provider,
+        model_name=template.model_name,
+        system_prompt=template.system_prompt,
+        allowed_tools=resolved_allowed_tools,
+        allowed_skills=allowed_skills,
+        options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
+        model_params=dict(template.model_params),
+    )
+```
+
+```python
+ConfigSnapshot = tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[tuple[str, Any], ...],
+    tuple[tuple[str, Any], ...],
+]
+
+
+def _config_snapshot(config: AgentConfigRecord) -> ConfigSnapshot:
+    return (
+        config.name,
+        config.description,
+        config.model_provider,
+        config.model_name,
+        config.system_prompt,
+        tuple(config.allowed_tools or ()),
+        tuple(config.allowed_skills or ()),
+        tuple(sorted(config.options.items())),
+        tuple(sorted(config.model_params.items())),
+    )
+```
+
+- [ ] **Step 4: Re-run the Console permission/cache tests**
+
+Run: `cd console && uv run pytest tests/test_config_env.py tests/test_agent_runtime_components.py -v`
+Expected: PASS, with empty tool allowlists preserved and `allowed_skills` changes forcing a new runtime agent.
+
+- [ ] **Step 5: Commit the Console semantics fixes**
+
+```bash
+git add console/server/services/runtime/agent_factory.py console/server/services/runtime/agent_runtime_cache.py console/tests/test_config_env.py console/tests/test_agent_runtime_components.py
+git commit -m "fix: align console tool and skill runtime semantics"
+```
+
+### Task 7: Run Integrated Verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-14-scheduler-semantics-alignment.md`
+
+- [ ] **Step 1: Run focused SDK scheduler coverage**
+
+Run: `uv run pytest tests/scheduler/test_models.py tests/scheduler/test_store.py tests/scheduler/test_scheduler.py -v`
+Expected: PASS for all scheduler model/store/engine/stream coverage.
+
+- [ ] **Step 2: Run focused Console coverage**
+
+Run: `cd console && uv run pytest tests/test_response_serialization.py tests/test_scheduler_api.py tests/test_sessions_api.py tests/test_config_env.py tests/test_agent_runtime_components.py -v`
+Expected: PASS for Console API, SSE fallback, default-agent semantics, and runtime cache refresh behavior.
+
+- [ ] **Step 3: Run repo-standard lint**
+
+Run: `uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/`
+Expected: `All checks passed!`
+
+Run: `uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/`
+Expected: no formatting diffs
+
+Run: `uv run python scripts/lint.py imports`
+Expected: all import contracts kept
+
+Run: `uv run python scripts/repo_guard.py`
+Expected: repo guard passes or reports no Python files needing checks
+
+- [ ] **Step 4: Update the plan checklist with actual results**
+
+```markdown
+- [x] Focused scheduler tests passed
+- [x] Focused Console tests passed
+- [x] Ruff, import-linter, and repo_guard passed
+```
+
+- [ ] **Step 5: Commit the final verified batch**
+
+```bash
+git add agiwo/ console/server/ tests/ console/tests/ docs/superpowers/plans/2026-04-14-scheduler-semantics-alignment.md
+git commit -m "fix: align scheduler run result semantics"
+```
+
+## Self-Review
+
+- Spec coverage check:
+  - `last_run_result` data model: Task 1
+  - storage and serialization: Task 2
+  - scheduler write/read semantics: Task 3
+  - stream race fix: Task 4
+  - Console API exposure and SSE fallback: Task 5
+  - default-agent and runtime cache semantics: Task 6
+  - verification: Task 7
+- Placeholder scan:
+  - Removed vague “where appropriate”/“handle edge cases” wording.
+  - Each task has explicit files, tests, commands, and code snippets.
+- Type consistency:
+  - Plan consistently uses `SchedulerRunResult` and `last_run_result`.
+  - Console view layer consistently uses `SchedulerRunResultResponse`.

--- a/docs/superpowers/specs/2026-04-14-scheduler-semantics-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-14-scheduler-semantics-alignment-design.md
@@ -1,0 +1,305 @@
+# Scheduler Semantics Alignment Design
+
+- Date: 2026-04-14
+- Status: Proposed
+- Scope: SDK scheduler, scheduler state storage, Console runtime/API models
+
+## Context
+
+Release review found four issues that are individually small but share the same root problem: the scheduler currently mixes lifecycle state, run outcome, and display summary.
+
+Observed problems:
+
+1. `Scheduler.wait_for()` reconstructs results from `AgentState.status` and loses the original `TerminationReason`.
+2. Scheduler stream subscription opens too late and can miss the entire run for fast completions.
+3. Console default-agent construction treats `allowed_tools=[]` as falsy and silently re-enables default tools.
+4. Console runtime agent cache does not invalidate on `allowed_skills` changes and can continue serving stale permissions.
+
+For the first release, we prefer semantic correctness over compatibility with the current flawed behavior. Old scheduler state can be deleted. We do not need backward-compatible persistence or response shims.
+
+## Goals
+
+- Make scheduler-owned result semantics explicit and durable.
+- Align `Scheduler.run()` / `wait_for()` behavior with streamed terminal events.
+- Remove stream subscriber race conditions for root runs.
+- Align Console default-agent permission semantics with SDK `allowed_tools` rules.
+- Ensure Console runtime agent cache refreshes when tool or skill permissions change.
+- Expose the scheduler's last run outcome directly in Console APIs.
+
+## Non-Goals
+
+- Preserve compatibility with old scheduler state rows or API payload shapes.
+- Add scheduler run history. This design stores only the most recent run result.
+- Refactor scheduler into a separate run-result subsystem.
+- Change core Agent run semantics.
+
+## Options Considered
+
+### Option A: Minimal Patches
+
+Patch `wait_for()` and stream setup locally without changing scheduler state shape.
+
+Pros:
+
+- Smallest code diff.
+- Lowest short-term implementation cost.
+
+Cons:
+
+- Does not solve persisted root-state queries or restart-time correctness.
+- Keeps result semantics implicit and fragile.
+- Leaves Console querying code with no durable source of truth.
+
+### Option B: Persist `last_run_result` on `AgentState`
+
+Add a small scheduler-owned record that captures the most recent agent-cycle outcome and use it as the canonical source for non-streamed result semantics.
+
+Pros:
+
+- Separates scheduler lifecycle from agent-cycle outcome cleanly.
+- Works for persistent roots, resume flows, restart-time queries, and Console APIs.
+- Keeps the change local to existing scheduler state and storage paths.
+
+Cons:
+
+- Requires state model, storage, serialization, and API changes.
+- Intentionally breaks compatibility with old persisted scheduler data.
+
+### Option C: Separate Scheduler Run Result Store
+
+Create a distinct persisted store for scheduler-owned run results.
+
+Pros:
+
+- Cleanest long-term modeling if we later need histories or analytics.
+
+Cons:
+
+- Too heavy for a release-blocking semantics fix.
+- Introduces a new subsystem without enough payoff right now.
+
+## Decision
+
+Choose Option B.
+
+The scheduler will continue to own lifecycle state through `AgentState.status`, but it will also persist the most recent run outcome in a dedicated `last_run_result` record. `status` will answer "what is the scheduler doing now?" and `last_run_result` will answer "how did the most recent agent cycle finish?"
+
+## 1. Data Model
+
+Add a new immutable scheduler model:
+
+```python
+@dataclass(frozen=True, slots=True)
+class SchedulerRunResult:
+    run_id: str | None
+    termination_reason: TerminationReason
+    summary: str | None = None
+    error: str | None = None
+    completed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+```
+
+Add to `AgentState`:
+
+```python
+last_run_result: SchedulerRunResult | None = None
+```
+
+`result_summary` remains on `AgentState`, but it becomes a scheduler/UI summary field rather than the canonical machine-readable outcome.
+
+Modeling rules:
+
+- `status` is scheduler lifecycle only.
+- `last_run_result` is the canonical durable outcome of the most recent completed agent cycle.
+- Only one result is stored. New cycles replace old results.
+
+## 2. State Transition Semantics
+
+### New root submission
+
+- New root state starts with `last_run_result=None`.
+
+### Persistent root enqueue
+
+- When a persistent root moves to `QUEUED`, preserve the previous `last_run_result`.
+- Rationale: before the next cycle actually starts, callers should still see the previous completed outcome.
+
+### Cycle start
+
+- Any transition to `RUNNING` for a new cycle clears `last_run_result`.
+- This includes root queued-input dispatch, child pending dispatch, timeout/event wake, and normal root submit.
+
+### Successful completion
+
+- Write `last_run_result` with:
+  - `run_id`
+  - `termination_reason=TerminationReason.COMPLETED`
+  - `summary=response`
+  - `error=None`
+- Persistent roots end in `IDLE`.
+- Non-persistent roots and children end in `COMPLETED`.
+
+### Failed or cancelled completion
+
+- Write `last_run_result` for:
+  - `CANCELLED`
+  - `TIMEOUT`
+  - `ERROR`
+  - `ERROR_WITH_CONTEXT`
+- `summary` may carry best-effort output text.
+- `error` carries the primary human-readable failure message.
+
+### Sleeping / waiting
+
+- `TerminationReason.SLEEPING` is not a final external run outcome and must not be persisted as `last_run_result`.
+- Periodic or waiting intermediate rounds must not overwrite the last durable terminal result.
+
+### Scheduler-originated termination
+
+Scheduler-side failures must also write `last_run_result`, not only `result_summary`. This includes:
+
+- wake rejected by guard
+- shutdown before completion
+- parent cancelled
+- scheduler dispatch failure paths that conclude the cycle
+
+If a direct `TerminationReason` exists, use it. Otherwise map to `ERROR` and preserve details in `error`.
+
+## 3. Read Semantics
+
+### `Scheduler.wait_for()`
+
+`wait_for()` must stop inferring run outcomes from `AgentState.status`.
+
+New behavior:
+
+- Wait until the state has a terminal scheduler status or a root-persistent idle status with a non-`None` `last_run_result`.
+- Return a `RunOutput` derived from `last_run_result`.
+- If timeout is hit before a result is written, return `TerminationReason.TIMEOUT`.
+
+This makes non-streamed waiting consistent with streamed terminal events.
+
+### Console runtime and APIs
+
+Expose `last_run_result` directly in:
+
+- scheduler state responses
+- scheduler state list items
+- session detail responses
+- any SSE fallback acknowledgment path that currently depends on `result_summary`
+
+The Console should show both:
+
+- current scheduler `status`
+- most recent `last_run_result`
+
+These answer different questions and should not be merged.
+
+## 4. Stream Subscription Race Fix
+
+The scheduler stream channel must exist before `submit()`, `enqueue_input()`, or `steer()` begins producing events.
+
+Change:
+
+- `route_with_stream()` opens the channel before invoking `operation()`.
+- If `operation()` fails, close the channel before re-raising.
+- Keep the single-subscriber invariant.
+
+This removes the fast-run race where the root run can start and finish before the subscriber exists.
+
+## 5. Console Permission Semantics
+
+`build_default_agent_record()` must distinguish:
+
+- `allowed_tools is None`: use default builtin tools
+- `allowed_tools == []`: no functional tools
+
+It must not use truthiness to decide fallback behavior.
+
+This aligns Console default-agent behavior with SDK `allowed_tools` semantics documented in `AGENTS.md`.
+
+## 6. Runtime Cache Invalidation
+
+`AgentRuntimeCache` snapshots must include all permission-shaping fields, including `allowed_skills`.
+
+Minimum invalidation set:
+
+- `allowed_tools`
+- `allowed_skills`
+- `system_prompt`
+- `model_provider`
+- `model_name`
+- `options`
+- `model_params`
+
+If a cached session agent becomes stale:
+
+- If scheduler rebind is allowed, replace it immediately.
+- If the state is active and rebind is deferred, keep serving the current runtime agent until the state becomes rebindable, then use the refreshed config on the next acquisition path.
+
+The goal is correctness, not hot-reload sophistication.
+
+## 7. Storage and Serialization
+
+Update scheduler persistence for memory and sqlite storage to encode/decode `last_run_result`.
+
+Constraints:
+
+- No migration layer.
+- Old rows failing to decode is acceptable for this release.
+- Console view models and response serializers must expose the new structure explicitly.
+
+## 8. Testing
+
+Add tests for the following:
+
+### Scheduler
+
+- `wait_for()` returns `COMPLETED`, `CANCELLED`, `TIMEOUT`, and `ERROR` from `last_run_result` rather than guessing from `status`
+- persistent root preserves previous `last_run_result` while `QUEUED`
+- transitioning to `RUNNING` clears prior `last_run_result`
+- scheduler-originated failures write `last_run_result`
+- fast root runs do not drop `run_started` / `run_completed` after stream setup changes
+
+### Console
+
+- scheduler and session detail APIs expose `last_run_result`
+- SSE fallback uses `last_run_result` semantics
+- default-agent `allowed_tools=[]` stays empty
+- runtime cache invalidates on `allowed_skills` changes
+
+### Storage
+
+- memory store round-trips `last_run_result`
+- sqlite store round-trips `last_run_result`
+
+## 9. Risks and Mitigations
+
+### Risk: accidental mixing of `status` and `last_run_result`
+
+Mitigation:
+
+- keep `wait_for()` and response serializers reading from `last_run_result`
+- leave `status` untouched as scheduler lifecycle
+
+### Risk: periodic/waiting flows overwrite durable terminal results incorrectly
+
+Mitigation:
+
+- treat `SLEEPING` as non-terminal for `last_run_result`
+- only write terminal outcomes for externally meaningful cycle ends
+
+### Risk: API consumers keep reading `result_summary`
+
+Mitigation:
+
+- expose `last_run_result` explicitly in Console responses
+- keep `result_summary` for display only, not machine semantics
+
+## 10. Acceptance Criteria
+
+- `Scheduler.run()` / `wait_for()` return the same terminal semantics a stream consumer would observe.
+- Fast runs no longer lose their root stream events due to late subscription.
+- `allowed_tools=None` and `allowed_tools=[]` have distinct Console behavior.
+- Runtime agent cache refreshes when skill allowlists change.
+- Console scheduler and session APIs expose `last_run_result`.
+- Tests cover the new semantics across scheduler, Console, and scheduler storage.

--- a/tests/scheduler/test_models.py
+++ b/tests/scheduler/test_models.py
@@ -2,11 +2,13 @@
 
 from datetime import datetime, timedelta, timezone
 
+from agiwo.agent import TerminationReason
 from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
     ChildAgentConfigOverrides,
     PendingEvent,
+    SchedulerRunResult,
     SchedulerConfig,
     SchedulerEventType,
     TaskLimits,
@@ -173,6 +175,45 @@ class TestAgentState:
         )
         assert state.is_queued_root()
         assert not state.can_accept_enqueue_input()
+
+    def test_with_running_clears_last_run_result(self):
+        state = AgentState(
+            id="root",
+            session_id="sess-1",
+            status=AgentStateStatus.IDLE,
+            task="task",
+            is_persistent=True,
+            last_run_result=SchedulerRunResult(
+                run_id="run-1",
+                termination_reason=TerminationReason.COMPLETED,
+                summary="done",
+            ),
+        )
+
+        updated = state.with_running(task="next task")
+
+        assert updated.status == AgentStateStatus.RUNNING
+        assert updated.last_run_result is None
+
+    def test_with_queued_preserves_last_run_result(self):
+        result = SchedulerRunResult(
+            run_id="run-2",
+            termination_reason=TerminationReason.CANCELLED,
+            error="cancelled by user",
+        )
+        state = AgentState(
+            id="root",
+            session_id="sess-1",
+            status=AgentStateStatus.IDLE,
+            task="task",
+            is_persistent=True,
+            last_run_result=result,
+        )
+
+        updated = state.with_queued(pending_input="next")
+
+        assert updated.status == AgentStateStatus.QUEUED
+        assert updated.last_run_result == result
 
 
 class TestPendingEvent:

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -21,6 +21,7 @@ from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
     PendingEvent,
+    SchedulerRunResult,
     SchedulerConfig,
     SchedulerEventType,
     WakeCondition,
@@ -880,6 +881,29 @@ class TestSchedulerEnqueueInput:
 
 class TestSchedulerQueuedMailbox:
     @pytest.mark.asyncio
+    async def test_wait_for_uses_last_run_result_termination_reason(self):
+        scheduler = Scheduler(_fast_config())
+        await scheduler._store.save_state(
+            AgentState(
+                id="root",
+                session_id="sess",
+                status=AgentStateStatus.FAILED,
+                task="initial",
+                last_run_result=SchedulerRunResult(
+                    run_id="run-1",
+                    termination_reason=TerminationReason.CANCELLED,
+                    error="cancelled by user",
+                ),
+            )
+        )
+
+        result = await scheduler.wait_for("root", timeout=_TEST_RUN_TIMEOUT)
+
+        assert result.termination_reason == TerminationReason.CANCELLED
+        assert result.error == "cancelled by user"
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
     async def test_queued_root_preserves_mailbox_input_for_next_run(self):
         scheduler = Scheduler(_fast_config(event_debounce_min_count=1))
         model = EchoMessagesModel()
@@ -915,6 +939,31 @@ class TestSchedulerQueuedMailbox:
 
 
 class TestSchedulerStream:
+    @pytest.mark.asyncio
+    async def test_route_root_input_stream_survives_fast_completion_before_iteration(
+        self,
+    ):
+        async with Scheduler(_fast_config()) as scheduler:
+            model = MockModel([_simple_completion("Fast answer")])
+            agent = _make_agent(name="stream-race", model=model, id="stream-race")
+
+            result = await scheduler.route_root_input(
+                "What happened?",
+                agent=agent,
+                session_id="sess-stream-race",
+                timeout=0.1,
+                persistent=True,
+                stream_mode="run_end",
+            )
+
+            await asyncio.sleep(0.05)
+            items = [item async for item in result.stream]
+
+        assert items
+        assert items[0].type == "run_started"
+        assert isinstance(items[-1], RunCompletedEvent)
+        assert items[-1].response == "Fast answer"
+
     @pytest.mark.asyncio
     async def test_stream_new_root_run(self):
         async with Scheduler(_fast_config()) as scheduler:

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -4,10 +4,12 @@ from datetime import datetime, timezone
 
 import pytest
 
+from agiwo.agent import TerminationReason
 from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
     PendingEvent,
+    SchedulerRunResult,
     SchedulerEventType,
     WakeCondition,
     WakeType,
@@ -100,6 +102,24 @@ class TestInMemorySaveStateUpdate:
         assert retrieved.explain == "idle"
         assert retrieved.wake_count == 2
 
+    @pytest.mark.asyncio
+    async def test_save_updates_last_run_result(self, store):
+        state = _make_state()
+        await store.save_state(state)
+        result = SchedulerRunResult(
+            run_id="run-1",
+            termination_reason=TerminationReason.ERROR,
+            error="boom",
+        )
+
+        await store.save_state(state.with_updates(last_run_result=result))
+        retrieved = await store.get_state("agent-1")
+
+        assert retrieved is not None
+        assert retrieved.last_run_result is not None
+        assert retrieved.last_run_result.run_id == "run-1"
+        assert retrieved.last_run_result.error == "boom"
+
 
 class TestInMemoryListStates:
     @pytest.mark.asyncio
@@ -183,6 +203,11 @@ class TestSQLiteAgentStateStorage:
                 wait_for=["child-1"],
                 completed_ids=["child-1"],
             ),
+            last_run_result=SchedulerRunResult(
+                run_id="run-1",
+                termination_reason=TerminationReason.COMPLETED,
+                summary="done",
+            ),
         )
 
         await store.save_state(state)
@@ -195,6 +220,8 @@ class TestSQLiteAgentStateStorage:
         assert retrieved.explain == "waiting for child"
         assert retrieved.wake_condition is not None
         assert retrieved.wake_condition.completed_ids == ("child-1",)
+        assert retrieved.last_run_result is not None
+        assert retrieved.last_run_result.summary == "done"
 
         await store.close()
 


### PR DESCRIPTION
## Summary
- add durable `last_run_result` semantics to scheduler state and use it in `wait_for()`
- fix root scheduler stream subscription race for fast completions
- expose `last_run_result` in Console APIs and SSE fallback
- align Console default-agent tool semantics and runtime cache invalidation for `allowed_skills`
- add implementation plan and focused regression coverage

## Testing
- `uv run pytest tests/scheduler/test_models.py tests/scheduler/test_store.py tests/scheduler/test_scheduler.py -q`
- `cd console && uv run pytest tests/test_response_serialization.py tests/test_scheduler_api.py tests/test_sessions_api.py tests/test_chat_api.py tests/test_config_env.py tests/test_agent_runtime_components.py -q`
- `uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/`
- `uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/`
- `uv run python scripts/lint.py imports`
- `uv run python scripts/repo_guard.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Agent states now expose detailed run outcome information including termination reason, errors, and execution summaries through Console APIs.
  - Enhanced stream handling with improved error recovery on operation failures.

* **Bug Fixes**
  - Fixed permission configuration handling to properly distinguish between unspecified and empty settings.
  - Improved runtime cache invalidation for permission-related configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->