### PR TITLE
feat: add openai responses provider

### DIFF
--- a/agiwo/config/settings.py
+++ b/agiwo/config/settings.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ModelProvider = Literal[
     "openai",
+    "openai-response",
     "openai-compatible",
     "deepseek",
     "anthropic",

--- a/agiwo/llm/__init__.py
+++ b/agiwo/llm/__init__.py
@@ -5,6 +5,7 @@ from agiwo.llm.factory import (
     create_model_from_dict,
 )
 from agiwo.llm.openai import OpenAIModel
+from agiwo.llm.openai_response import OpenAIResponsesModel
 from agiwo.llm.anthropic import AnthropicModel
 from agiwo.llm.bedrock_anthropic import BedrockAnthropicModel
 from agiwo.llm.deepseek import DeepseekModel
@@ -20,6 +21,7 @@ __all__ = [
     "create_model",
     "create_model_from_dict",
     "OpenAIModel",
+    "OpenAIResponsesModel",
     "AnthropicModel",
     "BedrockAnthropicModel",
     "DeepseekModel",

--- a/agiwo/llm/event_normalizer.py
+++ b/agiwo/llm/event_normalizer.py
@@ -32,6 +32,15 @@ def _get_val(obj: Any, key: str) -> Any:
     return getattr(obj, key, None)
 
 
+def _get_nested_val(obj: Any, *path: str) -> Any:
+    current = obj
+    for key in path:
+        current = _get_val(current, key)
+        if current is None:
+            return None
+    return current
+
+
 def _coerce_optional_int(value: object | None) -> int | None:
     return value if isinstance(value, int) else None
 
@@ -41,7 +50,10 @@ def _resolve_usage_metric(
     *names: str,
 ) -> int | None:
     for name in names:
-        value = _coerce_optional_int(_get_val(usage_data, name))
+        if "." in name:
+            value = _coerce_optional_int(_get_nested_val(usage_data, *name.split(".")))
+        else:
+            value = _coerce_optional_int(_get_val(usage_data, name))
         if value is not None:
             return value
     return None
@@ -54,6 +66,7 @@ _USAGE_METRIC_ALIASES: dict[str, tuple[str, ...]] = {
         "cache_read_tokens",
         "cache_read_input_tokens",
         "cached_tokens",
+        "input_tokens_details.cached_tokens",
     ),
     "cache_creation_tokens": ("cache_creation_tokens", "cache_creation_input_tokens"),
 }

--- a/agiwo/llm/factory.py
+++ b/agiwo/llm/factory.py
@@ -17,6 +17,7 @@ from agiwo.llm.config_policy import (
 from agiwo.llm.deepseek import DeepseekModel
 from agiwo.llm.nvidia import NvidiaModel
 from agiwo.llm.openai import OpenAIModel
+from agiwo.llm.openai_response import OpenAIResponsesModel
 from agiwo.config.settings import (
     ALL_MODEL_PROVIDERS,
     COMPATIBLE_MODEL_PROVIDERS,
@@ -121,6 +122,7 @@ def _build_model_for_provider(
 
 PROVIDER_SPECS: dict[ModelProvider, ProviderSpec] = {
     "openai": ProviderSpec(model_class=OpenAIModel),
+    "openai-response": ProviderSpec(model_class=OpenAIResponsesModel),
     "openai-compatible": ProviderSpec(
         model_class=OpenAIModel,
         disable_env_fallback=True,

--- a/agiwo/llm/openai_response.py
+++ b/agiwo/llm/openai_response.py
@@ -1,0 +1,315 @@
+from typing import AsyncIterator
+
+try:
+    from openai import (
+        AsyncOpenAI,
+        APIConnectionError,
+        APITimeoutError,
+        InternalServerError,
+        RateLimitError,
+    )
+except ImportError:
+    raise ImportError("Please install openai package: pip install openai") from None
+
+from agiwo.config.settings import get_settings
+from agiwo.llm.base import LLMConfig, Model, StreamChunk
+from agiwo.llm.event_normalizer import normalize_usage_metrics
+from agiwo.llm.openai_response_converter import (
+    convert_messages_to_responses_input,
+    convert_tools_to_responses_tools,
+    split_system_instructions,
+)
+from agiwo.utils.logging import get_logger
+from agiwo.utils.retry import retry_async
+
+logger = get_logger(__name__)
+
+OPENAI_RETRYABLE = (
+    APIConnectionError,
+    RateLimitError,
+    InternalServerError,
+    APITimeoutError,
+)
+
+
+OpenAIMessage = dict[str, object]
+OpenAITool = dict[str, object]
+ToolCallState = dict[int, dict[str, object]]
+
+
+def _get_attr(obj: object, key: str) -> object | None:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    if obj is None:
+        return None
+    return getattr(obj, key, None)
+
+
+def _flatten_response_usage(usage: object) -> object:
+    input_tokens_details = _get_attr(usage, "input_tokens_details")
+    cached_tokens = _get_attr(input_tokens_details, "cached_tokens")
+    if cached_tokens is None:
+        return usage
+    return {
+        "input_tokens": _get_attr(usage, "input_tokens"),
+        "output_tokens": _get_attr(usage, "output_tokens"),
+        "total_tokens": _get_attr(usage, "total_tokens"),
+        "input_tokens_details": {"cached_tokens": cached_tokens},
+    }
+
+
+def _extract_response_error_message(response: object) -> str:
+    error = _get_attr(response, "error")
+    if error is None:
+        return "OpenAI Responses request failed"
+    message = _get_attr(error, "message")
+    if isinstance(message, str) and message:
+        return message
+    return str(error)
+
+
+class OpenAIResponsesModel(Model):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        api_key: str | None = None,
+        base_url: str | None = "https://api.openai.com/v1",
+        allow_env_fallback: bool = True,
+        temperature: float = 0.7,
+        top_p: float = 1.0,
+        max_output_tokens: int = 4096,
+        max_context_window: int = 200000,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        cache_hit_price: float = 0.0,
+        input_price: float = 0.0,
+        output_price: float = 0.0,
+        provider: str = "openai-response",
+    ) -> None:
+        config = LLMConfig(
+            id=id,
+            name=name,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=temperature,
+            top_p=top_p,
+            max_output_tokens=max_output_tokens,
+            max_context_window=max_context_window,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            provider=provider,
+            cache_hit_price=cache_hit_price,
+            input_price=input_price,
+            output_price=output_price,
+        )
+        super().__init__(config)
+        self.allow_env_fallback = allow_env_fallback
+        self.client = self._create_client()
+
+    def _resolve_api_key(self) -> str | None:
+        if self.api_key:
+            return self.api_key
+        if self.allow_env_fallback:
+            settings = get_settings()
+            if settings.openai_api_key:
+                return settings.openai_api_key.get_secret_value()
+        return None
+
+    def _resolve_base_url(self) -> str | None:
+        if self.base_url:
+            return self.base_url
+        if self.allow_env_fallback:
+            return get_settings().openai_base_url
+        return None
+
+    def _create_client(self) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            api_key=self._resolve_api_key(),
+            base_url=self._resolve_base_url(),
+        )
+
+    def _build_params(
+        self,
+        messages: list[OpenAIMessage],
+        tools: list[OpenAITool] | None,
+    ) -> dict[str, object]:
+        instructions, remaining_messages = split_system_instructions(messages)
+        params: dict[str, object] = {
+            "model": self.id or self.name,
+            "input": convert_messages_to_responses_input(remaining_messages),
+            "stream": True,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
+        if instructions is not None:
+            params["instructions"] = instructions
+        if self.max_output_tokens:
+            params["max_output_tokens"] = self.max_output_tokens
+        if tools:
+            params["tools"] = convert_tools_to_responses_tools(tools)
+        return params
+
+    def _map_finish_reason(self, response: object) -> str:
+        output_items = _get_attr(response, "output") or []
+        if any(_get_attr(item, "type") == "function_call" for item in output_items):
+            return "tool_calls"
+
+        incomplete_details = _get_attr(response, "incomplete_details")
+        incomplete_reason = _get_attr(incomplete_details, "reason")
+        if incomplete_reason == "max_output_tokens":
+            return "length"
+        if isinstance(incomplete_reason, str) and incomplete_reason:
+            return incomplete_reason
+        return "stop"
+
+    def _handle_output_item_added(
+        self,
+        event: object,
+        tool_calls_state: ToolCallState,
+    ) -> None:
+        item = _get_attr(event, "item")
+        if _get_attr(item, "type") != "function_call":
+            return
+        output_index = _get_attr(event, "output_index")
+        if not isinstance(output_index, int):
+            return
+        tool_calls_state[output_index] = {
+            "id": _get_attr(item, "call_id") or _get_attr(item, "id") or "",
+            "name": _get_attr(item, "name") or "",
+            "name_emitted": False,
+        }
+
+    def _handle_function_call_delta(
+        self,
+        event: object,
+        tool_calls_state: ToolCallState,
+    ) -> StreamChunk | None:
+        output_index = _get_attr(event, "output_index")
+        if not isinstance(output_index, int):
+            return None
+        state = tool_calls_state.get(output_index)
+        if state is None:
+            return None
+        delta = _get_attr(event, "delta")
+        if not isinstance(delta, str):
+            return None
+        function_payload: dict[str, object] = {"arguments": delta}
+        if not state["name_emitted"]:
+            function_payload["name"] = state["name"]
+            state["name_emitted"] = True
+
+        return StreamChunk(
+            tool_calls=[
+                {
+                    "index": output_index,
+                    "id": state["id"],
+                    "type": "function",
+                    "function": function_payload,
+                }
+            ]
+        )
+
+    @staticmethod
+    def _build_text_chunk(delta: object) -> StreamChunk | None:
+        if isinstance(delta, str):
+            return StreamChunk(content=delta)
+        return None
+
+    @staticmethod
+    def _build_reasoning_chunk(delta: object) -> StreamChunk | None:
+        if isinstance(delta, str):
+            return StreamChunk(reasoning_content=delta)
+        return None
+
+    def _build_completed_chunk(self, response: object) -> StreamChunk:
+        usage = _get_attr(response, "usage")
+        normalized_usage = None
+        if usage is not None:
+            normalized_usage = normalize_usage_metrics(_flatten_response_usage(usage))
+        return StreamChunk(
+            usage=normalized_usage,
+            finish_reason=self._map_finish_reason(response),
+        )
+
+    def _raise_failed_response(self, event: object) -> None:
+        raise RuntimeError(
+            _extract_response_error_message(_get_attr(event, "response"))
+        )
+
+    def _event_to_chunk(
+        self,
+        event: object,
+        tool_calls_state: ToolCallState,
+    ) -> StreamChunk | None:
+        event_type = _get_attr(event, "type")
+        if event_type == "response.output_text.delta":
+            return self._build_text_chunk(_get_attr(event, "delta"))
+        if event_type in {
+            "response.reasoning_text.delta",
+            "response.reasoning_summary_text.delta",
+        }:
+            return self._build_reasoning_chunk(_get_attr(event, "delta"))
+        if event_type == "response.output_item.added":
+            self._handle_output_item_added(event, tool_calls_state)
+            return None
+        if event_type == "response.function_call_arguments.delta":
+            return self._handle_function_call_delta(event, tool_calls_state)
+        if event_type == "response.failed":
+            self._raise_failed_response(event)
+        if event_type == "response.completed":
+            return self._build_completed_chunk(_get_attr(event, "response"))
+        return None
+
+    @retry_async(exceptions=OPENAI_RETRYABLE)
+    async def arun_stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        actual_model = self.id or self.name
+        params = self._build_params(messages, tools)
+        logger.debug(
+            "llm_request",
+            model=actual_model,
+            messages_count=len(messages),
+            tools_count=len(tools) if tools else 0,
+            temperature=self.temperature,
+            max_output_tokens=self.max_output_tokens,
+            detail=params,
+        )
+
+        stream = await self.client.responses.create(**params)
+        chunk_count = 0
+        tool_calls_state: ToolCallState = {}
+        logger.info("openai_responses_stream_started", model=actual_model)
+
+        async for event in stream:
+            stream_chunk = self._event_to_chunk(event, tool_calls_state)
+            if stream_chunk is None:
+                continue
+            if (
+                stream_chunk.content is None
+                and stream_chunk.reasoning_content is None
+                and stream_chunk.tool_calls is None
+                and stream_chunk.usage is None
+                and stream_chunk.finish_reason is None
+            ):
+                continue
+            chunk_count += 1
+            yield stream_chunk
+
+        if chunk_count == 0:
+            raise RuntimeError(
+                "OpenAI Responses stream returned no chunks; "
+                "verify the model and base_url support the Responses API"
+            )
+
+        logger.info(
+            "openai_responses_stream_ended",
+            model=actual_model,
+            chunk_count=chunk_count,
+        )
+
+
+__all__ = ["OpenAIResponsesModel"]

--- a/agiwo/llm/openai_response_converter.py
+++ b/agiwo/llm/openai_response_converter.py
@@ -1,0 +1,194 @@
+import json
+
+OpenAIMessage = dict[str, object]
+OpenAITool = dict[str, object]
+ResponsesInputItem = dict[str, object]
+
+
+def split_system_instructions(
+    messages: list[OpenAIMessage],
+) -> tuple[str | None, list[OpenAIMessage]]:
+    instruction_parts: list[str] = []
+    remaining: list[OpenAIMessage] = []
+
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            if content is None:
+                continue
+            if not isinstance(content, str):
+                raise ValueError(
+                    "Unsupported system content for openai-response provider"
+                )
+            instruction_parts.append(content)
+            continue
+        remaining.append(message)
+
+    instructions = "\n\n".join(instruction_parts) or None
+    return instructions, remaining
+
+
+def _serialize_json_string(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=True)
+
+
+def _assistant_message_id(message_index: int) -> str:
+    return f"assistant_msg_{message_index}"
+
+
+def _assistant_tool_call_id(message_index: int, tool_index: int) -> str:
+    return f"assistant_tool_call_{message_index}_{tool_index}"
+
+
+def _tool_output_id(message_index: int) -> str:
+    return f"tool_output_{message_index}"
+
+
+def _convert_user_message(message: OpenAIMessage) -> ResponsesInputItem:
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("Unsupported user content for openai-response provider")
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": content}],
+    }
+
+
+def _convert_assistant_message(
+    message: OpenAIMessage,
+    *,
+    message_index: int,
+) -> list[ResponsesInputItem]:
+    items: list[ResponsesInputItem] = []
+    tool_calls = message.get("tool_calls") or []
+
+    for tool_index, tool_call in enumerate(tool_calls):
+        if tool_call.get("type") != "function":
+            raise ValueError(
+                "Unsupported assistant tool call type for openai-response provider"
+            )
+        function_payload = tool_call.get("function")
+        if not isinstance(function_payload, dict):
+            raise ValueError(
+                "Unsupported assistant tool call payload for openai-response provider"
+            )
+
+        tool_call_id = tool_call.get("id") or _assistant_tool_call_id(
+            message_index, tool_index
+        )
+        tool_name = function_payload.get("name")
+        if not isinstance(tool_name, str) or not tool_name:
+            raise ValueError("Assistant tool call name missing for openai-response")
+
+        items.append(
+            {
+                "type": "function_call",
+                "id": _assistant_tool_call_id(message_index, tool_index),
+                "call_id": tool_call_id,
+                "name": tool_name,
+                "arguments": _serialize_json_string(
+                    function_payload.get("arguments", "")
+                ),
+                "status": "completed",
+            }
+        )
+
+    content = message.get("content")
+    if content is not None:
+        if not isinstance(content, str):
+            raise ValueError("Unsupported assistant content for openai-response")
+        items.append(
+            {
+                "type": "message",
+                "id": _assistant_message_id(message_index),
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": content,
+                        "annotations": [],
+                    }
+                ],
+            }
+        )
+
+    return items
+
+
+def _convert_tool_message(
+    message: OpenAIMessage,
+    *,
+    message_index: int,
+) -> ResponsesInputItem:
+    tool_call_id = message.get("tool_call_id")
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        raise ValueError("Tool message missing tool_call_id for openai-response")
+    return {
+        "type": "function_call_output",
+        "id": _tool_output_id(message_index),
+        "call_id": tool_call_id,
+        "output": _serialize_json_string(message.get("content")),
+        "status": "completed",
+    }
+
+
+def convert_messages_to_responses_input(
+    messages: list[OpenAIMessage],
+) -> list[ResponsesInputItem]:
+    items: list[ResponsesInputItem] = []
+
+    for message_index, message in enumerate(messages):
+        role = message.get("role")
+        if role == "user":
+            items.append(_convert_user_message(message))
+            continue
+        if role == "assistant":
+            items.extend(
+                _convert_assistant_message(message, message_index=message_index)
+            )
+            continue
+        if role == "tool":
+            items.append(_convert_tool_message(message, message_index=message_index))
+            continue
+        raise ValueError(
+            f"Unsupported message role for openai-response provider: {role}"
+        )
+
+    return items
+
+
+def convert_tools_to_responses_tools(
+    tools: list[OpenAITool] | None,
+) -> list[ResponsesInputItem] | None:
+    if not tools:
+        return None
+
+    converted: list[ResponsesInputItem] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            raise ValueError("Unsupported tool type for openai-response provider")
+        function_payload = tool.get("function")
+        if not isinstance(function_payload, dict):
+            raise ValueError("Unsupported tool payload for openai-response provider")
+        converted.append(
+            {
+                "type": "function",
+                "name": function_payload["name"],
+                "description": function_payload.get("description", ""),
+                "parameters": function_payload.get("parameters", {}),
+            }
+        )
+
+    return converted
+
+
+__all__ = [
+    "convert_messages_to_responses_input",
+    "convert_tools_to_responses_tools",
+    "split_system_instructions",
+]

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -67,6 +67,21 @@ model = OpenAIModel(id="gpt-4o", name="gpt-4o")
 # Reads OPENAI_API_KEY from environment
 ```
 
+### `OpenAIResponsesModel`
+
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai-response",
+    model_name="gpt-4.1-mini",
+)
+```
+
+Uses OpenAI Responses API internally while preserving the SDK `StreamChunk`
+contract. First-version support covers streamed text and function calling.
+Multi-turn replay is stateless and does not use `previous_response_id`.
+
 ### `AnthropicModel`
 
 ```python
@@ -170,4 +185,4 @@ model = create_model_from_dict(
 )
 ```
 
-Supported provider strings: `"openai"`, `"anthropic"`, `"deepseek"`, `"nvidia"`, `"bedrock-anthropic"`, `"openai-compatible"`, `"anthropic-compatible"`.
+Supported provider strings: `"openai"`, `"openai-response"`, `"anthropic"`, `"deepseek"`, `"nvidia"`, `"bedrock-anthropic"`, `"openai-compatible"`, `"anthropic-compatible"`.

--- a/docs/concepts/model.md
+++ b/docs/concepts/model.md
@@ -67,6 +67,25 @@ model = OpenAIModel(id="gpt-4o", name="gpt-4o")
 # Reads OPENAI_API_KEY from environment
 ```
 
+### OpenAI Responses
+
+For OpenAI models that should use the Responses API instead of Chat
+Completions:
+
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai-response",
+    model_name="gpt-4.1-mini",
+)
+```
+
+This provider still exposes `Model.arun_stream()` and normalized
+`StreamChunk` output. It currently supports text streaming and function
+calling, and reconstructs each request statelessly from the SDK message
+ledger.
+
 ### Anthropic
 
 ```python

--- a/docs/superpowers/plans/2026-04-15-openai-response-provider.md
+++ b/docs/superpowers/plans/2026-04-15-openai-response-provider.md
@@ -1,0 +1,1138 @@
+# OpenAI Responses Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `openai-response` provider that uses OpenAI Responses API while keeping the SDK public `Model.arun_stream(messages, tools) -> AsyncIterator[StreamChunk]` contract and current agent/tool path unchanged.
+
+**Architecture:** Implement a dedicated `OpenAIResponsesModel` plus a private converter that maps canonical SDK messages/tools into Responses request items and maps Responses stream events back into normalized `StreamChunk` values. Keep all OpenAI Responses semantics inside the provider boundary and leave `openai` / `openai-compatible` on `chat.completions`.
+
+**Tech Stack:** Python 3.11+, `openai` async SDK, pytest, pytest-asyncio, existing `Model` / `StreamChunk` abstractions
+
+---
+
+## File Map
+
+- Create: `agiwo/llm/openai_response.py`
+  - Own the `OpenAIResponsesModel` provider, client setup, request assembly, stream normalization, retry behavior.
+- Create: `agiwo/llm/openai_response_converter.py`
+  - Own provider-private conversion from canonical SDK `messages` / chat-style tools to Responses `input` / function tools.
+- Modify: `agiwo/config/settings.py`
+  - Add `openai-response` to `ModelProvider` and provider registries.
+- Modify: `agiwo/llm/factory.py`
+  - Register the new provider in `PROVIDER_SPECS`.
+- Modify: `agiwo/llm/__init__.py`
+  - Export `OpenAIResponsesModel`.
+- Modify: `tests/llm/test_factory.py`
+  - Add factory construction coverage for `openai-response`.
+- Create: `tests/llm/test_openai_response.py`
+  - Add provider-level conversion and streaming tests.
+- Modify: `tests/agent/test_run_contracts.py`
+  - Add one contract test proving upper layers consume `openai-response`-style tool-call chunks unchanged.
+- Modify: `docs/api/model.md`
+  - Document the new provider and its scope.
+- Modify: `docs/concepts/model.md`
+  - Document stateless multi-turn behavior and function-calling support.
+
+## Task 1: Register the Provider Surface
+
+**Files:**
+- Modify: `agiwo/config/settings.py`
+- Modify: `agiwo/llm/factory.py`
+- Modify: `agiwo/llm/__init__.py`
+- Modify: `tests/llm/test_factory.py`
+
+- [ ] **Step 1: Write the failing factory tests**
+
+Add these tests to `tests/llm/test_factory.py`:
+
+```python
+from agiwo.llm.openai_response import OpenAIResponsesModel
+
+
+def test_create_model_builds_openai_response_instance() -> None:
+    model = create_model(
+        ModelSpec(
+            provider="openai-response",
+            model_name="gpt-4.1-mini",
+            temperature=0.2,
+            max_output_tokens=256,
+        )
+    )
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.provider == "openai-response"
+    assert model.temperature == 0.2
+    assert model.max_output_tokens == 256
+
+
+def test_create_model_from_dict_builds_openai_response_instance(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    model = create_model_from_dict(
+        provider="openai-response",
+        model_name="gpt-4.1-mini",
+        params={"temperature": 0.15, "max_output_tokens": 111},
+    )
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.provider == "openai-response"
+    assert model.temperature == 0.15
+    assert model.max_output_tokens == 111
+```
+
+- [ ] **Step 2: Run the factory tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_factory.py -v
+```
+
+Expected:
+
+```text
+FAIL tests/llm/test_factory.py::test_create_model_builds_openai_response_instance
+E   pydantic_core._pydantic_core.ValidationError: provider
+```
+
+- [ ] **Step 3: Add the provider enum and factory registration**
+
+Update `agiwo/config/settings.py`:
+
+```python
+ModelProvider = Literal[
+    "openai",
+    "openai-response",
+    "openai-compatible",
+    "deepseek",
+    "anthropic",
+    "anthropic-compatible",
+    "nvidia",
+    "bedrock-anthropic",
+]
+```
+
+Create a minimal provider shell in `agiwo/llm/openai_response.py`:
+
+```python
+from agiwo.llm.base import LLMConfig, Model, StreamChunk
+
+
+class OpenAIResponsesModel(Model):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        api_key: str | None = None,
+        base_url: str | None = "https://api.openai.com/v1",
+        allow_env_fallback: bool = True,
+        temperature: float = 0.7,
+        top_p: float = 1.0,
+        max_output_tokens: int = 4096,
+        max_context_window: int = 200000,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        cache_hit_price: float = 0.0,
+        input_price: float = 0.0,
+        output_price: float = 0.0,
+        provider: str = "openai-response",
+    ) -> None:
+        super().__init__(
+            LLMConfig(
+                id=id,
+                name=name,
+                api_key=api_key,
+                base_url=base_url,
+                temperature=temperature,
+                top_p=top_p,
+                max_output_tokens=max_output_tokens,
+                max_context_window=max_context_window,
+                frequency_penalty=frequency_penalty,
+                presence_penalty=presence_penalty,
+                provider=provider,
+                cache_hit_price=cache_hit_price,
+                input_price=input_price,
+                output_price=output_price,
+            )
+        )
+        self.allow_env_fallback = allow_env_fallback
+
+    async def arun_stream(self, messages, tools=None):
+        del messages, tools
+        if False:
+            yield StreamChunk()
+```
+
+Update `agiwo/llm/factory.py` imports and provider specs:
+
+```python
+from agiwo.llm.openai_response import OpenAIResponsesModel
+```
+
+```python
+    "openai-response": ProviderSpec(model_class=OpenAIResponsesModel),
+```
+
+Update `agiwo/llm/__init__.py`:
+
+```python
+from agiwo.llm.openai_response import OpenAIResponsesModel
+```
+
+and include:
+
+```python
+    "OpenAIResponsesModel",
+```
+
+- [ ] **Step 4: Run the factory tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_factory.py -v
+```
+
+Expected:
+
+```text
+PASSED tests/llm/test_factory.py::test_create_model_builds_openai_response_instance
+PASSED tests/llm/test_factory.py::test_create_model_from_dict_builds_openai_response_instance
+```
+
+- [ ] **Step 5: Commit the provider surface wiring**
+
+Run:
+
+```bash
+git add agiwo/config/settings.py agiwo/llm/factory.py agiwo/llm/__init__.py agiwo/llm/openai_response.py tests/llm/test_factory.py
+git commit -m "feat: register openai responses model provider"
+```
+
+## Task 2: Build the Responses Converter
+
+**Files:**
+- Create: `agiwo/llm/openai_response_converter.py`
+- Create: `tests/llm/test_openai_response.py`
+
+- [ ] **Step 1: Write failing converter tests**
+
+Create `tests/llm/test_openai_response.py` with these converter tests:
+
+```python
+import pytest
+
+from agiwo.llm.openai_response_converter import (
+    convert_messages_to_responses_input,
+    convert_tools_to_responses_tools,
+    split_system_instructions,
+)
+
+
+def test_split_system_instructions_collects_system_messages() -> None:
+    instructions, remaining = split_system_instructions(
+        [
+            {"role": "system", "content": "You are careful."},
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "Prefer tools."},
+        ]
+    )
+
+    assert instructions == "You are careful.\n\nPrefer tools."
+    assert remaining == [{"role": "user", "content": "hello"}]
+
+
+def test_convert_messages_to_responses_input_maps_user_assistant_tool_flow() -> None:
+    items = convert_messages_to_responses_input(
+        [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "weather_lookup", "arguments": '{"city":"Paris"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": '{"temp_c":21}'},
+            {"role": "assistant", "content": "It is 21C."},
+        ]
+    )
+
+    assert items[0]["type"] == "message"
+    assert items[0]["role"] == "user"
+    assert items[1]["type"] == "function_call"
+    assert items[1]["call_id"] == "call_123"
+    assert items[2]["type"] == "function_call_output"
+    assert items[2]["call_id"] == "call_123"
+    assert items[3]["type"] == "message"
+
+
+def test_convert_tools_to_responses_tools_flattens_function_schema() -> None:
+    tools = convert_tools_to_responses_tools(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather_lookup",
+                    "description": "Look up weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }
+        ]
+    )
+
+    assert tools == [
+        {
+            "type": "function",
+            "name": "weather_lookup",
+            "description": "Look up weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        }
+    ]
+
+
+def test_convert_messages_to_responses_input_rejects_unknown_role() -> None:
+    with pytest.raises(ValueError, match="Unsupported message role"):
+        convert_messages_to_responses_input([{"role": "developer", "content": "x"}])
+
+
+def test_convert_tools_to_responses_tools_rejects_non_function_tools() -> None:
+    with pytest.raises(ValueError, match="Unsupported tool type"):
+        convert_tools_to_responses_tools([{"type": "web_search"}])
+```
+
+- [ ] **Step 2: Run the converter tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_openai_response.py -v
+```
+
+Expected:
+
+```text
+ERROR tests/llm/test_openai_response.py
+E   ModuleNotFoundError: No module named 'agiwo.llm.openai_response_converter'
+```
+
+- [ ] **Step 3: Implement the converter**
+
+Create `agiwo/llm/openai_response_converter.py`:
+
+```python
+import json
+from typing import Any
+
+
+def split_system_instructions(
+    messages: list[dict[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    instruction_parts: list[str] = []
+    remaining: list[dict[str, Any]] = []
+
+    for message in messages:
+        if message.get("role") == "system":
+            content = message.get("content")
+            if isinstance(content, str) and content:
+                instruction_parts.append(content)
+            continue
+        remaining.append(message)
+
+    instructions = "\n\n".join(instruction_parts) or None
+    return instructions, remaining
+
+
+def _serialize_tool_output(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=True)
+
+
+def _convert_user_message(message: dict[str, Any]) -> dict[str, Any]:
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("Unsupported user content for openai-response provider")
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": content}],
+    }
+
+
+def _convert_assistant_message(message: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+
+    tool_calls = message.get("tool_calls") or []
+    for tool_call in tool_calls:
+        if tool_call.get("type") != "function":
+            raise ValueError("Unsupported assistant tool call type for openai-response provider")
+        function = tool_call.get("function") or {}
+        items.append(
+            {
+                "type": "function_call",
+                "call_id": tool_call["id"],
+                "name": function["name"],
+                "arguments": function.get("arguments", ""),
+            }
+        )
+
+    content = message.get("content")
+    if content is not None:
+        if not isinstance(content, str):
+            raise ValueError("Unsupported assistant content for openai-response provider")
+        items.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": content}],
+            }
+        )
+
+    return items
+
+
+def _convert_tool_message(message: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "function_call_output",
+        "call_id": message["tool_call_id"],
+        "output": _serialize_tool_output(message.get("content")),
+    }
+
+
+def convert_messages_to_responses_input(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+
+    for message in messages:
+        role = message.get("role")
+        if role == "user":
+            items.append(_convert_user_message(message))
+            continue
+        if role == "assistant":
+            items.extend(_convert_assistant_message(message))
+            continue
+        if role == "tool":
+            items.append(_convert_tool_message(message))
+            continue
+        raise ValueError(f"Unsupported message role for openai-response provider: {role}")
+
+    return items
+
+
+def convert_tools_to_responses_tools(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            raise ValueError("Unsupported tool type for openai-response provider")
+        function = tool["function"]
+        converted.append(
+            {
+                "type": "function",
+                "name": function["name"],
+                "description": function.get("description", ""),
+                "parameters": function.get("parameters", {}),
+            }
+        )
+
+    return converted
+```
+
+- [ ] **Step 4: Run the converter tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_openai_response.py -v
+```
+
+Expected:
+
+```text
+PASSED tests/llm/test_openai_response.py::test_split_system_instructions_collects_system_messages
+PASSED tests/llm/test_openai_response.py::test_convert_messages_to_responses_input_maps_user_assistant_tool_flow
+PASSED tests/llm/test_openai_response.py::test_convert_tools_to_responses_tools_flattens_function_schema
+```
+
+- [ ] **Step 5: Commit the converter**
+
+Run:
+
+```bash
+git add agiwo/llm/openai_response_converter.py tests/llm/test_openai_response.py
+git commit -m "feat: add openai responses request converter"
+```
+
+## Task 3: Implement Responses Streaming and Usage Normalization
+
+**Files:**
+- Modify: `agiwo/llm/openai_response.py`
+- Modify: `tests/llm/test_openai_response.py`
+
+- [ ] **Step 1: Extend provider tests with streaming scenarios**
+
+Append these tests to `tests/llm/test_openai_response.py`:
+
+```python
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from agiwo.llm.openai_response import OpenAIResponsesModel
+
+
+def _event(event_type: str, **kwargs):
+    return SimpleNamespace(type=event_type, **kwargs)
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_streams_text_and_usage(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(id="gpt-4.1-mini", name="gpt-4.1-mini", api_key="test-key")
+    model.client = AsyncMock()
+
+    stream_events = [
+        _event("response.output_text.delta", delta="Hel"),
+        _event("response.output_text.delta", delta="lo"),
+        _event(
+            "response.completed",
+            response=SimpleNamespace(
+                usage=SimpleNamespace(input_tokens=7, output_tokens=3, total_tokens=10),
+                output=[SimpleNamespace(type="message")],
+                incomplete_details=None,
+            ),
+        ),
+    ]
+
+    async def async_iter():
+        for item in stream_events:
+            yield item
+
+    mock_stream = AsyncMock()
+    mock_stream.__aiter__.return_value = async_iter()
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    chunks = []
+    async for chunk in model.arun_stream([{"role": "user", "content": "hello"}]):
+        chunks.append(chunk)
+
+    assert [chunk.content for chunk in chunks[:-1]] == ["Hel", "lo"]
+    assert chunks[-1].usage["input_tokens"] == 7
+    assert chunks[-1].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_streams_function_call_deltas(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(id="gpt-4.1-mini", name="gpt-4.1-mini", api_key="test-key")
+    model.client = AsyncMock()
+
+    stream_events = [
+        _event(
+            "response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_123",
+                name="weather_lookup",
+                arguments="",
+            ),
+        ),
+        _event(
+            "response.function_call_arguments.delta",
+            output_index=0,
+            item_id="fc_1",
+            delta='{"city":"Par',
+        ),
+        _event(
+            "response.function_call_arguments.delta",
+            output_index=0,
+            item_id="fc_1",
+            delta='is"}',
+        ),
+        _event(
+            "response.completed",
+            response=SimpleNamespace(
+                usage=None,
+                output=[SimpleNamespace(type="function_call")],
+                incomplete_details=None,
+            ),
+        ),
+    ]
+
+    async def async_iter():
+        for item in stream_events:
+            yield item
+
+    mock_stream = AsyncMock()
+    mock_stream.__aiter__.return_value = async_iter()
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    chunks = []
+    async for chunk in model.arun_stream([{"role": "user", "content": "weather"}]):
+        chunks.append(chunk)
+
+    assert chunks[0].tool_calls == [
+        {
+            "index": 0,
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "weather_lookup", "arguments": '{"city":"Par'},
+        }
+    ]
+    assert chunks[1].tool_calls == [
+        {
+            "index": 0,
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "weather_lookup", "arguments": 'is"}'},
+        }
+    ]
+    assert chunks[-1].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_rejects_empty_stream(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(id="gpt-4.1-mini", name="gpt-4.1-mini", api_key="test-key")
+    model.client = AsyncMock()
+
+    async def async_iter():
+        if False:
+            yield None
+
+    mock_stream = AsyncMock()
+    mock_stream.__aiter__.return_value = async_iter()
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    with pytest.raises(RuntimeError, match="returned no chunks"):
+        async for _ in model.arun_stream([{"role": "user", "content": "hello"}]):
+            pass
+```
+
+- [ ] **Step 2: Run the provider tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_openai_response.py -v
+```
+
+Expected:
+
+```text
+FAIL tests/llm/test_openai_response.py::test_openai_response_model_streams_text_and_usage
+E   AssertionError
+```
+
+- [ ] **Step 3: Implement request assembly and stream normalization**
+
+Replace the shell implementation in `agiwo/llm/openai_response.py` with:
+
+```python
+from typing import Any, AsyncIterator
+
+from openai import (
+    AsyncOpenAI,
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    RateLimitError,
+)
+
+from agiwo.config.settings import get_settings
+from agiwo.llm.base import LLMConfig, Model, StreamChunk
+from agiwo.llm.event_normalizer import normalize_usage_metrics
+from agiwo.llm.openai_response_converter import (
+    convert_messages_to_responses_input,
+    convert_tools_to_responses_tools,
+    split_system_instructions,
+)
+from agiwo.utils.logging import get_logger
+from agiwo.utils.retry import retry_async
+
+logger = get_logger(__name__)
+
+OPENAI_RETRYABLE = (
+    APIConnectionError,
+    RateLimitError,
+    InternalServerError,
+    APITimeoutError,
+)
+
+
+class OpenAIResponsesModel(Model):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        api_key: str | None = None,
+        base_url: str | None = "https://api.openai.com/v1",
+        allow_env_fallback: bool = True,
+        temperature: float = 0.7,
+        top_p: float = 1.0,
+        max_output_tokens: int = 4096,
+        max_context_window: int = 200000,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        cache_hit_price: float = 0.0,
+        input_price: float = 0.0,
+        output_price: float = 0.0,
+        provider: str = "openai-response",
+    ) -> None:
+        super().__init__(
+            LLMConfig(
+                id=id,
+                name=name,
+                api_key=api_key,
+                base_url=base_url,
+                temperature=temperature,
+                top_p=top_p,
+                max_output_tokens=max_output_tokens,
+                max_context_window=max_context_window,
+                frequency_penalty=frequency_penalty,
+                presence_penalty=presence_penalty,
+                provider=provider,
+                cache_hit_price=cache_hit_price,
+                input_price=input_price,
+                output_price=output_price,
+            )
+        )
+        self.allow_env_fallback = allow_env_fallback
+        self.client = self._create_client()
+
+    def _resolve_api_key(self) -> str | None:
+        if self.api_key:
+            return self.api_key
+        if self.allow_env_fallback:
+            settings = get_settings()
+            if settings.openai_api_key:
+                return settings.openai_api_key.get_secret_value()
+        return None
+
+    def _resolve_base_url(self) -> str | None:
+        if self.base_url:
+            return self.base_url
+        if self.allow_env_fallback:
+            return get_settings().openai_base_url
+        return None
+
+    def _create_client(self) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            api_key=self._resolve_api_key(),
+            base_url=self._resolve_base_url(),
+        )
+
+    def _build_params(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        instructions, remaining = split_system_instructions(messages)
+        params: dict[str, Any] = {
+            "model": self.id or self.name,
+            "input": convert_messages_to_responses_input(remaining),
+            "stream": True,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
+        if instructions is not None:
+            params["instructions"] = instructions
+        if self.max_output_tokens:
+            params["max_output_tokens"] = self.max_output_tokens
+        if tools:
+            params["tools"] = convert_tools_to_responses_tools(tools)
+        return params
+
+    @retry_async(exceptions=OPENAI_RETRYABLE)
+    async def arun_stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        stream = await self.client.responses.create(**self._build_params(messages, tools))
+
+        chunk_count = 0
+        tool_calls: dict[int, dict[str, Any]] = {}
+
+        async for event in stream:
+            stream_chunk = self._event_to_chunk(event, tool_calls)
+            if stream_chunk is None:
+                continue
+            chunk_count += 1
+            yield stream_chunk
+
+        if chunk_count == 0:
+            raise RuntimeError("OpenAI Responses stream returned no chunks")
+
+    def _event_to_chunk(
+        self,
+        event: Any,
+        tool_calls: dict[int, dict[str, Any]],
+    ) -> StreamChunk | None:
+        if event.type == "response.output_text.delta":
+            return StreamChunk(content=event.delta)
+
+        if event.type == "response.output_item.added" and event.item.type == "function_call":
+            tool_calls[event.output_index] = {
+                "id": event.item.call_id,
+                "name": event.item.name,
+            }
+            return None
+
+        if event.type == "response.function_call_arguments.delta":
+            state = tool_calls.get(event.output_index)
+            if state is None:
+                return None
+            return StreamChunk(
+                tool_calls=[
+                    {
+                        "index": event.output_index,
+                        "id": state["id"],
+                        "type": "function",
+                        "function": {
+                            "name": state["name"],
+                            "arguments": event.delta,
+                        },
+                    }
+                ]
+            )
+
+        if event.type == "response.completed":
+            finish_reason = "stop"
+            output_items = getattr(event.response, "output", None) or []
+            if any(getattr(item, "type", None) == "function_call" for item in output_items):
+                finish_reason = "tool_calls"
+
+            usage = None
+            if getattr(event.response, "usage", None):
+                usage = normalize_usage_metrics(event.response.usage)
+
+            return StreamChunk(usage=usage, finish_reason=finish_reason)
+
+        return None
+```
+
+Also make sure `__init__()` assigns:
+
+```python
+self.client = self._create_client()
+```
+
+- [ ] **Step 4: Run the provider tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_openai_response.py -v
+```
+
+Expected:
+
+```text
+PASSED tests/llm/test_openai_response.py::test_openai_response_model_streams_text_and_usage
+PASSED tests/llm/test_openai_response.py::test_openai_response_model_streams_function_call_deltas
+PASSED tests/llm/test_openai_response.py::test_openai_response_model_rejects_empty_stream
+```
+
+- [ ] **Step 5: Commit the provider implementation**
+
+Run:
+
+```bash
+git add agiwo/llm/openai_response.py tests/llm/test_openai_response.py
+git commit -m "feat: implement openai responses streaming provider"
+```
+
+## Task 4: Verify Upper-Layer Compatibility
+
+**Files:**
+- Modify: `tests/agent/test_run_contracts.py`
+
+- [ ] **Step 1: Add a contract test for chat-compatible tool-call deltas**
+
+Append this test to `tests/agent/test_run_contracts.py`:
+
+```python
+class ToolCallDeltaModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="tool-call-delta-model", name="tool-call-delta-model")
+
+    async def arun_stream(self, messages, tools=None) -> AsyncIterator[StreamChunk]:
+        del messages, tools
+        yield StreamChunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "weather_lookup", "arguments": '{"city":"Par'},
+                }
+            ]
+        )
+        yield StreamChunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "weather_lookup", "arguments": 'is"}'},
+                }
+            ]
+        )
+        yield StreamChunk(finish_reason="tool_calls")
+
+
+@pytest.mark.asyncio
+async def test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas() -> None:
+    session_runtime = SessionRuntime(
+        session_id="tool-call-contract-session",
+        run_step_storage=InMemoryRunStepStorage(),
+    )
+    agent = Agent(
+        AgentConfig(name="tool-call-contract", description="tool call contract test"),
+        model=ToolCallDeltaModel(),
+    )
+
+    handle = agent.start("weather?", session_id="tool-call-contract-session")
+    result = await handle.wait()
+    steps = await session_runtime.run_step_storage.get_steps(
+        session_id="tool-call-contract-session",
+        agent_id=agent.id,
+    )
+
+    assert result.response is None
+    assert steps[-1].tool_calls == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "weather_lookup", "arguments": '{"city":"Paris"}'},
+        }
+    ]
+```
+
+- [ ] **Step 2: Run the contract test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas -v
+```
+
+Expected:
+
+```text
+FAIL tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas
+E   AssertionError
+```
+
+- [ ] **Step 3: Fix the test to inspect persisted assistant steps through the agent session**
+
+Replace the test body with this exact version so it reads the persisted assistant step from the same `SessionRuntime` used by the run:
+
+```python
+@pytest.mark.asyncio
+async def test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas() -> None:
+    session_runtime = SessionRuntime(
+        session_id="tool-call-contract-session",
+        run_step_storage=InMemoryRunStepStorage(),
+    )
+    agent = Agent(
+        AgentConfig(name="tool-call-contract", description="tool call contract test"),
+        model=ToolCallDeltaModel(),
+    )
+
+    handle = agent.start(
+        "weather?",
+        session_id="tool-call-contract-session",
+        session_runtime=session_runtime,
+    )
+    result = await handle.wait()
+    steps = await session_runtime.run_step_storage.get_steps(
+        session_id="tool-call-contract-session",
+        agent_id=agent.id,
+    )
+
+    assert result.response is None
+    assert steps[-1].tool_calls == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "weather_lookup", "arguments": '{"city":"Paris"}'},
+        }
+    ]
+```
+
+- [ ] **Step 4: Run the contract test to verify it passes**
+
+Run:
+
+```bash
+uv run pytest tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas -v
+```
+
+Expected:
+
+```text
+PASSED tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas
+```
+
+- [ ] **Step 5: Commit the contract coverage**
+
+Run:
+
+```bash
+git add tests/agent/test_run_contracts.py
+git commit -m "test: cover tool-call delta contract for responses provider"
+```
+
+## Task 5: Document the Provider and Run the Repo Checks
+
+**Files:**
+- Modify: `docs/api/model.md`
+- Modify: `docs/concepts/model.md`
+
+- [ ] **Step 1: Update the docs**
+
+In `docs/api/model.md`, add `OpenAIResponsesModel` to the provider list:
+
+~~~markdown
+### `OpenAIResponsesModel`
+
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai-response",
+    model_name="gpt-4.1-mini",
+)
+```
+
+Uses OpenAI Responses API internally while preserving the SDK `StreamChunk` contract.
+First-version support covers streamed text and function calling. Multi-turn replay is stateless and does not use `previous_response_id`.
+~~~
+
+In `docs/concepts/model.md`, add this provider note under built-in providers:
+
+~~~markdown
+### OpenAI Responses
+
+For OpenAI models that should use the Responses API instead of Chat Completions:
+
+```python
+from agiwo.llm import create_model_from_dict
+
+model = create_model_from_dict(
+    provider="openai-response",
+    model_name="gpt-4.1-mini",
+)
+```
+
+This provider still exposes `Model.arun_stream()` and normalized `StreamChunk` output. It currently supports text streaming and function calling, and reconstructs each request statelessly from the SDK message ledger.
+~~~
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/llm/test_factory.py tests/llm/test_openai_response.py tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas -v
+```
+
+Expected:
+
+```text
+PASSED tests/llm/test_factory.py::test_create_model_builds_openai_response_instance
+PASSED tests/llm/test_openai_response.py::test_openai_response_model_streams_text_and_usage
+PASSED tests/agent/test_run_contracts.py::test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas
+```
+
+- [ ] **Step 3: Run changed-file lint**
+
+Run:
+
+```bash
+uv run python scripts/lint.py changed
+```
+
+Expected:
+
+```text
+All checks passed
+```
+
+- [ ] **Step 4: Commit the docs and verification updates**
+
+Run:
+
+```bash
+git add docs/api/model.md docs/concepts/model.md
+git commit -m "docs: add openai responses provider documentation"
+```
+
+- [ ] **Step 5: Run the pre-submit lint sequence**
+
+Run:
+
+```bash
+uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/
+uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/
+uv run python scripts/lint.py imports
+uv run python scripts/repo_guard.py
+```
+
+Expected:
+
+```text
+All commands exit with code 0.
+```
+
+## Self-Review
+
+### Spec coverage
+
+- New provider enum and factory registration: covered by Task 1.
+- Dedicated `OpenAIResponsesModel`: covered by Task 3.
+- Private converter for canonical messages/tools: covered by Task 2.
+- Stateless replay without `previous_response_id`: covered by Task 2 and Task 3 request assembly.
+- Streamed text and function calling: covered by Task 3.
+- Upper-layer `StreamChunk` compatibility: covered by Task 4.
+- Docs updates: covered by Task 5.
+
+### Placeholder scan
+
+Checked for `TBD`, `TODO`, vague "handle edge cases" wording, and references to undefined future tasks. None remain.
+
+### Type consistency
+
+- Provider class name is consistently `OpenAIResponsesModel`.
+- Provider string is consistently `openai-response`.
+- Converter helper names are consistently `split_system_instructions`, `convert_messages_to_responses_input`, and `convert_tools_to_responses_tools`.
+- Normalized tool-call delta shape matches `agiwo.agent.llm_caller._accumulate_tool_calls()`.

--- a/docs/superpowers/specs/2026-04-15-openai-response-design.md
+++ b/docs/superpowers/specs/2026-04-15-openai-response-design.md
@@ -1,0 +1,491 @@
+# OpenAI Responses Provider Design
+
+- Date: 2026-04-15
+- Status: Proposed
+- Scope: SDK LLM provider layer, model factory, model docs, provider tests
+
+## Context
+
+The current SDK LLM boundary is streaming-first and intentionally narrow:
+
+- `agiwo.llm.base.Model` exposes `arun_stream(messages, tools) -> AsyncIterator[StreamChunk]`
+- agent runtime consumes only normalized `StreamChunk` fields
+- `OpenAIModel` currently targets `chat.completions`
+
+We want to support OpenAI's Responses API without changing the public `Model` contract and without changing agent/runtime message ledger semantics.
+
+The requested scope is intentionally narrow:
+
+- add a new provider: `openai-response`
+- keep `openai` and `openai-compatible` on `chat.completions`
+- keep the upper-layer behavior aligned with other providers by continuing to emit `StreamChunk`
+- first version supports text streaming and function calling
+- multi-turn behavior remains stateless from the SDK point of view
+- do not add `previous_response_id`
+- do not add encrypted reasoning preservation
+
+## Goals
+
+- Add `provider="openai-response"` as a first-class SDK provider.
+- Keep the public `Model` contract unchanged.
+- Preserve compatibility with the current agent/tool execution path.
+- Support streamed text output.
+- Support streamed function-call deltas and tool-result follow-up turns.
+- Keep implementation localized to the OpenAI Responses provider boundary.
+
+## Non-Goals
+
+- Changing `agiwo.llm.base.Model` or `StreamChunk`.
+- Changing agent runtime ledger or message storage format.
+- Migrating `openai` or `openai-compatible` away from `chat.completions`.
+- Introducing `previous_response_id`, `conversation`, or SDK-managed Responses state.
+- Preserving encrypted reasoning items across turns.
+- Adding built-in Responses tools such as web search, file search, or code interpreter.
+- Refactoring all OpenAI-family providers into a new shared framework.
+
+## Options Considered
+
+### Option A: Extend `OpenAIModel` with a Responses branch
+
+Reuse `agiwo/llm/openai.py` and switch endpoint behavior based on provider.
+
+Pros:
+
+- Lowest immediate code volume.
+- Reuses existing client/retry configuration directly.
+
+Cons:
+
+- Mixes two distinct OpenAI protocols in one provider implementation.
+- Makes testing and debugging harder because chat-completions and Responses events have different semantics.
+- Increases regression risk for existing `openai` and `openai-compatible` behavior.
+
+### Option B: Add a dedicated `OpenAIResponsesModel`
+
+Create a new provider implementation dedicated to Responses and keep the existing OpenAI provider untouched.
+
+Pros:
+
+- Keeps protocol-specific logic isolated.
+- Matches the repository's preference for explicit provider adapters.
+- Minimizes risk to existing `chat.completions` behavior.
+- Keeps the upper layer unchanged by normalizing to `StreamChunk`.
+
+Cons:
+
+- Requires a private message/tool conversion layer.
+- Duplicates a small amount of client setup and retry wiring unless lightly shared.
+
+### Option C: Introduce a broader OpenAI-family abstraction first
+
+Extract common OpenAI-family infrastructure and then implement both chat-completions and Responses on top.
+
+Pros:
+
+- Potentially cleaner long-term architecture.
+- Avoids duplicated config/client logic.
+
+Cons:
+
+- Expands scope beyond the requested feature.
+- Raises implementation and review cost.
+- Risks unrelated regressions and refactoring drift.
+
+## Decision
+
+Choose Option B.
+
+Add a dedicated `OpenAIResponsesModel` and a new provider name `openai-response`. The provider is responsible for translating the SDK's canonical OpenAI-style message ledger into OpenAI Responses request items, then translating Responses stream events back into normalized `StreamChunk` values.
+
+The rest of the SDK continues to treat this provider exactly like any other `Model`.
+
+## 1. Public Surface and Factory Wiring
+
+### Provider enum
+
+Add `openai-response` to `ModelProvider` in `agiwo/config/settings.py` and include it in `ALL_MODEL_PROVIDERS`.
+
+### Factory registration
+
+Register the provider in `agiwo/llm/factory.py`:
+
+- provider name: `openai-response`
+- model class: `OpenAIResponsesModel`
+- env fallback behavior: same as `openai`
+- provider override: not needed
+
+### Public exports
+
+Export `OpenAIResponsesModel` from `agiwo/llm/__init__.py` if public provider classes are currently exported.
+
+### Configuration semantics
+
+`openai-response` uses the same core config fields as `openai`:
+
+- `api_key`
+- `base_url`
+- `temperature`
+- `top_p`
+- `max_output_tokens`
+- `frequency_penalty`
+- `presence_penalty`
+
+Provider-specific semantics stay internal. The factory and config layer should not introduce new public model params for the first version.
+
+## 2. Provider Structure
+
+Add a new provider module:
+
+- `agiwo/llm/openai_response.py`
+
+Optional private helper:
+
+- `agiwo/llm/openai_response_converter.py`
+
+Responsibilities:
+
+- `OpenAIResponsesModel`
+  - resolve API key and base URL using the same OpenAI env behavior as `OpenAIModel`
+  - construct `AsyncOpenAI`
+  - build Responses request params
+  - stream raw Responses events
+  - normalize events into `StreamChunk`
+
+- converter helper
+  - convert SDK canonical `messages` to Responses `input`
+  - convert OpenAI chat-style tool schemas to Responses function tools
+  - centralize any provider-specific validation
+
+The converter remains provider-private. The canonical SDK conversation format stays as the existing OpenAI-style message list.
+
+## 3. Request Mapping
+
+The provider receives:
+
+- `messages: list[dict]`
+- `tools: list[dict] | None`
+
+It must convert them into a Responses request while keeping the call stateless.
+
+### 3.1 Stateless multi-turn policy
+
+For every request:
+
+- convert the full current message ledger into Responses `input`
+- do not use `previous_response_id`
+- do not use `conversation`
+- do not depend on server-side retained state
+
+This preserves current SDK semantics, where the agent runtime owns conversation state.
+
+### 3.2 System prompt handling
+
+`system` messages should be lifted into `instructions`.
+
+Rules:
+
+- if there is one system message, use its content as `instructions`
+- if there are multiple system messages in the assembled ledger, concatenate them with clear separators in original order
+- do not also duplicate those system messages into `input`
+
+This keeps the provider aligned with the Responses API shape while preserving the SDK's existing prompt assembly.
+
+### 3.3 User messages
+
+Canonical input:
+
+```python
+{"role": "user", "content": "..."}
+```
+
+Responses input item:
+
+```python
+{
+    "type": "message",
+    "role": "user",
+    "content": [{"type": "input_text", "text": "..."}],
+}
+```
+
+If the current ledger already contains content structures that the first version does not support, the provider should fail fast with a clear `ValueError`.
+
+### 3.4 Assistant text messages
+
+Historical assistant text must be preserved in stateless replay.
+
+Convert assistant text messages into Responses-compatible assistant output-message items. The conversion layer should preserve:
+
+- assistant role
+- text content
+- item ordering in the conversation
+
+The implementation may use typed SDK params or raw dict payloads, but it must produce valid Responses input items that represent prior assistant outputs.
+
+### 3.5 Assistant tool calls
+
+Canonical assistant tool calls today look like chat-completions tool calls:
+
+```python
+{
+    "role": "assistant",
+    "tool_calls": [
+        {
+            "id": "...",
+            "type": "function",
+            "function": {"name": "...", "arguments": "..."},
+        }
+    ],
+}
+```
+
+Convert each tool call into a Responses `function_call` item:
+
+- `call_id` should use the canonical tool-call id
+- `name` should use the function name
+- `arguments` should remain the raw JSON string
+
+This is required so follow-up tool outputs can reference the same call id.
+
+### 3.6 Tool result messages
+
+Canonical tool-result messages:
+
+```python
+{
+    "role": "tool",
+    "tool_call_id": "...",
+    "content": "...",
+}
+```
+
+Convert them into Responses `function_call_output` items:
+
+- `call_id = tool_call_id`
+- `output = content` as string
+
+If `content` is not a string, serialize it consistently with existing tool-message behavior before sending it to the provider.
+
+### 3.7 Tool schema conversion
+
+Current tool schemas are OpenAI chat-style function tools:
+
+```python
+{
+    "type": "function",
+    "function": {
+        "name": "...",
+        "description": "...",
+        "parameters": {...},
+    },
+}
+```
+
+Responses function tools should be emitted as:
+
+```python
+{
+    "type": "function",
+    "name": "...",
+    "description": "...",
+    "parameters": {...},
+}
+```
+
+Only function tools are in scope for the first version. Any other tool type should be rejected at the provider boundary.
+
+## 4. Stream Event Normalization
+
+The provider must translate Responses stream events into `StreamChunk` so `agiwo.agent.llm_caller.stream_assistant_step()` continues to work unchanged.
+
+### 4.1 Text
+
+Map text deltas:
+
+- `response.output_text.delta` -> `StreamChunk(content=delta)`
+
+The provider should emit text chunks incrementally as they arrive.
+
+### 4.2 Function-call deltas
+
+Responses streams function-call arguments separately from text. The provider must accumulate these into chat-compatible tool-call deltas.
+
+Provider-internal state:
+
+- per-output-index function call buffer
+- stored fields: `id/call_id`, `name`, partial `arguments`
+
+Normalized output shape:
+
+```python
+{
+    "index": <output_index>,
+    "id": <call_id>,
+    "type": "function",
+    "function": {
+        "name": <name>,
+        "arguments": <partial_json>,
+    },
+}
+```
+
+This shape must stay compatible with the accumulator in `agiwo.agent.llm_caller._accumulate_tool_calls()`.
+
+### 4.3 Finish reason
+
+Map Responses completion semantics onto current `StreamChunk.finish_reason` values:
+
+- normal completion -> `stop`
+- function-call completion -> `tool_calls`
+- max-token/incomplete truncation -> `length`
+
+If the exact Responses terminal shape varies by event payload, normalize it in one provider-local helper rather than leaking protocol differences upward.
+
+### 4.4 Usage
+
+Provider usage should be normalized through the existing usage normalization path when possible.
+
+The provider should emit usage once it becomes available, typically on completion. The normalized shape must remain:
+
+- `input_tokens`
+- `output_tokens`
+- `total_tokens`
+- `cache_read_tokens`
+- `cache_creation_tokens`
+
+### 4.5 Reasoning content
+
+First-version policy:
+
+- if Responses emits stable reasoning text or summary content that can be surfaced safely, map it to `StreamChunk.reasoning_content`
+- if a reasoning event cannot be mapped cleanly, ignore it
+- do not preserve or replay encrypted reasoning items across turns
+
+This keeps the public contract unchanged while allowing best-effort reasoning visibility.
+
+## 5. Error Handling
+
+### Retry behavior
+
+Reuse the current OpenAI retry policy:
+
+- `APIConnectionError`
+- `RateLimitError`
+- `InternalServerError`
+- `APITimeoutError`
+
+### Validation failures
+
+If the converter encounters unsupported message or tool shapes, raise `ValueError` before making an API call. Error text should identify the unsupported input category.
+
+### Empty stream
+
+If the Responses stream yields no usable chunks, raise a runtime error equivalent in intent to the current `OpenAIModel` empty-stream failure.
+
+### Unsupported output items
+
+Ignore irrelevant protocol events that do not affect text, tool calls, usage, or completion.
+
+Fail fast when the response contains output-item shapes that are required for correctness but unsupported by this provider version.
+
+## 6. Compatibility Rules
+
+The following invariants must hold:
+
+- `Model.arun_stream()` signature does not change
+- `StreamChunk` shape does not change
+- agent/tool execution path does not branch on provider type
+- existing `openai` and `openai-compatible` behavior does not change
+- provider-specific Responses state does not leak into `RunContext`, `StepRecord`, or persisted messages
+
+## 7. Testing
+
+Add a dedicated provider test module:
+
+- `tests/llm/test_openai_response.py`
+
+Required coverage:
+
+### Provider tests
+
+- text streaming returns incremental `StreamChunk.content`
+- completion usage is normalized
+- function-call arguments stream into chat-compatible `tool_calls`
+- follow-up requests convert prior assistant tool calls and tool outputs correctly
+- empty stream raises a clear error
+- unsupported message/tool inputs fail at the provider boundary
+- OpenAI API exceptions still propagate through the existing retry policy
+
+### Factory tests
+
+- `create_model()` builds `OpenAIResponsesModel` for `provider="openai-response"`
+- config/env resolution matches `openai`
+
+### Contract tests
+
+At least one agent-level or llm-caller-level contract test should verify that `stream_assistant_step()` can consume `openai-response` tool-call chunks without any caller changes.
+
+## 8. Documentation
+
+Update:
+
+- `docs/api/model.md`
+- `docs/concepts/model.md`
+
+Document:
+
+- new provider name `openai-response`
+- that it uses OpenAI Responses API under the hood
+- that upper-layer semantics remain `StreamChunk`-based
+- that first-version support covers text and function calling only
+- that multi-turn handling is stateless and does not use `previous_response_id`
+
+## 9. Rollout Sequence
+
+Implement in this order:
+
+1. Add provider enum and factory wiring.
+2. Add `OpenAIResponsesModel` with client setup and retry behavior.
+3. Add message/tool conversion helper.
+4. Add Responses stream-event normalization to `StreamChunk`.
+5. Add provider and factory tests.
+6. Add one upper-layer contract test.
+7. Update model docs.
+
+## 10. Risks and Mitigations
+
+### Risk: assistant-history replay shape is subtly wrong
+
+Mitigation:
+
+- isolate conversion logic in one helper
+- test realistic message sequences: user -> assistant tool call -> tool output -> assistant final text
+
+### Risk: Responses function-call events do not align with current tool-call accumulator expectations
+
+Mitigation:
+
+- normalize all provider-emitted tool-call deltas into the exact shape currently consumed by `agiwo.agent.llm_caller`
+- add explicit tests for partial argument streaming
+
+### Risk: unsupported content types appear in current ledgers later
+
+Mitigation:
+
+- fail fast at the provider boundary for unsupported shapes
+- keep the first version intentionally narrow
+
+### Risk: provider starts duplicating too much `OpenAIModel` logic
+
+Mitigation:
+
+- allow light extraction of shared OpenAI client/setup helpers if it clearly reduces duplication
+- avoid broader refactors unrelated to Responses support
+
+## Acceptance Criteria
+
+- A caller can construct a model with `provider="openai-response"`.
+- The model streams text output as normalized `StreamChunk.content`.
+- The model streams function-call deltas as normalized `StreamChunk.tool_calls`.
+- Existing agent runtime code can execute tools against this provider without provider-specific branches.
+- Existing `openai` and `openai-compatible` providers remain unchanged.

--- a/tests/agent/test_run_contracts.py
+++ b/tests/agent/test_run_contracts.py
@@ -33,6 +33,40 @@ class FixedResponseModel(Model):
         yield StreamChunk(finish_reason="stop")
 
 
+class ToolCallDeltaModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="tool-call-delta-model", name="tool-call-delta-model")
+
+    async def arun_stream(self, messages, tools=None) -> AsyncIterator[StreamChunk]:
+        del messages, tools
+        yield StreamChunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "weather_lookup",
+                        "arguments": '{"city":"Par',
+                    },
+                }
+            ]
+        )
+        yield StreamChunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "arguments": 'is"}',
+                    },
+                }
+            ]
+        )
+        yield StreamChunk(finish_reason="tool_calls")
+
+
 @pytest.mark.asyncio
 async def test_handle_wait_is_idempotent() -> None:
     agent = Agent(
@@ -84,6 +118,34 @@ async def test_trivial_root_run_keeps_steps_count_stable() -> None:
 
     assert result.response == "final answer"
     assert result.metrics.steps_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_assistant_step_accumulates_chat_compatible_tool_call_deltas() -> (
+    None
+):
+    agent = Agent(
+        AgentConfig(name="tool-call-contract", description="tool call contract test"),
+        model=ToolCallDeltaModel(),
+    )
+
+    await agent.run("weather?", session_id="tool-call-contract-session")
+    steps = await agent.run_step_storage.get_steps(
+        session_id="tool-call-contract-session",
+        agent_id=agent.id,
+    )
+
+    assistant_steps = [step for step in steps if step.role == "assistant"]
+    assert assistant_steps[-1].tool_calls == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+                "name": "weather_lookup",
+                "arguments": '{"city":"Paris"}',
+            },
+        }
+    ]
 
 
 async def _collect_stream(stream):

--- a/tests/llm/test_factory.py
+++ b/tests/llm/test_factory.py
@@ -4,6 +4,7 @@ from agiwo.llm import ModelSpec, create_model, create_model_from_dict
 from agiwo.llm.anthropic import AnthropicModel
 from agiwo.llm.deepseek import DeepseekModel
 from agiwo.llm.openai import OpenAIModel
+from agiwo.llm.openai_response import OpenAIResponsesModel
 
 
 def test_create_model_builds_provider_specific_instance() -> None:
@@ -20,6 +21,24 @@ def test_create_model_builds_provider_specific_instance() -> None:
     assert model.name == "claude-3-5-sonnet-20240620"
     assert model.temperature == 0.1
     assert model.max_output_tokens == 512
+
+
+def test_create_model_builds_openai_response_instance(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    model = create_model(
+        ModelSpec(
+            provider="openai-response",
+            model_name="gpt-4.1-mini",
+            temperature=0.2,
+            max_output_tokens=256,
+        )
+    )
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.provider == "openai-response"
+    assert model.temperature == 0.2
+    assert model.max_output_tokens == 256
 
 
 def test_create_model_from_dict_uses_max_output_tokens(
@@ -60,6 +79,23 @@ def test_create_model_from_dict_resolves_openai_compatible_api_key_env(
     assert model.api_key == "minimax-key"
     assert model.base_url == "https://api.minimax.chat/v1"
     assert model.allow_env_fallback is False
+
+
+def test_create_model_from_dict_builds_openai_response_instance(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    model = create_model_from_dict(
+        provider="openai-response",
+        model_name="gpt-4.1-mini",
+        params={"temperature": 0.15, "max_output_tokens": 111},
+    )
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.provider == "openai-response"
+    assert model.temperature == 0.15
+    assert model.max_output_tokens == 111
 
 
 def test_create_model_from_dict_rejects_openai_compatible_without_env_name(

--- a/tests/llm/test_helper.py
+++ b/tests/llm/test_helper.py
@@ -69,6 +69,22 @@ def test_normalize_usage_metrics_partial_data():
     assert result["total_tokens"] is None
 
 
+def test_normalize_usage_metrics_openai_responses_nested_cached_tokens():
+    usage_data = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "input_tokens_details": {"cached_tokens": 3},
+    }
+
+    result = normalize_usage_metrics(usage_data)
+
+    assert result["input_tokens"] == 10
+    assert result["output_tokens"] == 5
+    assert result["total_tokens"] == 15
+    assert result["cache_read_tokens"] == 3
+
+
 def test_normalize_anthropic_stop_reason_maps_shared_semantics():
     assert normalize_anthropic_stop_reason("tool_use") == "tool_calls"
     assert normalize_anthropic_stop_reason("max_tokens") == "length"

--- a/tests/llm/test_openai_response.py
+++ b/tests/llm/test_openai_response.py
@@ -1,0 +1,299 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agiwo.llm.openai_response import OpenAIResponsesModel
+from agiwo.llm.openai_response_converter import (
+    convert_messages_to_responses_input,
+    convert_tools_to_responses_tools,
+    split_system_instructions,
+)
+
+
+def _event(event_type: str, **kwargs):
+    return SimpleNamespace(type=event_type, **kwargs)
+
+
+class _MockResponseStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for item in self._events:
+            yield item
+
+
+def test_split_system_instructions_collects_system_messages() -> None:
+    instructions, remaining = split_system_instructions(
+        [
+            {"role": "system", "content": "You are careful."},
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "Prefer tools."},
+        ]
+    )
+
+    assert instructions == "You are careful.\n\nPrefer tools."
+    assert remaining == [{"role": "user", "content": "hello"}]
+
+
+def test_convert_messages_to_responses_input_maps_user_assistant_tool_flow() -> None:
+    items = convert_messages_to_responses_input(
+        [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "weather_lookup",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": '{"temp_c":21}'},
+            {"role": "assistant", "content": "It is 21C."},
+        ]
+    )
+
+    assert items[0] == {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "weather?"}],
+    }
+    assert items[1]["type"] == "function_call"
+    assert items[1]["call_id"] == "call_123"
+    assert items[2]["type"] == "function_call_output"
+    assert items[2]["call_id"] == "call_123"
+    assert items[3]["type"] == "message"
+    assert items[3]["role"] == "assistant"
+    assert items[3]["content"] == [
+        {"type": "output_text", "text": "It is 21C.", "annotations": []}
+    ]
+
+
+def test_convert_tools_to_responses_tools_flattens_function_schema() -> None:
+    tools = convert_tools_to_responses_tools(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather_lookup",
+                    "description": "Look up weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+    )
+
+    assert tools == [
+        {
+            "type": "function",
+            "name": "weather_lookup",
+            "description": "Look up weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+
+
+def test_convert_messages_to_responses_input_rejects_unknown_role() -> None:
+    with pytest.raises(ValueError, match="Unsupported message role"):
+        convert_messages_to_responses_input([{"role": "developer", "content": "x"}])
+
+
+def test_convert_tools_to_responses_tools_rejects_non_function_tools() -> None:
+    with pytest.raises(ValueError, match="Unsupported tool type"):
+        convert_tools_to_responses_tools([{"type": "web_search"}])
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_streams_text_reasoning_and_usage(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(
+        id="gpt-4.1-mini",
+        name="gpt-4.1-mini",
+        api_key="test-key",
+    )
+    model.client = AsyncMock()
+
+    stream_events = [
+        _event("response.output_text.delta", delta="Hel"),
+        _event("response.reasoning_summary_text.delta", delta="think"),
+        _event("response.output_text.delta", delta="lo"),
+        _event(
+            "response.completed",
+            response=SimpleNamespace(
+                usage=SimpleNamespace(
+                    input_tokens=7,
+                    output_tokens=3,
+                    total_tokens=10,
+                    input_tokens_details=SimpleNamespace(cached_tokens=2),
+                ),
+                output=[SimpleNamespace(type="message")],
+                incomplete_details=None,
+            ),
+        ),
+    ]
+
+    mock_stream = _MockResponseStream(stream_events)
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    chunks = []
+    async for chunk in model.arun_stream([{"role": "user", "content": "hello"}]):
+        chunks.append(chunk)
+
+    assert chunks[0].content == "Hel"
+    assert chunks[1].reasoning_content == "think"
+    assert chunks[2].content == "lo"
+    assert chunks[-1].usage is not None
+    assert chunks[-1].usage["input_tokens"] == 7
+    assert chunks[-1].usage["cache_read_tokens"] == 2
+    assert chunks[-1].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_streams_function_call_deltas(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(
+        id="gpt-4.1-mini",
+        name="gpt-4.1-mini",
+        api_key="test-key",
+    )
+    model.client = AsyncMock()
+
+    stream_events = [
+        _event(
+            "response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_123",
+                name="weather_lookup",
+                arguments="",
+            ),
+        ),
+        _event(
+            "response.function_call_arguments.delta",
+            output_index=0,
+            item_id="fc_1",
+            delta='{"city":"Par',
+        ),
+        _event(
+            "response.function_call_arguments.delta",
+            output_index=0,
+            item_id="fc_1",
+            delta='is"}',
+        ),
+        _event(
+            "response.completed",
+            response=SimpleNamespace(
+                usage=None,
+                output=[SimpleNamespace(type="function_call")],
+                incomplete_details=None,
+            ),
+        ),
+    ]
+
+    mock_stream = _MockResponseStream(stream_events)
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    chunks = []
+    async for chunk in model.arun_stream([{"role": "user", "content": "weather"}]):
+        chunks.append(chunk)
+
+    assert chunks[0].tool_calls == [
+        {
+            "index": 0,
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "weather_lookup", "arguments": '{"city":"Par'},
+        }
+    ]
+    assert chunks[1].tool_calls == [
+        {
+            "index": 0,
+            "id": "call_123",
+            "type": "function",
+            "function": {"arguments": 'is"}'},
+        }
+    ]
+    assert chunks[-1].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_rejects_empty_stream(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(
+        id="gpt-4.1-mini",
+        name="gpt-4.1-mini",
+        api_key="test-key",
+    )
+    model.client = AsyncMock()
+
+    mock_stream = _MockResponseStream([])
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    with pytest.raises(RuntimeError, match="returned no chunks"):
+        async for _ in model.arun_stream([{"role": "user", "content": "hello"}]):
+            pass
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai_response.get_settings")
+async def test_openai_response_model_raises_failed_event_message(
+    mock_get_settings,
+) -> None:
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIResponsesModel(
+        id="gpt-4.1-mini",
+        name="gpt-4.1-mini",
+        api_key="test-key",
+    )
+    model.client = AsyncMock()
+
+    mock_stream = _MockResponseStream(
+        [
+            _event(
+                "response.failed",
+                response=SimpleNamespace(
+                    error=SimpleNamespace(message="provider failed"),
+                ),
+            )
+        ]
+    )
+    model.client.responses.create = AsyncMock(return_value=mock_stream)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        async for _ in model.arun_stream([{"role": "user", "content": "hello"}]):
+            pass


### PR DESCRIPTION
## Summary
- add a new `openai-response` provider backed by OpenAI Responses API
- keep the SDK public `Model.arun_stream(...)->StreamChunk` contract unchanged via a dedicated converter and stream adapter
- add factory wiring, docs, plan/spec artifacts, and coverage for provider behavior and tool-call compatibility

## Testing
- uv run python scripts/lint.py changed
- uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/
- uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/
- uv run python scripts/lint.py imports
- uv run python scripts/repo_guard.py
- uv run pytest tests/ -v
- cd console && uv run pytest tests/ -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Responses API support as a new model provider (`openai-response`), enabling streaming text, function calling, and improved token usage tracking with cache-aware metrics.

* **Documentation**
  * Added comprehensive guides for the new OpenAI Responses provider, including configuration, usage patterns, and multi-turn conversation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->