### PR TITLE
Prepare 0.1.0 publish surface and add console CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,5 +145,11 @@ jobs:
       - name: Install dependencies
         run: cd console && uv sync
 
+      - name: Build SDK package
+        run: uv build
+
       - name: Build Console package
         run: cd console && uv build
+
+      - name: Smoke test built Console wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)" "$(ls console/dist/agiwo_console-*.whl | head -n 1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,71 @@ jobs:
 
       - name: Run tests
         run: cd console && uv run pytest tests/ -v --tb=short
+
+  test-web:
+    name: Test Web
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: console/web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm --prefix console/web ci
+
+      - name: Run web lint
+        run: npm --prefix console/web run lint
+
+      - name: Run web tests
+        run: npm --prefix console/web test
+
+      - name: Run web production build
+        run: npm --prefix console/web run build
+
+  package-sdk:
+    name: Package SDK
+    runs-on: ubuntu-latest
+    needs: [lint, test-sdk]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Smoke test built SDK wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)"
+
+  package-console:
+    name: Package Console
+    runs-on: ubuntu-latest
+    needs: [lint, test-console]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: cd console && uv sync
+
+      - name: Build Console package
+        run: cd console && uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      release_version: ${{ steps.version.outputs.release_version }}
+    steps:
+      - name: Normalize release tag
+        id: version
+        shell: bash
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected release tag in the form vX.Y.Z, got: $tag" >&2
+            exit 1
+          fi
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  build-sdk:
+    name: Build SDK
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate release metadata
+        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Smoke test built SDK wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)"
+
+      - name: Upload SDK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish-sdk:
+    name: Publish SDK
+    runs-on: ubuntu-latest
+    needs: [build-sdk]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SDK artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-dist
+          path: dist
+
+      - name: Publish SDK to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          print-hash: true
+
+  build-console:
+    name: Build Console
+    runs-on: ubuntu-latest
+    needs: [prepare, publish-sdk]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install SDK dependencies
+        run: uv sync
+
+      - name: Install Console dependencies
+        run: (cd console && uv sync)
+
+      - name: Validate release metadata
+        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Build Console package
+        run: (cd console && uv build)
+
+      - name: Smoke test built Console wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)" "$(ls console/dist/agiwo_console-*.whl | head -n 1)"
+
+      - name: Upload Console artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: console-dist
+          path: console/dist/*
+          if-no-files-found: error
+
+  publish-console:
+    name: Publish Console
+    runs-on: ubuntu-latest
+    needs: [build-console]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Console artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: console-dist
+          path: dist
+
+      - name: Publish Console to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          print-hash: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@
 ```bash
 # 安装依赖
 uv sync
-cd console && uv sync
+(cd console && uv sync)
 
 # 标准检查
 uv run python scripts/lint.py changed
@@ -196,17 +196,17 @@ uv run python scripts/repo_guard.py
 uv run pytest tests/ -v
 
 # Console 后端测试
-cd console && uv run pytest tests/ -v
+(cd console && uv run pytest tests/ -v)
 
 # Console 前端检查
-cd console/web && npm run lint
-cd console/web && npm test
-cd console/web && npm run build
+(cd console/web && npm run lint)
+(cd console/web && npm test)
+(cd console/web && npm run build)
 
 # release 前构建与安装验证
 uv build
 uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
-cd console && uv build
+(cd console && uv build)
 ```
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,7 @@
 ```bash
 # 安装依赖
 uv sync
+cd console && uv sync
 
 # 标准检查
 uv run python scripts/lint.py changed
@@ -196,6 +197,16 @@ uv run pytest tests/ -v
 
 # Console 后端测试
 cd console && uv run pytest tests/ -v
+
+# Console 前端检查
+cd console/web && npm run lint
+cd console/web && npm test
+cd console/web && npm run build
+
+# release 前构建与安装验证
+uv build
+uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
+cd console && uv build
 ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Contributing guide (`CONTRIBUTING.md`)
 - CI pipeline (lint + test on PR)
 - GitHub issue and PR templates
-- Optional dependency groups (`pip install agiwo[anthropic,web,feishu,mongo,observability]`)
+- Release packaging and documentation cleanup for the first public release
 
-## [0.1.0] - 2026-03-17
+## [0.1.0] - 2026-04-16
 
 ### Added
 - Streaming-first Agent SDK with `run()`, `run_stream()`, and `start()` API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ uv run pytest tests/ -v
 # Console backend tests
 (cd console && uv run pytest tests/ -v)
 
+# Console frontend checks
+(cd console/web && npm run lint)
+(cd console/web && npm test)
+(cd console/web && npm run build)
+
+# Release smoke check from built wheel
+uv build
+uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
+
 # Run a specific test file
 uv run pytest tests/agent/test_agent_tool.py -v
 ```
@@ -106,9 +115,10 @@ See [AGENTS.md](./AGENTS.md) for detailed architecture documentation.
 1. Create a feature branch from `main`
 2. Make your changes with clear, focused commits
 3. Run `uv run python scripts/lint.py changed` before committing
-4. Ensure tests pass: `uv run pytest tests/ -v`
-5. Update documentation if you changed public APIs
-6. Open a PR with a clear description of what and why
+4. Ensure tests pass: `uv run pytest tests/ -v` and `(cd console && uv run pytest tests/ -v)`
+5. If you changed release-facing behavior, also run `(cd console/web && npm run lint && npm test && npm run build)` and `uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl` after `uv build`
+6. Update documentation if you changed public APIs
+7. Open a PR with a clear description of what and why
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Agiwo has three main areas:
 Agiwo has two parts:
 
 - **SDK**: an async, streaming-first Python framework for building LLM agents with tools, hooks, storage, observability, skills, and scheduler-based orchestration.
-- **Console**: a FastAPI + Next.js control plane for managing agent configs, chatting over SSE, inspecting scheduler state, viewing traces, and integrating channels such as Feishu.
+- **Console**: an optional self-hosted FastAPI + Next.js control plane for managing agent configs, chatting over SSE, inspecting scheduler state, and integrating channels. It is currently best suited for internal deployments, supports Feishu as its only built-in channel integration, and is not yet production-ready.
 
 The project favors explicit runtime wiring over hidden global state. Agent execution, tool execution, scheduler orchestration, and persistence are all separate layers.
 
@@ -47,30 +47,26 @@ The project favors explicit runtime wiring over hidden global state. Agent execu
 - Scheduler orchestration for roots and child agents, including `submit`, `route_root_input`, `stream`, `wait_for`, `steer`, and cancellation flows
 - Run and step persistence plus trace collection with memory, SQLite, and MongoDB-backed storage options
 - Global skill discovery with per-agent allowlisting through explicit `allowed_skills`
-- Console APIs and web control plane for agent config management, session chat, scheduler views, trace inspection, and channel integration
+- Optional Console package for control-plane operations, trace inspection, session chat, and Feishu channel integration
 
 ## Quick Start
 
 ### Install
 
 ```bash
-# Core SDK (OpenAI provider only)
+# SDK
 pip install agiwo
+```
 
-# With specific providers/features
-pip install "agiwo[anthropic]"          # Anthropic provider
-pip install "agiwo[web]"               # Web tools (web_reader, Playwright)
-pip install "agiwo[feishu]"            # Feishu channel integration
-pip install "agiwo[mongo]"             # MongoDB storage backends
-pip install "agiwo[all]"               # Everything
+For development from source:
 
-# From source (development)
+```bash
 git clone https://github.com/xhwSkhizein/agiwo.git
 cd agiwo
 uv sync
 ```
 
-For SDK-only usage, export provider credentials in your shell or place them in a local `.env`.
+For SDK usage, export provider credentials in your shell or place them in a local `.env`. Set only the credentials for the providers you actually use.
 
 Example:
 
@@ -94,7 +90,7 @@ async def main() -> None:
             description="A helpful assistant",
             system_prompt="You are a concise assistant.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     result = await agent.run("What is 2 + 2?")
@@ -201,6 +197,13 @@ asyncio.run(main())
 For long-running roots, the scheduler API also supports `submit`, `enqueue_input`, `route_root_input`, `stream`, `wait_for`, `steer`, `cancel`, and `shutdown`.
 
 ## Console
+
+The Console is a separately published control-plane package and is intentionally positioned below the SDK in scope and readiness.
+
+- Package: `pip install agiwo-console`
+- Recommended deployment model: internal/self-hosted use
+- Built-in channel integrations today: Feishu only
+- Readiness: useful for operators, not yet production-ready
 
 ### Start The API Server
 
@@ -328,7 +331,7 @@ uv run pytest tests/ -v
 
 ## Current Status
 
-The project is usable for experimentation and development. Core SDK APIs (Agent, Tool, Scheduler) are stabilizing; Console APIs continue to evolve with new features.
+The project is usable for experimentation and development. Core SDK APIs (Agent, Tool, Scheduler) are stabilizing. The Console remains an internal-use control plane that is still evolving and should not yet be treated as production-ready.
 
 Areas that still change:
 

--- a/README.md
+++ b/README.md
@@ -210,10 +210,14 @@ The Console is a separately published control-plane package and is intentionally
 The Console environment template lives at [console/.env.example.full](console/.env.example.full).
 
 ```bash
-cd console
-cp .env.example.full .env
-uv run uvicorn server.app:app --reload --env-file .env
+pip install agiwo-console
+cat > .env <<'EOF'
+OPENAI_API_KEY=...
+EOF
+agiwo-console serve --env-file .env
 ```
+
+If you are running from source instead of the published package, the full template lives at `console/.env.example.full`.
 
 The API server defaults to `http://localhost:8422`.
 

--- a/agiwo/llm/openai.py
+++ b/agiwo/llm/openai.py
@@ -31,8 +31,8 @@ OPENAI_RETRYABLE = (
 class OpenAIModel(Model):
     def __init__(
         self,
-        id: str,
-        name: str,
+        id: str | None = None,
+        name: str | None = None,
         api_key: str | None = None,
         base_url: str | None = "https://api.openai.com/v1",
         allow_env_fallback: bool = True,
@@ -47,9 +47,14 @@ class OpenAIModel(Model):
         output_price: float = 0.0,
         provider: str = "openai",
     ):
+        if id is None and name is None:
+            raise TypeError("OpenAIModel requires at least one of id or name")
+
+        resolved_id = id or name
+        resolved_name = name or id
         config = LLMConfig(
-            id=id,
-            name=name,
+            id=resolved_id,
+            name=resolved_name,
             api_key=api_key,
             base_url=base_url,
             temperature=temperature,

--- a/console/pyproject.toml
+++ b/console/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agiwo Agent SDK Control Plane Dashboard"
 requires-python = ">=3.11"
 dependencies = [
-    "agiwo[all]",  # include all optional provider dependencies
+    "agiwo",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "httpx[socks]>=0.27.0",
@@ -34,8 +34,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["server"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
 ]

--- a/console/pyproject.toml
+++ b/console/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agiwo Agent SDK Control Plane Dashboard"
 requires-python = ">=3.11"
 dependencies = [
-    "agiwo",
+    "agiwo ~= 0.1.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "httpx[socks]>=0.27.0",

--- a/console/pyproject.toml
+++ b/console/pyproject.toml
@@ -27,6 +27,9 @@ dev = [
     "pytest-asyncio>=0.23.0",
 ]
 
+[project.scripts]
+agiwo-console = "server.cli:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/console/server/cli.py
+++ b/console/server/cli.py
@@ -1,0 +1,40 @@
+import argparse
+from collections.abc import Sequence
+
+import uvicorn
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agiwo-console")
+    subparsers = parser.add_subparsers(dest="command")
+
+    serve = subparsers.add_parser("serve", help="Start the Agiwo Console server")
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--port", type=int, default=8422)
+    serve.add_argument("--env-file", default=None)
+    serve.add_argument("--reload", action="store_true")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command != "serve":
+        parser.print_help()
+        return 0
+
+    uvicorn.run(
+        "server.app:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        env_file=args.env_file,
+        factory=False,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/console/tests/test_cli.py
+++ b/console/tests/test_cli.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+from server.cli import build_parser, main
+
+
+def test_build_parser_supports_serve_subcommand() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["serve"])
+
+    assert args.command == "serve"
+    assert args.host == "0.0.0.0"
+    assert args.port == 8422
+    assert args.env_file is None
+    assert args.reload is False
+
+
+def test_cli_serve_dispatches_to_uvicorn() -> None:
+    with patch("server.cli.uvicorn.run") as run:
+        exit_code = main(["serve", "--host", "127.0.0.1", "--port", "9999"])
+
+    assert exit_code == 0
+    run.assert_called_once_with(
+        "server.app:app",
+        host="127.0.0.1",
+        port=9999,
+        reload=False,
+        env_file=None,
+        factory=False,
+    )
+
+
+def test_cli_serve_forwards_reload_and_env_file() -> None:
+    with patch("server.cli.uvicorn.run") as run:
+        exit_code = main(
+            [
+                "serve",
+                "--env-file",
+                "/tmp/console.env",
+                "--reload",
+            ]
+        )
+
+    assert exit_code == 0
+    run.assert_called_once_with(
+        "server.app:app",
+        host="0.0.0.0",
+        port=8422,
+        reload=True,
+        env_file="/tmp/console.env",
+        factory=False,
+    )

--- a/console/uv.lock
+++ b/console/uv.lock
@@ -13,10 +13,18 @@ source = { editable = "../" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiosqlite" },
+    { name = "anthropic" },
+    { name = "boto3" },
     { name = "browser-control-and-automation-cli" },
+    { name = "bs4" },
+    { name = "curl-cffi" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
+    { name = "lark-oapi" },
+    { name = "motor" },
     { name = "openai" },
+    { name = "opentelemetry-distro" },
+    { name = "opentelemetry-exporter-otlp" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -25,41 +33,27 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tiktoken" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "anthropic" },
-    { name = "boto3" },
-    { name = "bs4" },
-    { name = "curl-cffi" },
-    { name = "lark-oapi" },
-    { name = "motor" },
-    { name = "opentelemetry-distro" },
-    { name = "opentelemetry-exporter-otlp" },
     { name = "trafilatura" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "agiwo", extras = ["all"], marker = "extra == 'dev'" },
-    { name = "agiwo", extras = ["anthropic", "bedrock", "web", "feishu", "mongo", "observability"], marker = "extra == 'all'" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.34.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.59" },
+    { name = "anthropic", specifier = ">=0.34.0" },
+    { name = "boto3", specifier = ">=1.42.59" },
     { name = "browser-control-and-automation-cli", specifier = ">=0.1.3" },
-    { name = "bs4", marker = "extra == 'web'", specifier = ">=0.0.2" },
-    { name = "curl-cffi", marker = "extra == 'web'", specifier = ">=0.14.0" },
+    { name = "bs4", specifier = ">=0.0.2" },
+    { name = "curl-cffi", specifier = ">=0.14.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3" },
-    { name = "motor", marker = "extra == 'mongo'", specifier = ">=3.7.1" },
+    { name = "lark-oapi", specifier = ">=1.5.3" },
+    { name = "motor", specifier = ">=3.7.1" },
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "opentelemetry-distro", marker = "extra == 'observability'", specifier = ">=0.60b1" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'observability'", specifier = ">=1.39.1" },
+    { name = "opentelemetry-distro", specifier = ">=0.60b1" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -72,9 +66,9 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
-    { name = "trafilatura", marker = "extra == 'web'", specifier = ">=2.0.0" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
 ]
-provides-extras = ["anthropic", "bedrock", "web", "feishu", "mongo", "observability", "all", "dev"]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "agiwo", extras = ["dev"] }]
@@ -84,7 +78,7 @@ name = "agiwo-console"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "agiwo", extra = ["all"] },
+    { name = "agiwo" },
     { name = "aiofiles" },
     { name = "aiosqlite" },
     { name = "bs4" },
@@ -115,7 +109,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agiwo", extras = ["all"], editable = "../" },
+    { name = "agiwo", editable = "../" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "bs4", specifier = ">=0.0.2" },

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Welcome to the Agiwo documentation. Agiwo is a streaming-first AI Agent SDK and 
 - **[Hooks](./guides/hooks.md)** — Observe and intercept agent lifecycle events
 - **[Storage & Observability](./guides/storage.md)** — Persist runs, sessions, and traces
 - **[Skills](./guides/skills.md)** — File-based skill discovery and loading
+- **[Release Publishing](./release.md)** — Maintainer runbook for GitHub Release driven PyPI publishing
 
 ## Console
 

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -63,7 +63,7 @@ class StreamChunk:
 ```python
 from agiwo.llm import OpenAIModel
 
-model = OpenAIModel(id="gpt-4o", name="gpt-4o")
+model = OpenAIModel(name="gpt-5.4")
 # Reads OPENAI_API_KEY from environment
 ```
 

--- a/docs/concepts/model.md
+++ b/docs/concepts/model.md
@@ -35,12 +35,12 @@ Every provider yields standardized `StreamChunk` objects:
 
 ## Model Configuration
 
-All models share these fields:
+All runtime models expose these fields through `LLMConfig`, even if individual provider constructors offer slightly different ergonomics:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `id` | (required) | Provider model ID (e.g., `"gpt-4o"`) |
-| `name` | (required) | Human-readable name |
+| `id` | provider-specific | Provider model ID (for `OpenAIModel`, omitting `id` mirrors `name`) |
+| `name` | provider-specific | Human-readable or provider-facing model name |
 | `temperature` | `0.7` | Sampling temperature (0.0–2.0) |
 | `top_p` | `1.0` | Nucleus sampling |
 | `max_output_tokens` | `4096` | Max tokens in response |
@@ -63,7 +63,7 @@ Pricing fields (for cost tracking):
 ```python
 from agiwo.llm import OpenAIModel
 
-model = OpenAIModel(id="gpt-4o", name="gpt-4o")
+model = OpenAIModel(name="gpt-5.4")
 # Reads OPENAI_API_KEY from environment
 ```
 

--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -44,7 +44,7 @@ async def main() -> None:
             description="Coordinates long-running work",
             system_prompt="Delegate only truly independent work.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     async with Scheduler() as scheduler:

--- a/docs/concepts/tool.md
+++ b/docs/concepts/tool.md
@@ -110,7 +110,7 @@ Agiwo includes these tools out of the box:
 | `bash` | Execute shell commands with security sandboxing |
 | `bash_process` | Manage long-running background processes (inspect logs, stop, send input) |
 | `web_search` | Search the web via multiple search engines |
-| `web_reader` | Fetch and extract readable content from URLs (supports curl and Playwright) |
+| `web_reader` | Fetch and extract readable content from URLs (supports lightweight fetch plus browser fallback) |
 | `memory_retrieval` | Hybrid BM25 + vector search over MEMORY/ files |
 
 Builtin tools are automatically included when you create an Agent. They live in `agiwo/tool/builtin/`.

--- a/docs/console/feishu.md
+++ b/docs/console/feishu.md
@@ -47,8 +47,7 @@ AgIWO_CONSOLE_FEISHU_BOT_OPEN_ID=ou_bot_xxxx    # Required for group @mention de
 The Feishu channel starts automatically with the Console server:
 
 ```bash
-cd console
-uv run uvicorn server.app:app --reload --env-file .env
+agiwo-console serve --env-file .env
 ```
 
 ## Architecture

--- a/docs/console/overview.md
+++ b/docs/console/overview.md
@@ -23,12 +23,14 @@ Console
 ### Start the API Server
 
 ```bash
-cd console
-cp .env.example .env
-# Edit .env with your provider credentials
-
-uv run uvicorn server.app:app --reload --env-file .env
+pip install agiwo-console
+cat > .env <<'EOF'
+OPENAI_API_KEY=...
+EOF
+agiwo-console serve --env-file .env
 ```
+
+If you are running from the source repository instead, you can still start from `console/.env.example.full`.
 
 The server starts at `http://localhost:8422`.
 

--- a/docs/console/overview.md
+++ b/docs/console/overview.md
@@ -1,6 +1,6 @@
 # Console Overview
 
-The Console is a control plane for managing Agiwo agents. It consists of a FastAPI backend and a Next.js frontend.
+The Console is a self-hosted control plane for managing Agiwo agents. It consists of a FastAPI backend and a Next.js frontend, is currently best suited for internal deployments, and should not yet be treated as a production-ready end-user product.
 
 ## Architecture
 
@@ -45,6 +45,12 @@ npm run dev
 ```
 
 The UI starts at `http://localhost:3000`.
+
+## Current Positioning
+
+- Recommended use: internal/self-hosted operator workflows
+- Built-in channel integrations today: Feishu only
+- Production readiness: not yet production-ready
 
 ## Health Check
 
@@ -102,7 +108,7 @@ SDK settings (`AGIWO_*`) and provider credentials (`OPENAI_API_KEY`, etc.) are a
 
 ### Channels
 
-- **Feishu**: Full integration with Feishu messaging
+- **Feishu**: Built-in integration with Feishu messaging
   - WebSocket connection for real-time messages
   - Command parsing and routing (`/status`, `/new`, `/switch`, etc.)
   - Group and direct message support

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ cd agiwo
 uv sync
 ```
 
-### With pip (coming soon)
+### With pip
 
 ```bash
 pip install agiwo
@@ -23,10 +23,10 @@ pip install agiwo
 
 ## Configuration
 
-Agiwo reads provider credentials from environment variables. Create a `.env` file in your project root:
+Agiwo reads provider credentials from environment variables. Install once with `pip install agiwo`, then configure only the providers you plan to use. Create a `.env` file in your project root:
 
 ```bash
-# At least one provider is required
+# Example provider credentials
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
 DEEPSEEK_API_KEY=sk-...
@@ -66,7 +66,7 @@ async def main() -> None:
             description="A helpful assistant",
             system_prompt="You are a concise assistant. Answer in one sentence.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     result = await agent.run("What is the capital of France?")
@@ -143,7 +143,7 @@ agent = Agent(
         description="Can do math",
         system_prompt="Use the calculator tool for arithmetic.",
     ),
-    model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+    model=OpenAIModel(name="gpt-5.4"),
     tools=[CalculatorTool()],
 )
 ```

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -17,7 +17,7 @@ researcher = Agent(
         description="Researches topics thoroughly and returns summaries",
         system_prompt="You are a research specialist. Be thorough and cite sources.",
     ),
-    model=OpenAIModel(id="gpt-4o", name="gpt-4o"),
+    model=OpenAIModel(name="gpt-5.4"),
 )
 
 # Orchestrator agent that can delegate to the researcher
@@ -27,7 +27,7 @@ orchestrator = Agent(
         description="Coordinates research tasks",
         system_prompt="Delegate independent research tasks to the researcher tool.",
     ),
-    model=OpenAIModel(id="gpt-4o", name="gpt-4o"),
+    model=OpenAIModel(name="gpt-5.4"),
     tools=[researcher.as_tool()],
 )
 

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -133,8 +133,7 @@ When `input_price`, `output_price`, and `cache_hit_price` are set on the Model, 
 
 ```python
 model = OpenAIModel(
-    id="gpt-4o",
-    name="gpt-4o",
+    name="gpt-5.4",
     input_price=0.005,     # per 1K tokens
     output_price=0.015,    # per 1K tokens
     cache_hit_price=0.001, # per 1K tokens (cached)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,45 @@
+# Release Publishing
+
+## Prerequisites
+
+Configure PyPI Trusted Publisher for both projects before the first release:
+
+- `agiwo`
+- `agiwo-console`
+
+Point both PyPI projects at this GitHub repository and workflow:
+
+- Repository: `xhwSkhizein/agiwo`
+- Workflow file: `.github/workflows/release.yml`
+
+Trusted Publisher is the intended publish path. The workflow does not require a long-lived PyPI API token in GitHub secrets.
+
+## Tag Format
+
+Create GitHub Releases with tags in this format:
+
+- `v0.1.0`
+- `v0.1.1`
+
+Do not publish releases with bare tags like `0.1.0`.
+
+## Publish Flow
+
+1. Merge the release-ready changes into `main`.
+2. Confirm the root `pyproject.toml` version matches the intended release version.
+3. Confirm `console/pyproject.toml` uses the same version and still depends on the matching `agiwo` release line.
+4. Create a GitHub Release with tag `vX.Y.Z`.
+5. Publish the release.
+6. Open the `Release Publish` workflow in GitHub Actions and confirm all jobs succeed.
+
+The workflow will normalize the `v` tag, validate package metadata, build both packages, run the release smoke checks, publish `agiwo`, and then publish `agiwo-console`.
+
+## Failure Handling
+
+Publishing is not atomic.
+
+- If `publish-sdk` fails, `agiwo-console` will not publish.
+- If `publish-sdk` succeeds and `publish-console` fails, `agiwo` stays published.
+- Fix the failure and rerun the workflow to publish the missing package.
+
+The upload steps use duplicate-tolerant publishing so reruns can recover after a partial publish.

--- a/docs/superpowers/plans/2026-04-16-console-cli.md
+++ b/docs/superpowers/plans/2026-04-16-console-cli.md
@@ -1,0 +1,233 @@
+# Console CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the packaged Console startup command with a user-facing `agiwo-console serve` entrypoint.
+
+**Architecture:** Add a thin CLI wrapper around the existing ASGI app startup path. The CLI only parses arguments and forwards them into `uvicorn.run("server.app:app", ...)`, while packaging and docs are updated to expose the new command.
+
+**Tech Stack:** Python 3.11+, argparse, uvicorn, Hatchling, pytest
+
+---
+
+## File Structure
+
+- Modify: `console/pyproject.toml`
+  - Publish the `agiwo-console` script entry.
+- Create: `console/server/cli.py`
+  - Provide the top-level CLI parser and `serve` subcommand.
+- Create: `console/tests/test_cli.py`
+  - Verify argument parsing and `uvicorn.run(...)` dispatch.
+- Modify: `README.md`
+  - Replace packaged Console startup instructions with `agiwo-console serve`.
+- Modify: `docs/console/overview.md`
+  - Replace startup instructions with `agiwo-console serve`.
+- Modify: `docs/console/feishu.md`
+  - Keep Feishu setup docs aligned with the new startup command.
+- Modify: `scripts/smoke_release_install.py`
+  - Extend release smoke to verify the installed `agiwo-console` command can print help.
+
+### Task 1: Add the packaged `agiwo-console` entrypoint
+
+**Files:**
+- Modify: `console/pyproject.toml`
+- Create: `console/server/cli.py`
+- Test: `console/tests/test_cli.py`
+
+- [ ] **Step 1: Add a failing CLI test before implementing the command**
+
+```python
+from unittest.mock import patch
+
+from server.cli import main
+
+
+def test_cli_serve_dispatches_to_uvicorn():
+    with patch("server.cli.uvicorn.run") as run:  # noqa: SIM117
+        exit_code = main(["serve", "--host", "127.0.0.1", "--port", "9999"])
+
+    assert exit_code == 0
+    run.assert_called_once_with(
+        "server.app:app",
+        host="127.0.0.1",
+        port=9999,
+        reload=False,
+        env_file=None,
+        factory=False,
+    )
+```
+
+- [ ] **Step 2: Run the new targeted test file to confirm it fails**
+
+Run: `cd console && uv run pytest tests/test_cli.py -q`
+
+Expected: FAIL because `server.cli` does not exist yet.
+
+- [ ] **Step 3: Add the package script entry to `console/pyproject.toml`**
+
+```toml
+[project.scripts]
+agiwo-console = "server.cli:main"
+```
+
+- [ ] **Step 4: Implement the thin CLI wrapper in `console/server/cli.py`**
+
+```python
+import argparse
+from collections.abc import Sequence
+
+import uvicorn
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agiwo-console")
+    subparsers = parser.add_subparsers(dest="command")
+
+    serve = subparsers.add_parser("serve", help="Start the Agiwo Console server")
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--port", type=int, default=8422)
+    serve.add_argument("--env-file", default=None)
+    serve.add_argument("--reload", action="store_true")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command != "serve":
+        parser.print_help()
+        return 0
+
+    uvicorn.run(
+        "server.app:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        env_file=args.env_file,
+        factory=False,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 5: Expand tests to cover `--env-file` and `--reload` pass-through**
+
+```python
+def test_cli_serve_forwards_reload_and_env_file():
+    with patch("server.cli.uvicorn.run") as run:
+        exit_code = main(
+            [
+                "serve",
+                "--env-file",
+                "/tmp/console.env",
+                "--reload",
+            ]
+        )
+
+    assert exit_code == 0
+    run.assert_called_once_with(
+        "server.app:app",
+        host="0.0.0.0",
+        port=8422,
+        reload=True,
+        env_file="/tmp/console.env",
+        factory=False,
+    )
+```
+
+- [ ] **Step 6: Run the targeted CLI tests**
+
+Run: `cd console && uv run pytest tests/test_cli.py -q`
+
+Expected: PASS
+
+- [ ] **Step 7: Run the full Console backend test suite**
+
+Run: `cd console && uv run pytest tests/ -q`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit the CLI entrypoint implementation**
+
+```bash
+git add console/pyproject.toml console/server/cli.py console/tests/test_cli.py
+git commit -m "feat: add agiwo-console serve command"
+```
+
+### Task 2: Update packaged Console docs and smoke verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/console/overview.md`
+- Modify: `docs/console/feishu.md`
+- Modify: `scripts/smoke_release_install.py`
+
+- [ ] **Step 1: Replace packaged startup docs in the README**
+
+```md
+```bash
+pip install agiwo-console
+agiwo-console serve --env-file .env
+```
+```
+
+- [ ] **Step 2: Replace startup docs in Console overview and Feishu docs**
+
+```md
+```bash
+agiwo-console serve --env-file .env
+```
+```
+
+- [ ] **Step 3: Extend the release smoke script to verify the installed command exists**
+
+```python
+        cli_path = (
+            venv_path / "Scripts" / "agiwo-console.exe"
+            if sys.platform == "win32"
+            else venv_path / "bin" / "agiwo-console"
+        )
+        run([str(cli_path), "--help"])
+```
+
+- [ ] **Step 4: Rebuild the packages and run smoke validation**
+
+Run:
+
+```bash
+uv build
+cd console && uv build
+cd .. && uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
+```
+
+Expected: PASS, including installed `agiwo-console --help` output from the fresh environment.
+
+- [ ] **Step 5: Run a grep to ensure release-facing docs no longer expose `server.app:app` as the packaged startup path**
+
+Run: `rg -n 'uvicorn server.app:app' README.md docs/console`
+
+Expected: no matches
+
+- [ ] **Step 6: Commit the docs and smoke cleanup**
+
+```bash
+git add README.md docs/console/overview.md docs/console/feishu.md scripts/smoke_release_install.py
+git commit -m "docs: publish console cli startup flow"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - package entrypoint: Task 1
+  - `serve` command: Task 1
+  - docs replacement: Task 2
+  - installed-package smoke: Task 2
+- Placeholder scan:
+  - No `TODO`, `TBD`, or vague steps remain
+- Type consistency:
+  - The CLI always dispatches through `main(argv: Sequence[str] | None = None) -> int` and forwards into `uvicorn.run("server.app:app", ...)`

--- a/docs/superpowers/plans/2026-04-16-first-release.md
+++ b/docs/superpowers/plans/2026-04-16-first-release.md
@@ -1,0 +1,569 @@
+# First Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agiwo` and `agiwo-console` ready for the first public release by simplifying installation, fixing the public SDK entry path, lowering Console marketing claims, and adding release gates that verify the built artifacts.
+
+**Architecture:** Keep the runtime mostly intact and solve the release issues at the publish surface. The only intentional API change is making `OpenAIModel` support the documented single-argument constructor form; the rest of the work is packaging, docs, and CI hardening.
+
+**Tech Stack:** Python 3.11+, Hatchling, uv, FastAPI, Next.js, Vitest, GitHub Actions
+
+---
+
+## File Structure
+
+- Modify: `agiwo/llm/openai.py`
+  - Relax the constructor so `OpenAIModel(name="gpt-5.4")` is valid and mirrors `name` into `id`.
+- Modify: `tests/llm/test_openai.py`
+  - Add unit coverage for the name-only constructor and missing-name/id failure mode.
+- Modify: `pyproject.toml`
+  - Move current runtime extras into the default dependency set and simplify optional dependencies to the dev-only surface.
+- Modify: `console/pyproject.toml`
+  - Depend on `agiwo` directly instead of `agiwo[all]`; remove the deprecated `tool.uv.dev-dependencies` block in favor of dependency groups.
+- Create: `scripts/smoke_release_install.py`
+  - Build-artifact smoke test that installs a wheel into a fresh venv and verifies the documented public import/constructor/tool surface.
+- Modify: `README.md`
+  - Make SDK the primary story, switch the public example to `OpenAIModel(name="gpt-5.4")`, simplify install instructions, and downscope Console positioning.
+- Modify: `docs/getting-started.md`
+  - Update first-run install and code examples to the new constructor and default install model.
+- Modify: `docs/concepts/model.md`
+  - Update the OpenAI example and shared model-field explanation to match the ergonomic constructor.
+- Modify: `docs/concepts/tool.md`
+  - Keep builtin tool docs aligned with the default install surface.
+- Modify: `docs/console/overview.md`
+  - Add explicit internal/self-hosted and not-production-ready language; keep Feishu as the only current channel integration.
+- Modify: `docs/api/model.md`
+  - Keep API docs aligned with the OpenAI example surface.
+- Modify: `examples/01_hello_agent.py`
+- Modify: `examples/02_streaming.py`
+- Modify: `examples/03_custom_tool.py`
+- Modify: `examples/04_builtin_tools.py`
+- Modify: `examples/05_hooks.py`
+- Modify: `examples/06_agent_as_tool.py`
+- Modify: `examples/07_scheduler.py`
+- Modify: `examples/08_multi_agent.py`
+  - Update repo-visible sample code to the `OpenAIModel(name="gpt-5.4")` style wherever the example is using the default OpenAI path.
+- Modify: `CHANGELOG.md`
+  - Refresh the `0.1.0` release entry so the first release metadata matches the actual release-prep state.
+- Modify: `.github/workflows/ci.yml`
+  - Add package build jobs, wheel smoke validation, and `console/web` lint/test/build verification.
+
+### Task 1: Make `OpenAIModel(name=...)` a valid public constructor
+
+**Files:**
+- Modify: `agiwo/llm/openai.py`
+- Modify: `tests/llm/test_openai.py`
+- Test: `tests/llm/test_openai.py`
+
+- [ ] **Step 1: Add failing unit tests for the new constructor contract**
+
+```python
+@patch("agiwo.llm.openai.get_settings")
+def test_openai_model_name_only_defaults_id(mock_get_settings):
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIModel(name="gpt-5.4", api_key="test-key")
+
+    assert model.id == "gpt-5.4"
+    assert model.name == "gpt-5.4"
+
+
+def test_openai_model_requires_name_or_id():
+    with pytest.raises(
+        TypeError,
+        match="OpenAIModel requires at least one of id or name",
+    ):
+        OpenAIModel()
+```
+
+- [ ] **Step 2: Run the targeted test file to confirm the new contract currently fails**
+
+Run: `uv run pytest tests/llm/test_openai.py -q`
+
+Expected: FAIL with a `TypeError` showing that `name` is required or that `OpenAIModel()` cannot be called with only `name`.
+
+- [ ] **Step 3: Update `OpenAIModel.__init__` to normalize missing `id`/`name`**
+
+```python
+class OpenAIModel(Model):
+    def __init__(
+        self,
+        id: str | None = None,
+        name: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = "https://api.openai.com/v1",
+        allow_env_fallback: bool = True,
+        temperature: float = 0.7,
+        top_p: float = 1.0,
+        max_output_tokens: int = 4096,
+        max_context_window: int = 200000,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        cache_hit_price: float = 0.0,
+        input_price: float = 0.0,
+        output_price: float = 0.0,
+        provider: str = "openai",
+    ):
+        if id is None and name is None:
+            raise TypeError("OpenAIModel requires at least one of id or name")
+
+        resolved_id = id or name
+        resolved_name = name or id
+
+        config = LLMConfig(
+            id=resolved_id,
+            name=resolved_name,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=temperature,
+            top_p=top_p,
+            max_output_tokens=max_output_tokens,
+            max_context_window=max_context_window,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            provider=provider,
+            cache_hit_price=cache_hit_price,
+            input_price=input_price,
+            output_price=output_price,
+        )
+        super().__init__(config)
+        self.allow_env_fallback = allow_env_fallback
+        self.client = self._create_client()
+```
+
+- [ ] **Step 4: Run the targeted test file again**
+
+Run: `uv run pytest tests/llm/test_openai.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Run the full LLM test slice to catch constructor regressions in provider subclasses**
+
+Run: `uv run pytest tests/llm/ -q`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the constructor contract change**
+
+```bash
+git add agiwo/llm/openai.py tests/llm/test_openai.py
+git commit -m "feat: support name-only openai model construction"
+```
+
+### Task 2: Make the default `agiwo` install include the full runtime surface
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `console/pyproject.toml`
+- Create: `scripts/smoke_release_install.py`
+- Test: `scripts/smoke_release_install.py`
+
+- [ ] **Step 1: Add the release smoke script before changing package metadata**
+
+```python
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python scripts/smoke_release_install.py <wheel-path>")
+
+    wheel_path = Path(sys.argv[1]).resolve()
+    if not wheel_path.is_file():
+        raise SystemExit(f"Wheel not found: {wheel_path}")
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise SystemExit("uv executable not found in PATH")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        venv_path = tmp_path / "venv"
+        python_path = (
+            venv_path / "Scripts" / "python.exe"
+            if sys.platform == "win32"
+            else venv_path / "bin" / "python"
+        )
+
+        run([uv, "venv", str(venv_path)])
+        run([uv, "pip", "install", "--python", str(python_path), str(wheel_path)])
+        run(
+            [
+                str(python_path),
+                "-c",
+                (
+                    "from agiwo.llm import OpenAIModel; "
+                    "from agiwo.tool.manager import ToolManager; "
+                    "model = OpenAIModel(name='gpt-5.4', api_key='test-key'); "
+                    "assert model.id == 'gpt-5.4'; "
+                    "assert model.name == 'gpt-5.4'; "
+                    "defaults = set(ToolManager().list_default_tool_names()); "
+                    "assert {'bash', 'bash_process', 'web_search', 'web_reader', 'memory_retrieval'} <= defaults; "
+                    "print('release smoke ok')"
+                ),
+            ]
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Build the current wheel and prove the smoke script fails before the dependency cleanup**
+
+Run: `uv build && uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl`
+
+Expected: FAIL because the wheel-installed package is still missing provider/web dependencies or the default tool surface does not yet include `web_reader`.
+
+- [ ] **Step 3: Move runtime extras into the root package default dependency list**
+
+```toml
+[project]
+dependencies = [
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "structlog>=24.0.0",
+    "tenacity>=8.0.0",
+    "openai>=1.0.0",
+    "anthropic>=0.34.0",
+    "boto3>=1.42.59",
+    "python-dotenv>=1.0.0",
+    "orjson>=3.11.6",
+    "aiosqlite>=0.22.1",
+    "jinja2>=3.1.6",
+    "pyyaml>=6.0.3",
+    "tiktoken>=0.7.0",
+    "httpx[socks]>=0.27.0",
+    "aiofiles>=25.1.0",
+    "browser-control-and-automation-cli>=0.1.3",
+    "curl-cffi>=0.14.0",
+    "bs4>=0.0.2",
+    "trafilatura>=2.0.0",
+    "lark-oapi>=1.5.3",
+    "motor>=3.7.1",
+    "opentelemetry-distro>=0.60b1",
+    "opentelemetry-exporter-otlp>=1.39.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.14.0",
+    "httpx>=0.27.0",
+    "ruff>=0.15.5",
+    "import-linter>=2.4.0",
+]
+```
+
+- [ ] **Step 4: Update the Console package to depend on the base SDK package directly**
+
+```toml
+[project]
+dependencies = [
+    "agiwo",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "httpx[socks]>=0.27.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "sse-starlette>=2.0.0",
+    "aiosqlite>=0.22.1",
+    "motor>=3.7.1",
+    "bs4>=0.0.2",
+    "trafilatura>=2.0.0",
+    "lark-oapi>=1.5.3",
+    "sqlite-vec>=0.1.6",
+    "aiofiles>=25.1.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.uv.sources]
+agiwo = { path = "..", editable = true }
+```
+
+- [ ] **Step 5: Rebuild the wheel and rerun the release smoke**
+
+Run: `uv build && uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl`
+
+Expected: PASS with `release smoke ok`
+
+- [ ] **Step 6: Rebuild the Console package to verify its dependency metadata still works**
+
+Run: `cd console && uv build`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the packaging and smoke-test changes**
+
+```bash
+git add pyproject.toml console/pyproject.toml scripts/smoke_release_install.py
+git commit -m "build: default agiwo install to full runtime surface"
+```
+
+### Task 3: Update public docs, examples, and release messaging
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/getting-started.md`
+- Modify: `docs/concepts/model.md`
+- Modify: `docs/concepts/tool.md`
+- Modify: `docs/console/overview.md`
+- Modify: `docs/api/model.md`
+- Modify: `examples/01_hello_agent.py`
+- Modify: `examples/02_streaming.py`
+- Modify: `examples/03_custom_tool.py`
+- Modify: `examples/04_builtin_tools.py`
+- Modify: `examples/05_hooks.py`
+- Modify: `examples/06_agent_as_tool.py`
+- Modify: `examples/07_scheduler.py`
+- Modify: `examples/08_multi_agent.py`
+- Modify: `CHANGELOG.md`
+- Test: `README.md`, `docs/getting-started.md`
+
+- [ ] **Step 1: Rewrite the README install and SDK quick-start sections**
+
+````md
+### Install
+
+```bash
+pip install agiwo
+```
+
+### Minimal SDK Example
+
+```python
+import asyncio
+
+from agiwo.agent import Agent, AgentConfig
+from agiwo.llm import OpenAIModel
+
+
+async def main() -> None:
+    agent = Agent(
+        AgentConfig(
+            name="assistant",
+            description="A helpful assistant",
+            system_prompt="You are a concise assistant.",
+        ),
+        model=OpenAIModel(name="gpt-5.4"),
+    )
+
+    result = await agent.run("What is 2 + 2?")
+    print(result.response)
+
+    await agent.close()
+
+
+asyncio.run(main())
+```
+````
+
+- [ ] **Step 2: Reduce Console promotion in the README and make the readiness statement explicit**
+
+```md
+## Console
+
+The Console is an optional control-plane backend with a bundled web UI for operating Agiwo agents.
+
+- Current channel integration: Feishu only
+- Recommended deployment model: internal/self-hosted use
+- Readiness: useful today for operator workflows, but not yet production-ready
+```
+
+- [ ] **Step 3: Update repo docs and examples to use the same public OpenAI path**
+
+```python
+model = OpenAIModel(name="gpt-5.4")
+```
+
+Apply that constructor style anywhere the file is demonstrating the default OpenAI path:
+
+- `docs/getting-started.md`
+- `docs/concepts/model.md`
+- `docs/api/model.md`
+- `examples/01_hello_agent.py`
+- `examples/02_streaming.py`
+- `examples/03_custom_tool.py`
+- `examples/04_builtin_tools.py`
+- `examples/05_hooks.py`
+- `examples/06_agent_as_tool.py`
+- `examples/07_scheduler.py`
+- `examples/08_multi_agent.py`
+
+- [ ] **Step 4: Keep builtin tool and Console docs aligned with the new install and readiness surface**
+
+```md
+| `web_reader` | Fetch and extract web page content |
+```
+
+```md
+## Console Overview
+
+The Console is a self-hosted control plane for Agiwo. It includes a FastAPI backend and a bundled Next.js UI, and is best treated as an internal operations tool rather than a production-ready end-user product.
+
+Current channel integrations:
+
+- Feishu
+```
+
+- [ ] **Step 5: Refresh the changelog entry for the actual first release date**
+
+```md
+## [0.1.0] - 2026-04-16
+```
+
+- [ ] **Step 6: Run a focused documentation/example grep to ensure the old invalid OpenAI example is gone**
+
+Run: `rg -n 'OpenAIModel\\(id=\"gpt-4o-mini\"|OpenAIModel\\(id=\"gpt-4o\"' README.md docs examples`
+
+Expected: no matches in README, getting-started, model docs, or the updated examples
+
+- [ ] **Step 7: Commit the public-docs release cleanup**
+
+```bash
+git add README.md docs/getting-started.md docs/concepts/model.md docs/concepts/tool.md docs/console/overview.md docs/api/model.md examples/01_hello_agent.py examples/02_streaming.py examples/03_custom_tool.py examples/04_builtin_tools.py examples/05_hooks.py examples/06_agent_as_tool.py examples/07_scheduler.py examples/08_multi_agent.py CHANGELOG.md
+git commit -m "docs: align public release docs and examples"
+```
+
+### Task 4: Add release gates for wheel build, wheel smoke, and Console web
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Test: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add an SDK package job that builds the wheel and runs the smoke script**
+
+```yaml
+  package-sdk:
+    name: Package SDK
+    runs-on: ubuntu-latest
+    needs: [lint, test-sdk]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Smoke test built SDK wheel
+        run: uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
+```
+
+- [ ] **Step 2: Add a Console package job**
+
+```yaml
+  package-console:
+    name: Package Console
+    runs-on: ubuntu-latest
+    needs: [lint, test-console]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: cd console && uv sync
+
+      - name: Build Console package
+        run: cd console && uv build
+```
+
+- [ ] **Step 3: Add a `console/web` verification job**
+
+```yaml
+  test-web:
+    name: Test Web
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: console/web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm --prefix console/web ci
+
+      - name: Run web lint
+        run: npm --prefix console/web run lint
+
+      - name: Run web tests
+        run: npm --prefix console/web test
+
+      - name: Run web production build
+        run: npm --prefix console/web run build
+```
+
+- [ ] **Step 4: Run the full local release gate before pushing**
+
+Run:
+
+```bash
+uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/
+uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/
+uv run python scripts/lint.py imports
+uv run python scripts/repo_guard.py
+uv run pytest tests/ -q
+cd console && uv run pytest tests/ -q
+cd ../console/web && npm run lint && npm test && npm run build
+cd ../.. && uv build && uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl
+cd console && uv build
+```
+
+Expected: PASS end-to-end
+
+- [ ] **Step 5: Commit the release-gate workflow changes**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add release packaging and web verification gates"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - Simpler default install: Task 2
+  - `OpenAIModel(name="gpt-5.4")` public path: Task 1 + Task 3 + Task 4 smoke
+  - Console de-emphasis / internal-use positioning: Task 3
+  - Version/release metadata refresh: Task 3
+  - CI release gates: Task 4
+- Placeholder scan:
+  - No `TODO`, `TBD`, or “similar to” placeholders remain
+- Type consistency:
+  - The new OpenAI constructor contract is consistently `id: str | None = None`, `name: str | None = None`, with normalization to non-optional `LLMConfig` values

--- a/docs/superpowers/plans/2026-04-16-github-release-publish.md
+++ b/docs/superpowers/plans/2026-04-16-github-release-publish.md
@@ -1,0 +1,500 @@
+# GitHub Release Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish both `agiwo` and `agiwo-console` from a GitHub Release so a maintainer can create `vX.Y.Z` in GitHub and let Actions validate, build, smoke-test, and upload both packages to PyPI.
+
+**Architecture:** Add a dedicated `release.yml` workflow triggered only by `release.published`, with a prepare step for tag normalization, separate build and publish jobs per package, and Trusted Publisher uploads isolated to the publish jobs. Keep release metadata validation explicit with a tiny checked-in Python script so CI can fail early on version drift and maintainers can run the same check locally.
+
+**Tech Stack:** GitHub Actions, Python 3.11, uv, Hatchling, PyPI Trusted Publisher, tomllib
+
+---
+
+## File Structure
+
+- Create: `.github/workflows/release.yml`
+  - Dedicated release workflow that triggers on `release.published`, normalizes `vX.Y.Z`, builds both packages, runs smoke checks, uploads artifacts, and publishes to PyPI through Trusted Publisher.
+- Create: `scripts/check_release_metadata.py`
+  - Small Python CLI that validates the root package version, console package version, and the console's `agiwo` dependency release line against the requested release version.
+- Create: `tests/scripts/test_check_release_metadata.py`
+  - Unit tests for the release metadata validator so version/tag drift checks are covered outside of workflow YAML.
+- Create: `docs/release.md`
+  - Maintainer runbook for PyPI Trusted Publisher setup, GitHub Release triggering, and partial-failure recovery.
+- Modify: `docs/README.md`
+  - Surface the release runbook from the main docs index.
+
+### Task 1: Add a tested release metadata validator
+
+**Files:**
+- Create: `scripts/check_release_metadata.py`
+- Create: `tests/scripts/test_check_release_metadata.py`
+- Test: `tests/scripts/test_check_release_metadata.py`
+
+- [ ] **Step 1: Write failing unit tests for release metadata validation**
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_release_metadata import (
+    expected_console_dependency,
+    validate_release_metadata,
+)
+
+
+ROOT_PYPROJECT = Path("pyproject.toml")
+CONSOLE_PYPROJECT = Path("console/pyproject.toml")
+
+
+def test_expected_console_dependency_uses_major_minor_release_line() -> None:
+    assert expected_console_dependency("0.1.0") == "agiwo ~= 0.1.0"
+    assert expected_console_dependency("0.1.7") == "agiwo ~= 0.1.0"
+    assert expected_console_dependency("1.4.2") == "agiwo ~= 1.4.0"
+
+
+def test_validate_release_metadata_accepts_current_release_surface() -> None:
+    validate_release_metadata(
+        release_version="0.1.0",
+        root_pyproject_path=ROOT_PYPROJECT,
+        console_pyproject_path=CONSOLE_PYPROJECT,
+    )
+
+
+def test_validate_release_metadata_rejects_root_version_mismatch(tmp_path: Path) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        "[project]\nname = 'agiwo'\nversion = '0.1.1'\n",
+        encoding="utf-8",
+    )
+
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    console_pyproject = console_dir / "pyproject.toml"
+    console_pyproject.write_text(
+        "[project]\nname = 'agiwo-console'\nversion = '0.1.0'\ndependencies = ['agiwo ~= 0.1.0']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="Root package version mismatch"):
+        validate_release_metadata(
+            release_version="0.1.0",
+            root_pyproject_path=root_pyproject,
+            console_pyproject_path=console_pyproject,
+        )
+
+
+def test_validate_release_metadata_rejects_console_dependency_drift(tmp_path: Path) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        "[project]\nname = 'agiwo'\nversion = '0.2.1'\n",
+        encoding="utf-8",
+    )
+
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    console_pyproject = console_dir / "pyproject.toml"
+    console_pyproject.write_text(
+        "[project]\nname = 'agiwo-console'\nversion = '0.2.1'\ndependencies = ['agiwo ~= 0.1.0']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="Console dependency mismatch"):
+        validate_release_metadata(
+            release_version="0.2.1",
+            root_pyproject_path=root_pyproject,
+            console_pyproject_path=console_pyproject,
+        )
+```
+
+- [ ] **Step 2: Run the targeted tests and confirm they fail because the validator does not exist yet**
+
+Run: `uv run pytest tests/scripts/test_check_release_metadata.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `scripts.check_release_metadata`.
+
+- [ ] **Step 3: Implement the release metadata validator**
+
+```python
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+def load_project(pyproject_path: Path) -> dict[str, object]:
+    with pyproject_path.open("rb") as file:
+        data = tomllib.load(file)
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise SystemExit(f"Missing [project] table in {pyproject_path}")
+    return project
+
+
+def expected_console_dependency(release_version: str) -> str:
+    major, minor, *_ = release_version.split(".")
+    return f"agiwo ~= {major}.{minor}.0"
+
+
+def validate_release_metadata(
+    *,
+    release_version: str,
+    root_pyproject_path: Path,
+    console_pyproject_path: Path,
+) -> None:
+    root_project = load_project(root_pyproject_path)
+    console_project = load_project(console_pyproject_path)
+
+    root_version = root_project.get("version")
+    if root_version != release_version:
+        raise SystemExit(
+            f"Root package version mismatch: expected {release_version}, got {root_version}"
+        )
+
+    console_version = console_project.get("version")
+    if console_version != release_version:
+        raise SystemExit(
+            f"Console package version mismatch: expected {release_version}, got {console_version}"
+        )
+
+    console_dependencies = console_project.get("dependencies")
+    if not isinstance(console_dependencies, list):
+        raise SystemExit("Console dependencies must be a list")
+
+    expected_dependency = expected_console_dependency(release_version)
+    if expected_dependency not in console_dependencies:
+        raise SystemExit(
+            "Console dependency mismatch: "
+            f"expected {expected_dependency!r} in dependencies, got {console_dependencies!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        raise SystemExit(
+            "Usage: python scripts/check_release_metadata.py <release-version>"
+        )
+
+    validate_release_metadata(
+        release_version=args[0],
+        root_pyproject_path=Path("pyproject.toml"),
+        console_pyproject_path=Path("console/pyproject.toml"),
+    )
+    print(f"release metadata ok: {args[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run: `uv run pytest tests/scripts/test_check_release_metadata.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the validator against the current repository metadata**
+
+Run: `uv run python scripts/check_release_metadata.py 0.1.0`
+Expected: PASS with `release metadata ok: 0.1.0`.
+
+- [ ] **Step 6: Commit the validator**
+
+```bash
+git add scripts/check_release_metadata.py tests/scripts/test_check_release_metadata.py
+git commit -m "test: add release metadata validator"
+```
+
+### Task 2: Add the GitHub Release publishing workflow
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+- Modify: `.github/workflows/release.yml` only in this task
+- Test: `.github/workflows/release.yml` via local package builds and smoke checks
+
+- [ ] **Step 1: Add the release workflow with prepare, build, and publish job boundaries**
+
+```yaml
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      release_version: ${{ steps.version.outputs.release_version }}
+    steps:
+      - name: Normalize release tag
+        id: version
+        shell: bash
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected release tag in the form vX.Y.Z, got: $tag" >&2
+            exit 1
+          fi
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  build-sdk:
+    name: Build SDK
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate release metadata
+        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Smoke test built SDK wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)"
+
+      - name: Upload SDK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish-sdk:
+    name: Publish SDK
+    runs-on: ubuntu-latest
+    needs: [prepare, build-sdk]
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SDK artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-dist
+          path: dist
+
+      - name: Publish SDK to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          print-hash: true
+
+  build-console:
+    name: Build Console
+    runs-on: ubuntu-latest
+    needs: [prepare, publish-sdk]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install SDK dependencies
+        run: uv sync
+
+      - name: Install Console dependencies
+        run: (cd console && uv sync)
+
+      - name: Validate release metadata
+        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
+
+      - name: Build SDK package
+        run: uv build
+
+      - name: Build Console package
+        run: (cd console && uv build)
+
+      - name: Smoke test built Console wheel
+        run: uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)" "$(ls console/dist/agiwo_console-*.whl | head -n 1)"
+
+      - name: Upload Console artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: console-dist
+          path: console/dist/*
+          if-no-files-found: error
+
+  publish-console:
+    name: Publish Console
+    runs-on: ubuntu-latest
+    needs: [prepare, build-console]
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Console artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: console-dist
+          path: dist
+
+      - name: Publish Console to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          print-hash: true
+```
+
+- [ ] **Step 2: Check the workflow file for the expected release trigger and OIDC publish boundaries**
+
+Run: `rg -n "release:|types: \[published\]|id-token: write|skip-existing: true|pypa/gh-action-pypi-publish@release/v1" .github/workflows/release.yml`
+Expected: PASS with matches for the release trigger, OIDC permissions, duplicate-tolerant publish, and PyPI publish action.
+
+- [ ] **Step 3: Validate the release build path locally with the same commands used by the workflow**
+
+Run: `uv sync && uv run python scripts/check_release_metadata.py 0.1.0 && uv build && (cd console && uv sync) && (cd console && uv build) && uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)" "$(ls console/dist/agiwo_console-*.whl | head -n 1)"`
+Expected: PASS with `release metadata ok: 0.1.0`, `release smoke ok`, and `agiwo-console --help` succeeding.
+
+- [ ] **Step 4: Commit the release workflow**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: publish packages from github releases"
+```
+
+### Task 3: Add maintainer release documentation
+
+**Files:**
+- Create: `docs/release.md`
+- Modify: `docs/README.md`
+- Test: `docs/release.md`, `docs/README.md`
+
+- [ ] **Step 1: Add the maintainer release runbook**
+
+```md
+# Release Publishing
+
+## Prerequisites
+
+Configure PyPI Trusted Publisher for both projects before the first release:
+
+- `agiwo`
+- `agiwo-console`
+
+Use the same GitHub repository and workflow:
+
+- Repository: `xhwSkhizein/agiwo`
+- Workflow file: `.github/workflows/release.yml`
+- Environment: `pypi`
+
+## Tag Format
+
+Create GitHub Releases with tags in this format:
+
+- `v0.1.0`
+- `v0.1.1`
+
+Do not create releases with bare tags like `0.1.0`.
+
+## Publish Flow
+
+1. Merge the release-ready changes into `main`.
+2. Confirm both package versions match the intended release version.
+3. Confirm `console/pyproject.toml` still depends on the matching `agiwo` release line.
+4. Create a GitHub Release with tag `vX.Y.Z`.
+5. Publish the release.
+6. Open the `Release Publish` workflow in GitHub Actions and confirm all jobs succeed.
+
+## Failure Handling
+
+Publishing is not atomic.
+
+- If `publish-sdk` fails, `agiwo-console` will not publish.
+- If `publish-sdk` succeeds and `publish-console` fails, `agiwo` stays published.
+- Fix the failure and rerun the workflow to publish the missing package.
+
+The workflow is configured with duplicate-tolerant uploads so reruns can recover after a partial publish.
+```
+
+- [ ] **Step 2: Review the new release guide for the required operational details**
+
+Run: `rg -n "Trusted Publisher|v0.1.0|Environment: `pypi`|not atomic|rerun" docs/release.md`
+Expected: PASS with matches for Trusted Publisher setup, tag format, environment, and partial-failure handling.
+
+- [ ] **Step 3: Link the release guide from the docs index**
+
+```md
+## Guides
+
+- **[Custom Tools](./guides/custom-tools.md)** — Build your own tools
+- **[Multi-Agent & Composition](./guides/multi-agent.md)** — Agent-as-tool and scheduler orchestration
+- **[Streaming](./guides/streaming.md)** — Real-time streaming responses
+- **[Hooks](./guides/hooks.md)** — Observe and intercept agent lifecycle events
+- **[Storage & Observability](./guides/storage.md)** — Persist runs, sessions, and traces
+- **[Skills](./guides/skills.md)** — File-based skill discovery and loading
+- **[Release Publishing](./release.md)** — Maintainer runbook for GitHub Release driven PyPI publishing
+```
+
+- [ ] **Step 4: Confirm the docs index now exposes the release runbook**
+
+Run: `rg -n "Release Publishing" docs/README.md docs/release.md`
+Expected: PASS with a link in `docs/README.md` and the title in `docs/release.md`.
+
+- [ ] **Step 5: Commit the docs update**
+
+```bash
+git add docs/README.md docs/release.md
+git commit -m "docs: add github release publish runbook"
+```
+
+### Task 4: Run the final validation sweep
+
+**Files:**
+- Modify: none
+- Test: `.github/workflows/release.yml`, `scripts/check_release_metadata.py`, `tests/scripts/test_check_release_metadata.py`, `docs/release.md`, `docs/README.md`
+
+- [ ] **Step 1: Run the targeted tests and changed-file lint**
+
+Run: `uv run pytest tests/scripts/test_check_release_metadata.py -v && uv run python scripts/lint.py changed`
+Expected: PASS.
+
+- [ ] **Step 2: Re-run the release build smoke end to end**
+
+Run: `uv build && (cd console && uv build) && uv run python scripts/smoke_release_install.py "$(ls dist/agiwo-*.whl | head -n 1)" "$(ls console/dist/agiwo_console-*.whl | head -n 1)"`
+Expected: PASS with `release smoke ok` and successful `agiwo-console --help` output.
+
+- [ ] **Step 3: Run the repo guardrails required before shipping**
+
+Run: `uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 scripts/ tests/scripts/ && uv run ruff format --check scripts/ tests/scripts/ && uv run python scripts/repo_guard.py`
+Expected: PASS, except for any already-known pre-existing warnings that are unchanged by this work.
+
+- [ ] **Step 4: Push the branch and update the existing PR**
+
+```bash
+git push origin feat/first-release-prep
+```
+
+Expected: PASS and the PR shows the release workflow, validator, and docs changes.

--- a/docs/superpowers/specs/2026-04-16-console-cli-design.md
+++ b/docs/superpowers/specs/2026-04-16-console-cli-design.md
@@ -1,0 +1,133 @@
+# Console CLI Design
+
+**Date:** 2026-04-16
+
+## Goal
+
+Make the published `agiwo-console` package startable through a user-facing command instead of exposing the internal ASGI module path `server.app:app`.
+
+## Scope
+
+This design covers only the installed-package startup experience for `agiwo-console`.
+
+It includes:
+
+1. adding a package entrypoint command
+2. implementing a `serve` subcommand
+3. updating release-facing docs to use the new command
+4. adding minimal tests for CLI argument handling
+
+It does not include:
+
+- new Console features
+- auth or production hardening
+- web frontend packaging changes
+- a broader CLI suite beyond the single startup command
+
+## Current Problem
+
+After `pip install agiwo-console`, the user currently has to start the server with:
+
+```bash
+uvicorn server.app:app --host 0.0.0.0 --port 8422
+```
+
+This works from an installed environment and does not require entering the source repo, but it is still poor UX because:
+
+- it exposes internal module structure
+- it forces users to learn Uvicorn invocation details
+- it makes the package feel like source code rather than a product command
+
+## Decision
+
+Expose a console script named:
+
+```bash
+agiwo-console serve
+```
+
+This will be the documented startup path for the packaged Console.
+
+## Command Surface
+
+The CLI should support:
+
+```bash
+agiwo-console serve
+agiwo-console serve --host 0.0.0.0
+agiwo-console serve --port 8422
+agiwo-console serve --env-file /path/to/.env
+agiwo-console serve --reload
+```
+
+Behavior:
+
+- defaults should match the existing Console defaults where possible
+- `serve` should call `uvicorn.run("server.app:app", ...)`
+- the CLI should stay thin and avoid duplicating app startup logic
+
+## Packaging Design
+
+`console/pyproject.toml` will publish a script entry similar to:
+
+```toml
+[project.scripts]
+agiwo-console = "server.cli:main"
+```
+
+The implementation module should be small and live inside `console/server/`.
+
+## Implementation Shape
+
+Add a new module:
+
+- `console/server/cli.py`
+
+Responsibilities:
+
+- build the top-level argument parser
+- provide the `serve` subcommand
+- forward normalized arguments into `uvicorn.run(...)`
+- return a standard process exit code
+
+The CLI should use the standard library `argparse` rather than introducing a new dependency just for one command.
+
+## Docs Changes
+
+Release-facing docs should replace:
+
+```bash
+uvicorn server.app:app ...
+```
+
+with:
+
+```bash
+agiwo-console serve ...
+```
+
+At minimum this should update:
+
+- `README.md`
+- `docs/console/overview.md`
+
+If any installation or startup guidance for the packaged Console appears elsewhere, it should be kept consistent.
+
+## Testing Strategy
+
+Add minimal tests that verify:
+
+1. `serve` dispatches to `uvicorn.run`
+2. `--host`, `--port`, `--env-file`, and `--reload` are passed through correctly
+3. the package exposes the script entry after build/install
+
+The installed-command smoke can remain lightweight. It is enough to verify the console script exists and can print help from a fresh installed environment.
+
+## Acceptance Criteria
+
+The change is complete when:
+
+1. `pip install agiwo-console` exposes an `agiwo-console` command
+2. `agiwo-console serve` starts the same app currently started by `uvicorn server.app:app`
+3. release-facing docs no longer tell packaged users to invoke the internal module path directly
+4. CLI behavior is covered by at least one automated test and one installed-package smoke path

--- a/docs/superpowers/specs/2026-04-16-first-release-design.md
+++ b/docs/superpowers/specs/2026-04-16-first-release-design.md
@@ -1,0 +1,197 @@
+# First Release Design
+
+**Date:** 2026-04-16
+
+## Goal
+
+Prepare the repository for the first public release of both `agiwo` and `agiwo-console` with a simpler install story, accurate public docs, and release gates that catch broken packaging and broken quick-start paths before publish.
+
+## Scope
+
+This design covers four release-facing areas only:
+
+1. Python package dependency and packaging layout for `agiwo` and `agiwo-console`
+2. Public documentation and examples, with SDK-first positioning
+3. Version surface alignment across SDK, Console backend, and Console web
+4. CI checks required to block a bad release
+
+This design does not include broader runtime refactors, API redesign, auth, or production-hardening work outside the minimum positioning and release-safety changes described below.
+
+## Context
+
+The current repository is close to release-ready from a testing perspective, but the publish surface still has several first-use failures:
+
+- `pip install agiwo` does not match the documented user experience because public imports can fail when optional providers are missing
+- README quick-start examples are not copy-paste safe
+- builtin tool docs do not match the effective install/runtime surface
+- CI does not exercise package build, clean-install smoke, or Console web verification
+- Console messaging is currently too strong for its actual readiness level
+
+For a first release, reducing surface complexity is more valuable than preserving a finely segmented extras model.
+
+## Design Summary
+
+### 1. Default install model
+
+`agiwo` will install with the full current runtime dependency set by default. The package should no longer depend on optional extras for providers or web capabilities to make the documented primary path work.
+
+Implications:
+
+- Core dependencies in the root `pyproject.toml` include the currently used provider and web dependencies needed by the published SDK surface
+- Existing extras may remain only where they still add real value, but the install story and docs no longer rely on them
+- `agiwo-console` depends on `agiwo` directly rather than `agiwo[all]`
+
+Rationale:
+
+- This matches the maintainer decision to optimize for lower release complexity
+- It removes the current mismatch between public imports and install instructions
+- It keeps first-time installation predictable at the cost of a heavier wheel, which is acceptable for a `0.1.0`
+
+### 2. Public SDK examples
+
+Public docs should prefer the simplest constructor form that is valid in the released package. The canonical example becomes:
+
+```python
+from agiwo.llm import OpenAIModel
+
+model = OpenAIModel(name="gpt-5.4")
+```
+
+The documentation should consistently prefer this style unless a page is explicitly teaching lower-level provider details. When an example needs a concrete `id`, it must still be internally consistent with the actual constructor contract.
+
+Implications:
+
+- README, getting-started, and public model/tool concept docs must be updated together
+- Release-facing docs should avoid examples that imply optional install steps are required for the default SDK path
+
+### 3. Console positioning
+
+README and other public entry docs should continue to present the SDK as the main product. Console messaging should be reduced to a compact, accurate positioning:
+
+- Console is a directly usable control-plane backend with a bundled web UI
+- Current channel integration is limited to Feishu
+- Recommended deployment model is internal/self-hosted use
+- It is not yet production-ready
+
+This is a messaging change, not a promise of new runtime constraints. The intent is to keep the release honest without removing the Console package from the release.
+
+### 4. Version surface alignment
+
+The release version must be represented consistently in:
+
+- root `pyproject.toml`
+- `console/pyproject.toml`
+- FastAPI app version string
+- Console web visible version label
+- changelog release entry
+
+The release version remains `0.1.0` unless changed separately, but all user-visible version surfaces must derive from or at least match the same value.
+
+For this release, alignment is sufficient; introducing a new cross-language version generation system is optional and should only be done if it stays small.
+
+### 5. Release gate in CI
+
+CI must validate the same surfaces that are most likely to break the first release:
+
+- Python lint
+- Python test suites
+- SDK package build
+- Console package build
+- clean-install smoke for the published SDK wheel
+- Console web lint
+- Console web tests
+- Console web production build
+
+The clean-install smoke should verify at least one documented public import path and one minimal constructor path from a fresh environment built from the wheel artifact, not the editable checkout.
+
+## Implementation Shape
+
+### Packaging
+
+Root package changes are expected in:
+
+- dependency declarations
+- optional dependency cleanup
+- any docs or tests that refer to extras-based installation
+
+Console package changes are expected in:
+
+- dependency declaration on `agiwo`
+- release metadata consistency
+
+### Documentation
+
+Primary public docs to update:
+
+- `README.md`
+- `docs/getting-started.md`
+- `docs/concepts/model.md`
+- `docs/concepts/tool.md`
+- any other release-facing page that still demonstrates the invalid `OpenAIModel(id=...)` quick-start or overstates Console readiness
+
+Docs under internal planning or historical architecture notes do not need broad cleanup unless they directly conflict with the release entry surface.
+
+### Verification
+
+Verification should be split into:
+
+- normal repo lint and tests
+- package build checks
+- fresh-environment smoke checks for built wheels
+- Console web lint/test/build
+
+## Error Handling and Failure Modes
+
+### Install/runtime mismatch
+
+Risk:
+Public imports succeed in editable development but fail from an installed wheel.
+
+Mitigation:
+Require clean-install smoke in CI from built wheel artifacts.
+
+### Doc drift
+
+Risk:
+README and docs point to constructors or install commands that no longer reflect shipped behavior.
+
+Mitigation:
+Update the public docs set together and include at least one smoke check that mirrors README usage.
+
+### Console expectation gap
+
+Risk:
+Users interpret the Console package as production-ready because the README presents it as a flagship feature.
+
+Mitigation:
+Reduce README emphasis and add explicit internal-use / not-production-ready language.
+
+## Testing Strategy
+
+The release work is complete when all of the following pass:
+
+- existing SDK lint and test commands
+- existing Console backend lint and test commands
+- `uv build` at repo root
+- `uv build` in `console/`
+- fresh-wheel smoke import and minimal model construction for `agiwo`
+- `npm run lint`, `npm test`, and `npm run build` in `console/web`
+
+At least one smoke test or CI command should prove that the documented `OpenAIModel(name="gpt-5.4")` path is valid from an installed wheel.
+
+## Non-Goals
+
+- No new provider abstractions
+- No Console authentication or multi-tenant hardening
+- No broad documentation rewrite beyond release-facing accuracy
+- No runtime behavior changes unrelated to release correctness
+
+## Acceptance Criteria
+
+The repository is ready for `0.1.0` release when:
+
+1. `pip install agiwo` provides a working public SDK import path without extra dependency selection
+2. README quick start is copy-paste valid for the released package
+3. Console is documented as an internal/self-hosted, not-yet-production-ready control plane with current Feishu-only channel integration
+4. `agiwo` and `agiwo-console` both build successfully
+5. CI verifies package build, clean-install smoke, and Console web quality gates

--- a/docs/superpowers/specs/2026-04-16-github-release-publish-design.md
+++ b/docs/superpowers/specs/2026-04-16-github-release-publish-design.md
@@ -1,0 +1,254 @@
+# GitHub Release Publish Design
+
+**Goal:** Let a maintainer publish both `agiwo` and `agiwo-console` directly from a GitHub Release, with release-triggered CI building, validating, and uploading both packages to PyPI.
+
+## Scope
+
+This design covers the first release automation path for the two Python packages already present in this repository:
+
+1. `agiwo`
+2. `agiwo-console`
+
+The design adds a dedicated GitHub Actions workflow for release publishing and the minimum supporting documentation needed for maintainers to operate it safely.
+
+This design does not cover:
+
+- npm or frontend package publishing
+- automatic version bumping
+- changelog generation
+- rollback automation for failed PyPI releases
+- broader production-hardening outside the publish path
+
+## Context
+
+The repository already has CI checks that lint, test, build both packages, and run fresh-install smoke checks. That is enough to block many bad releases, but the actual publish step is still manual.
+
+The maintainer requirement is to publish from GitHub itself by creating a Release, instead of running a separate local release script. The tag format is `v0.1.0` rather than `0.1.0`. The maintainer also accepts that publishing is not atomic: if `agiwo` succeeds and `agiwo-console` fails, the workflow should fail overall but retain any package that was already uploaded successfully.
+
+## Recommended Approach
+
+Add a separate `.github/workflows/release.yml` workflow triggered by `release.published`.
+
+This workflow should:
+
+1. extract the version from the GitHub Release tag
+2. verify that the repository package versions match that release version
+3. rebuild and smoke-test the SDK artifacts
+4. publish `agiwo`
+5. rebuild and smoke-test the Console artifacts
+6. publish `agiwo-console`
+
+This keeps release operations separate from ordinary CI and maps directly to the maintainer's desired GitHub Release workflow.
+
+## Workflow Architecture
+
+### Trigger
+
+The publish workflow triggers only on:
+
+- `release.published`
+
+It should not trigger on:
+
+- branch pushes
+- pull requests
+- plain tag pushes
+
+This keeps regular validation and formal publishing clearly separated.
+
+### Job Structure
+
+The workflow should have three jobs:
+
+1. `prepare`
+2. `publish-sdk`
+3. `publish-console`
+
+`publish-sdk` depends on `prepare`.
+
+`publish-console` depends on `publish-sdk`.
+
+This dependency order is deliberate. `agiwo-console` depends on `agiwo`, so the console package should not be published before the SDK publish has succeeded.
+
+### Prepare Job
+
+`prepare` is responsible for:
+
+- reading `github.event.release.tag_name`
+- requiring a `v` prefix
+- normalizing `v0.1.0` to `0.1.0`
+- exposing the normalized version as a workflow output
+
+If the tag does not follow the required `v<semver>` style, the workflow should fail immediately before any build or upload starts.
+
+## Version Validation Rules
+
+Every publish job must explicitly validate package metadata against the normalized release version.
+
+### SDK Version Check
+
+The root `pyproject.toml` version must exactly equal the normalized release version.
+
+If the release tag is `v0.1.0`, then:
+
+- `pyproject.toml` must contain `version = "0.1.0"`
+
+If not, `publish-sdk` fails before building or uploading.
+
+### Console Version Check
+
+`console/pyproject.toml` must also exactly equal the normalized release version.
+
+If the release tag is `v0.1.0`, then:
+
+- `console/pyproject.toml` must contain `version = "0.1.0"`
+
+If not, `publish-console` fails before building or uploading.
+
+### Console Dependency Check
+
+Because the console package is released together with the SDK, the console dependency on `agiwo` must remain aligned with the same release line.
+
+For the `0.1.0` release line, the workflow should validate that the console dependency entry stays compatible with that same line, for example:
+
+- `agiwo ~= 0.1.0`
+
+This prevents releasing a console package whose dependency range can drift away from the paired SDK release.
+
+## Build And Validation Flow
+
+Each publish job should rebuild artifacts in CI instead of trusting checked-in local outputs.
+
+### SDK Publish Flow
+
+`publish-sdk` should:
+
+1. check out the repository
+2. install Python 3.11 and `uv`
+3. run `uv sync`
+4. validate the root package version against the release version
+5. build the SDK package with `uv build`
+6. run the existing smoke script against the built SDK wheel
+7. upload SDK artifacts to PyPI using Trusted Publisher
+
+### Console Publish Flow
+
+`publish-console` should:
+
+1. check out the repository
+2. install Python 3.11 and `uv`
+3. run `(cd console && uv sync)`
+4. validate `console/pyproject.toml` version against the release version
+5. validate the console dependency on `agiwo` matches the same release line
+6. rebuild the SDK package as the install source for smoke verification
+7. build the console package with `(cd console && uv build)`
+8. run the existing smoke script against both wheels, including `agiwo-console --help`
+9. upload console artifacts to PyPI using Trusted Publisher
+
+The console smoke should continue to install both wheels into a clean environment to verify the released pairing instead of validating the console wheel in isolation.
+
+## Publishing Credentials Model
+
+The workflow should use PyPI Trusted Publisher rather than long-lived API tokens stored in GitHub secrets.
+
+That implies:
+
+- the workflow job that uploads to PyPI must request `id-token: write`
+- each package upload step must target its own PyPI project
+- PyPI must be configured to trust this repository and this workflow for both `agiwo` and `agiwo-console`
+
+This is the preferred first-release setup because it reduces secret handling and aligns with current PyPI best practice.
+
+## Failure Semantics
+
+The release process is intentionally non-atomic.
+
+Expected behavior:
+
+- if `publish-sdk` fails, `publish-console` does not run
+- if `publish-sdk` succeeds and `publish-console` fails, the overall workflow fails
+- any package already uploaded to PyPI remains published
+- the maintainer fixes the issue and reruns the workflow to publish the missing package
+
+The workflow should not try to delete releases, delete tags, or remove already-published PyPI artifacts.
+
+## Re-Run Behavior
+
+Workflow re-runs must be safe when one package was already published successfully.
+
+That means the upload action or upload command should tolerate already-existing files so a rerun can:
+
+- skip already uploaded SDK artifacts
+- continue toward the missing publish step
+
+The goal is operational recovery, not strict transactional behavior.
+
+## Documentation Changes
+
+Release-facing maintainer docs should add a short operational section that covers:
+
+1. required PyPI Trusted Publisher setup for both projects
+2. the fact that publishing is triggered by creating a GitHub Release
+3. the required tag format, for example `v0.1.0`
+4. the expected partial-failure behavior
+
+This documentation should stay short and procedural. It only needs to explain how the release automation works and what prerequisites must exist outside the repository.
+
+## Security And Permissions
+
+The release workflow should use the minimum permissions needed:
+
+- `contents: read` for checkout
+- `id-token: write` only for jobs that publish to PyPI
+
+No repository write-back is required. The workflow should not create commits, mutate tags, or edit release notes.
+
+## Alternatives Considered
+
+### 1. Publish On Tag Push
+
+This would trigger on `push` of `v*` tags.
+
+Why not chosen:
+
+- the maintainer explicitly wants to publish from GitHub Release
+- tag pushes are easier to trigger accidentally
+- Release as the publish event is more legible operationally
+
+### 2. Add Publish Logic Into Existing CI
+
+This would extend `.github/workflows/ci.yml` with conditional publish steps.
+
+Why not chosen:
+
+- it mixes ordinary validation with formal release behavior
+- it makes the main CI workflow harder to understand and maintain
+- publish-only permissions and release triggers deserve a separate workflow boundary
+
+### 3. Publish SDK And Console In Parallel
+
+This would reduce total workflow time.
+
+Why not chosen:
+
+- `agiwo-console` depends on `agiwo`
+- sequential publish preserves a cleaner failure story for the first release
+
+## Acceptance Criteria
+
+The release automation is complete when all of the following are true:
+
+1. Creating a GitHub Release with tag `vX.Y.Z` triggers a dedicated publish workflow.
+2. The workflow extracts `X.Y.Z` and validates both package versions before any upload begins.
+3. The workflow builds and smoke-tests `agiwo` before publishing it.
+4. The workflow builds and smoke-tests `agiwo-console` against the paired SDK wheel before publishing it.
+5. The workflow publishes with PyPI Trusted Publisher rather than stored API tokens.
+6. The console publish path validates its dependency on `agiwo` stays aligned with the same release line.
+7. A partial failure leaves already-published artifacts intact and surfaces a failing GitHub Actions run for maintainer follow-up.
+8. Maintainer-facing release docs explain the required tag format and the required external PyPI setup.
+
+## Implementation Notes
+
+Keep this release automation small and explicit.
+
+Reuse the existing release smoke script and existing package build commands instead of inventing a new release toolchain. The value here is moving the last manual publish step into GitHub Actions, not redesigning packaging.

--- a/docs/superpowers/specs/2026-04-16-skill-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-16-skill-discovery-design.md
@@ -1,0 +1,310 @@
+# Skill Discovery And Dynamic Activation Design
+
+**Date:** 2026-04-16
+
+## Goal
+
+Stop skill discovery from inflating the agent system prompt while preserving the ability to use skills when they are actually needed.
+
+## Scope
+
+This design covers the first-stage skill discovery redesign for the SDK.
+
+It includes:
+
+1. shrinking the skill-related system prompt surface
+2. keeping a small statically configured default skill set in prompt
+3. extending the existing `skill` tool to support `search` and `activate`
+4. adding runtime skill recommendation based on embedding TopK plus LLM judgment
+5. keeping all filtering constrained by `allowed_skills`
+
+It does not include:
+
+- schema migration
+- persistent vector indexes
+- telemetry-driven default skill selection
+- automatic runtime injection of hidden skill recommendations without a tool call
+- changes to the core allowlist semantics
+
+## Current Problem
+
+Today `[build_system_prompt()](/home/hongv/workspace/agiwo/agiwo/agent/prompt.py)` asks `SkillManager` to render a full skills section into the system prompt. `[SkillPromptCatalog.render_section()](/home/hongv/workspace/agiwo/agiwo/skill/prompt_catalog.py)` emits one prompt entry for every discovered skill, including its name, description, and location.
+
+This creates a linear prompt growth problem:
+
+- every discovered skill increases prompt size
+- large `skills_dirs` make prompt cost and latency scale with repository size rather than user need
+- most requests do not require any skill at all
+- the current design pays prompt cost before the model has decided whether a skill is useful
+
+The existing `[SkillTool](/home/hongv/workspace/agiwo/agiwo/skill/skill_tool.py)` already loads full `SKILL.md` content on demand. The missing piece is dynamic discovery, not dynamic activation.
+
+## Decision
+
+Adopt a two-layer design:
+
+1. prompt-time skill visibility becomes small and static
+2. runtime skill discovery becomes explicit through the existing `skill` tool
+
+The `skill` tool remains the only skill-facing tool, but its protocol expands to support:
+
+- `search`: recommend a skill or explicitly recommend none
+- `activate`: load the full `SKILL.md` content for a chosen skill
+
+The model should not be pushed toward skills by default. "Do not use a skill" must remain a normal, successful result.
+
+## Prompt Design
+
+The system prompt should no longer list every discovered skill.
+
+Instead, the skill section should contain:
+
+- a short instruction that skills are optional and should be used only when clearly helpful
+- a small statically configured `default_prompt_skills` subset
+- brief instructions to use `skill.search` before `skill.activate` when the model is unsure
+
+`default_prompt_skills` is SDK global configuration. It is validated as a list of explicit skill names during startup and must fail fast for unknown names.
+
+Prompt rendering must apply the same allowlist boundary as runtime search:
+
+- if `allowed_skills is None`, the prompt may show all configured default prompt skills
+- if `allowed_skills` is a list, the prompt may only show `default_prompt_skills ∩ allowed_skills`
+- if `allowed_skills == []`, skills are disabled and no skill section is rendered
+
+This keeps prompt size stable while preserving a small high-signal set of commonly useful skills.
+
+## Tool Protocol
+
+The existing `skill` tool becomes a dual-mode tool.
+
+### `skill.search`
+
+Input schema:
+
+```json
+{
+  "mode": "search",
+  "query": "original user request"
+}
+```
+
+Behavior:
+
+- `query` is the raw user request text as seen by the model
+- the tool does not activate any skill
+- the tool returns a structured recommendation only
+
+Output shape:
+
+```json
+{
+  "decision": "recommend",
+  "skill_name": "brainstorming",
+  "reason": "The request is about exploring approaches before implementation."
+}
+```
+
+or:
+
+```json
+{
+  "decision": "no_recommendation",
+  "reason": "No available skill is necessary or clearly matched for this request."
+}
+```
+
+### `skill.activate`
+
+Input schema:
+
+```json
+{
+  "mode": "activate",
+  "skill_name": "brainstorming"
+}
+```
+
+Behavior:
+
+- preserves the current activation semantics
+- loads the full `SKILL.md` body for the requested skill
+- fails if the skill does not exist or is not allowed
+
+The tool name stays `skill` so the tool surface remains simple.
+
+## Search Pipeline
+
+`skill.search` should run the following steps in order.
+
+### 1. Candidate Filtering
+
+Start from the discovered skill metadata cache in `SkillManager`.
+
+Apply allowlist semantics first:
+
+- `allowed_skills is None`: all discovered skills are eligible
+- `allowed_skills == []`: return `no_recommendation`
+- explicit list: only those skills are eligible
+
+This preserves the current security and boundary semantics. An agent must never discover or activate a skill outside its allowed set.
+
+### 2. Embedding Recall
+
+Build an in-memory searchable text for each skill from existing metadata:
+
+- `name`
+- `description`
+- optional `metadata` entries when present
+
+No migration or new persisted index is introduced in this phase.
+
+At runtime:
+
+- embed the user query
+- embed the filtered skill corpus
+- compute similarity
+- take TopK candidates, default `K = 6`
+
+The searchable corpus can be rebuilt in memory when skills are initialized or reloaded. This keeps the first version simple and consistent with the existing metadata cache design.
+
+### 3. LLM Judgment
+
+Pass only the following to the judge model:
+
+- the raw user query
+- the TopK candidate skill metadata
+
+The judge must choose one of two valid outcomes:
+
+1. recommend exactly one specific skill from the candidate set
+2. recommend no skill
+
+This judgment is recommendation-only. It does not activate the skill automatically.
+
+If the judge returns an unknown skill or a skill outside the candidate set, the runtime must treat that as invalid output and downgrade to `no_recommendation`.
+
+## Failure Semantics
+
+`skill.search` is advisory and must not block the main task.
+
+The first-stage behavior should be:
+
+- if skills are disabled, the `skill` tool is not registered
+- if the candidate set is empty, return `no_recommendation`
+- if embedding is unavailable or fails, return `no_recommendation`
+- if the judge LLM fails, times out, or returns invalid structured output, return `no_recommendation`
+
+`skill.activate` keeps strict failure behavior:
+
+- unknown skill -> failed tool result
+- disallowed skill -> failed tool result
+- unreadable or invalid `SKILL.md` -> failed tool result
+
+This asymmetric design keeps discovery cheap and safe while preserving explicit failure for actual activation.
+
+## Module Boundaries
+
+The implementation should stay mostly inside `agiwo/skill/`.
+
+### Existing Modules To Change
+
+- `[agiwo/agent/prompt.py](/home/hongv/workspace/agiwo/agiwo/agent/prompt.py)`
+  render only the reduced prompt-time skill section
+- `[agiwo/skill/manager.py](/home/hongv/workspace/agiwo/agiwo/skill/manager.py)`
+  remain the facade for discovery, prompt rendering, and search entrypoints
+- `[agiwo/skill/skill_tool.py](/home/hongv/workspace/agiwo/agiwo/skill/skill_tool.py)`
+  parse `mode`, call search or activate, and return `ToolResult`
+
+### New Module
+
+Add a focused runtime search module:
+
+- `agiwo/skill/search.py`
+
+Responsibilities:
+
+- convert skill metadata into searchable text
+- manage in-memory search corpus
+- run embedding TopK recall
+- run LLM judgment
+- return structured recommendation results
+
+`ToolManager` should remain unaware of search internals. Its only job is still to create `SkillTool` when skills are enabled.
+
+## Configuration
+
+Add SDK-level configuration in `[agiwo/config/settings.py](/home/hongv/workspace/agiwo/agiwo/config/settings.py)` for the first-stage rollout:
+
+- `default_prompt_skills: list[str] = []`
+- `skill_search_enabled: bool = True`
+- `skill_search_top_k: int = 6`
+
+The first version should not add a separate persisted config model or migration path.
+
+Judge model configuration should stay simple:
+
+- the first version reuses the existing runtime model capability instead of adding separate judge-model settings
+- no dedicated persisted or console-level judge configuration is introduced in this phase
+
+This keeps the first implementation focused on prompt reduction and dynamic discovery rather than provider plumbing.
+
+## Testing Strategy
+
+Add tests in three layers.
+
+### 1. Prompt Construction Tests
+
+Verify that:
+
+- full discovered skills are no longer rendered into the system prompt
+- only configured default prompt skills appear
+- rendered prompt skills still respect `allowed_skills`
+- disabling skills removes the prompt section entirely
+
+### 2. Skill Search Tests
+
+Verify that:
+
+- `skill.search` only considers skills inside the allowed set
+- search returns TopK candidates before judge evaluation
+- judge can recommend exactly one candidate
+- judge can return `no_recommendation`
+- invalid judge output downgrades to `no_recommendation`
+- embedding or judge failure downgrades to `no_recommendation`
+
+### 3. Activation And Integration Tests
+
+Verify that:
+
+- `skill.activate` keeps current successful activation behavior
+- disallowed activation still fails
+- a normal non-skill task can proceed without activating any skill
+- a clear skill-matching task can call `search` first and `activate` second
+
+## Rollout Plan
+
+The first rollout should be intentionally narrow:
+
+1. stop injecting the full skill catalog into the system prompt
+2. render only `default_prompt_skills`
+3. add `skill.search`
+4. keep activation explicit through `skill.activate`
+5. keep all search state in memory
+
+The implementation should not add:
+
+- migration logic
+- usage-frequency ranking
+- hidden auto-routing
+- persisted embedding caches
+
+## Acceptance Criteria
+
+The change is complete when:
+
+1. system prompt size no longer scales with the total number of discovered skills
+2. only statically configured default prompt skills are rendered, subject to `allowed_skills`
+3. the `skill` tool supports both `search` and `activate`
+4. `skill.search` can return either a concrete recommendation or `no_recommendation`
+5. search can never reveal or recommend a skill outside the agent's allowed set
+6. the first implementation works without schema migration or persisted search indexes

--- a/examples/01_hello_agent.py
+++ b/examples/01_hello_agent.py
@@ -18,7 +18,7 @@ async def main() -> None:
             description="A friendly assistant",
             system_prompt="You are concise. Answer in one sentence.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     result = await agent.run("What is the capital of France?")

--- a/examples/02_streaming.py
+++ b/examples/02_streaming.py
@@ -18,7 +18,7 @@ async def main() -> None:
             description="A creative storyteller",
             system_prompt="You are a creative writer. Be vivid and engaging.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     print("Streaming response:\n")

--- a/examples/03_custom_tool.py
+++ b/examples/03_custom_tool.py
@@ -64,7 +64,7 @@ async def main() -> None:
             description="Can check weather",
             system_prompt="Use the get_weather tool when asked about weather.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
         tools=[WeatherTool()],
     )
 

--- a/examples/04_builtin_tools.py
+++ b/examples/04_builtin_tools.py
@@ -24,7 +24,7 @@ async def main() -> None:
                 "and bash when you need to check system state."
             ),
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
         # No tools=[] needed — builtins are auto-included
     )
 

--- a/examples/05_hooks.py
+++ b/examples/05_hooks.py
@@ -27,7 +27,7 @@ async def main() -> None:
             description="An agent with hooks",
             system_prompt="You are a helpful assistant.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
         hooks=hooks,
     )
 

--- a/examples/06_agent_as_tool.py
+++ b/examples/06_agent_as_tool.py
@@ -22,7 +22,7 @@ async def main() -> None:
                 "provide 3-5 key facts with brief explanations. Be factual and concise."
             ),
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     # Orchestrator: delegates research, then synthesizes
@@ -36,7 +36,7 @@ async def main() -> None:
                 "Use the researcher tool to gather facts before writing."
             ),
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
         tools=[researcher.as_tool()],
     )
 

--- a/examples/07_scheduler.py
+++ b/examples/07_scheduler.py
@@ -19,7 +19,7 @@ async def main() -> None:
             description="A thorough analyst",
             system_prompt="You analyze topics in depth. Be systematic.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     async with Scheduler() as scheduler:

--- a/examples/08_multi_agent.py
+++ b/examples/08_multi_agent.py
@@ -20,7 +20,7 @@ async def main() -> None:
             description="Researches a specific topic",
             system_prompt="Research the given topic and provide 3 key findings.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     # Synthesizer agent — combines multiple findings
@@ -30,7 +30,7 @@ async def main() -> None:
             description="Combines research into a summary",
             system_prompt="Given multiple research findings, write a cohesive summary.",
         ),
-        model=OpenAIModel(id="gpt-4o-mini", name="gpt-4o-mini"),
+        model=OpenAIModel(name="gpt-5.4"),
     )
 
     async with Scheduler() as scheduler:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "structlog>=24.0.0",
     "tenacity>=8.0.0",
     "openai>=1.0.0",
+    "anthropic>=0.34.0",
+    "boto3>=1.42.59",
     "python-dotenv>=1.0.0",
     "orjson>=3.11.6",
     "aiosqlite>=0.22.1",
@@ -19,35 +21,17 @@ dependencies = [
     "httpx[socks]>=0.27.0",
     "aiofiles>=25.1.0",
     "browser-control-and-automation-cli>=0.1.3",
-]
-
-[project.optional-dependencies]
-anthropic = [
-    "anthropic>=0.34.0",
-]
-bedrock = [
-    "boto3>=1.42.59",
-]
-web = [
     "curl-cffi>=0.14.0",
     "bs4>=0.0.2",
     "trafilatura>=2.0.0",
-]
-feishu = [
     "lark-oapi>=1.5.3",
-]
-mongo = [
     "motor>=3.7.1",
-]
-observability = [
     "opentelemetry-distro>=0.60b1",
     "opentelemetry-exporter-otlp>=1.39.1",
 ]
-all = [
-    "agiwo[anthropic,bedrock,web,feishu,mongo,observability]",
-]
+
+[project.optional-dependencies]
 dev = [
-    "agiwo[all]",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-mock>=3.14.0",

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,76 @@
+import sys
+import tomllib
+from pathlib import Path
+
+
+def load_project(pyproject_path: Path) -> dict[str, object]:
+    with pyproject_path.open("rb") as file:
+        data = tomllib.load(file)
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise SystemExit(f"Missing [project] table in {pyproject_path}")
+    return project
+
+
+def expected_console_dependency(release_version: str) -> str:
+    parts = release_version.split(".")
+    if len(parts) != 3 or any(not part.isdigit() for part in parts):
+        raise SystemExit(
+            f"Release version must be in the form X.Y.Z, got: {release_version}"
+        )
+    major, minor, _patch = parts
+    return f"agiwo ~= {major}.{minor}.0"
+
+
+def validate_release_metadata(
+    *,
+    release_version: str,
+    root_pyproject_path: Path,
+    console_pyproject_path: Path,
+) -> None:
+    root_project = load_project(root_pyproject_path)
+    console_project = load_project(console_pyproject_path)
+
+    root_version = root_project.get("version")
+    if root_version != release_version:
+        raise SystemExit(
+            f"Root package version mismatch: expected {release_version}, got {root_version}"
+        )
+
+    console_version = console_project.get("version")
+    if console_version != release_version:
+        raise SystemExit(
+            "Console package version mismatch: "
+            f"expected {release_version}, got {console_version}"
+        )
+
+    console_dependencies = console_project.get("dependencies")
+    if not isinstance(console_dependencies, list):
+        raise SystemExit("Console dependencies must be a list")
+
+    expected_dependency = expected_console_dependency(release_version)
+    if expected_dependency not in console_dependencies:
+        raise SystemExit(
+            "Console dependency mismatch: "
+            f"expected {expected_dependency!r} in dependencies, got {console_dependencies!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        raise SystemExit(
+            "Usage: python scripts/check_release_metadata.py <release-version>"
+        )
+
+    validate_release_metadata(
+        release_version=args[0],
+        root_pyproject_path=Path("pyproject.toml"),
+        console_pyproject_path=Path("console/pyproject.toml"),
+    )
+    print(f"release metadata ok: {args[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_release_install.py
+++ b/scripts/smoke_release_install.py
@@ -4,9 +4,19 @@ import sys
 import tempfile
 from pathlib import Path
 
+TIMEOUT_SECONDS = 300
+
 
 def run(cmd: list[str]) -> None:
-    subprocess.run(cmd, check=True)
+    try:
+        subprocess.run(cmd, check=True, timeout=TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        print(
+            "Command timed out after "
+            f"{TIMEOUT_SECONDS}s: {' '.join(str(part) for part in cmd)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
 
 
 def resolve_cli_path(venv_path: Path, name: str) -> Path:

--- a/scripts/smoke_release_install.py
+++ b/scripts/smoke_release_install.py
@@ -1,0 +1,55 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python scripts/smoke_release_install.py <wheel-path>")
+
+    wheel_path = Path(sys.argv[1]).resolve()
+    if not wheel_path.is_file():
+        raise SystemExit(f"Wheel not found: {wheel_path}")
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise SystemExit("uv executable not found in PATH")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        venv_path = tmp_path / "venv"
+        python_path = (
+            venv_path / "Scripts" / "python.exe"
+            if sys.platform == "win32"
+            else venv_path / "bin" / "python"
+        )
+
+        run([uv, "venv", str(venv_path)])
+        run([uv, "pip", "install", "--python", str(python_path), str(wheel_path)])
+        run(
+            [
+                str(python_path),
+                "-c",
+                (
+                    "from agiwo.llm import OpenAIModel; "
+                    "from agiwo.tool.manager import ToolManager; "
+                    "model = OpenAIModel(name='gpt-5.4', api_key='test-key'); "
+                    "assert model.id == 'gpt-5.4'; "
+                    "assert model.name == 'gpt-5.4'; "
+                    "defaults = set(ToolManager().list_default_tool_names()); "
+                    "assert {'bash', 'bash_process', 'web_search', 'web_reader', 'memory_retrieval'} <= defaults; "
+                    "print('release smoke ok')"
+                ),
+            ]
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_release_install.py
+++ b/scripts/smoke_release_install.py
@@ -9,13 +9,27 @@ def run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        raise SystemExit("Usage: python scripts/smoke_release_install.py <wheel-path>")
+def resolve_cli_path(venv_path: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv_path / "Scripts" / f"{name}.exe"
+    return venv_path / "bin" / name
 
-    wheel_path = Path(sys.argv[1]).resolve()
-    if not wheel_path.is_file():
-        raise SystemExit(f"Wheel not found: {wheel_path}")
+
+def main() -> int:
+    if not (2 <= len(sys.argv) <= 3):
+        raise SystemExit(
+            "Usage: python scripts/smoke_release_install.py <agiwo-wheel-path> [agiwo-console-wheel-path]"
+        )
+
+    sdk_wheel_path = Path(sys.argv[1]).resolve()
+    if not sdk_wheel_path.is_file():
+        raise SystemExit(f"Wheel not found: {sdk_wheel_path}")
+
+    console_wheel_path: Path | None = None
+    if len(sys.argv) == 3:
+        console_wheel_path = Path(sys.argv[2]).resolve()
+        if not console_wheel_path.is_file():
+            raise SystemExit(f"Wheel not found: {console_wheel_path}")
 
     uv = shutil.which("uv")
     if uv is None:
@@ -24,14 +38,20 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         venv_path = tmp_path / "venv"
-        python_path = (
-            venv_path / "Scripts" / "python.exe"
-            if sys.platform == "win32"
-            else venv_path / "bin" / "python"
-        )
+        python_path = resolve_cli_path(venv_path, "python")
 
         run([uv, "venv", str(venv_path)])
-        run([uv, "pip", "install", "--python", str(python_path), str(wheel_path)])
+        install_cmd = [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(python_path),
+            str(sdk_wheel_path),
+        ]
+        if console_wheel_path is not None:
+            install_cmd.append(str(console_wheel_path))
+        run(install_cmd)
         run(
             [
                 str(python_path),
@@ -48,6 +68,11 @@ def main() -> int:
                 ),
             ]
         )
+
+        if console_wheel_path is not None:
+            cli_path = resolve_cli_path(venv_path, "agiwo-console")
+            run([str(cli_path), "--help"])
+
     return 0
 
 

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -10,6 +10,25 @@ def mock_openai_client():
     return client
 
 
+@patch("agiwo.llm.openai.get_settings")
+def test_openai_model_name_only_defaults_id(mock_get_settings):
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+
+    model = OpenAIModel(name="gpt-5.4", api_key="test-key")
+
+    assert model.id == "gpt-5.4"
+    assert model.name == "gpt-5.4"
+
+
+def test_openai_model_requires_name_or_id():
+    with pytest.raises(
+        TypeError,
+        match="OpenAIModel requires at least one of id or name",
+    ):
+        OpenAIModel()
+
+
 @pytest.mark.asyncio
 @patch("agiwo.llm.openai.get_settings")
 async def test_openai_model_arun_stream_basic(mock_get_settings, mock_openai_client):

--- a/tests/scripts/test_check_release_metadata.py
+++ b/tests/scripts/test_check_release_metadata.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.check_release_metadata import (
+    expected_console_dependency,
+    validate_release_metadata,
+)
+
+
+ROOT_PYPROJECT = Path("pyproject.toml")
+CONSOLE_PYPROJECT = Path("console/pyproject.toml")
+
+
+def test_expected_console_dependency_uses_major_minor_release_line() -> None:
+    assert expected_console_dependency("0.1.0") == "agiwo ~= 0.1.0"
+    assert expected_console_dependency("0.1.7") == "agiwo ~= 0.1.0"
+    assert expected_console_dependency("1.4.2") == "agiwo ~= 1.4.0"
+
+
+def test_validate_release_metadata_accepts_current_release_surface() -> None:
+    validate_release_metadata(
+        release_version="0.1.0",
+        root_pyproject_path=ROOT_PYPROJECT,
+        console_pyproject_path=CONSOLE_PYPROJECT,
+    )
+
+
+def test_validate_release_metadata_rejects_root_version_mismatch(
+    tmp_path: Path,
+) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        "[project]\nname = 'agiwo'\nversion = '0.1.1'\n",
+        encoding="utf-8",
+    )
+
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    console_pyproject = console_dir / "pyproject.toml"
+    console_pyproject.write_text(
+        "[project]\nname = 'agiwo-console'\nversion = '0.1.0'\n"
+        "dependencies = ['agiwo ~= 0.1.0']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="Root package version mismatch"):
+        validate_release_metadata(
+            release_version="0.1.0",
+            root_pyproject_path=root_pyproject,
+            console_pyproject_path=console_pyproject,
+        )
+
+
+def test_validate_release_metadata_rejects_console_dependency_drift(
+    tmp_path: Path,
+) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        "[project]\nname = 'agiwo'\nversion = '0.2.1'\n",
+        encoding="utf-8",
+    )
+
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    console_pyproject = console_dir / "pyproject.toml"
+    console_pyproject.write_text(
+        "[project]\nname = 'agiwo-console'\nversion = '0.2.1'\n"
+        "dependencies = ['agiwo ~= 0.1.0']\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="Console dependency mismatch"):
+        validate_release_metadata(
+            release_version="0.2.1",
+            root_pyproject_path=root_pyproject,
+            console_pyproject_path=console_pyproject,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -13,10 +13,18 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiosqlite" },
+    { name = "anthropic" },
+    { name = "boto3" },
     { name = "browser-control-and-automation-cli" },
+    { name = "bs4" },
+    { name = "curl-cffi" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
+    { name = "lark-oapi" },
+    { name = "motor" },
     { name = "openai" },
+    { name = "opentelemetry-distro" },
+    { name = "opentelemetry-exporter-otlp" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -25,57 +33,17 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tiktoken" },
+    { name = "trafilatura" },
 ]
 
 [package.optional-dependencies]
-all = [
-    { name = "anthropic" },
-    { name = "boto3" },
-    { name = "bs4" },
-    { name = "curl-cffi" },
-    { name = "lark-oapi" },
-    { name = "motor" },
-    { name = "opentelemetry-distro" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "trafilatura" },
-]
-anthropic = [
-    { name = "anthropic" },
-]
-bedrock = [
-    { name = "boto3" },
-]
 dev = [
-    { name = "anthropic" },
-    { name = "boto3" },
-    { name = "bs4" },
-    { name = "curl-cffi" },
     { name = "httpx" },
     { name = "import-linter" },
-    { name = "lark-oapi" },
-    { name = "motor" },
-    { name = "opentelemetry-distro" },
-    { name = "opentelemetry-exporter-otlp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "ruff" },
-    { name = "trafilatura" },
-]
-feishu = [
-    { name = "lark-oapi" },
-]
-mongo = [
-    { name = "motor" },
-]
-observability = [
-    { name = "opentelemetry-distro" },
-    { name = "opentelemetry-exporter-otlp" },
-]
-web = [
-    { name = "bs4" },
-    { name = "curl-cffi" },
-    { name = "trafilatura" },
 ]
 
 [package.dev-dependencies]
@@ -85,24 +53,22 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agiwo", extras = ["all"], marker = "extra == 'dev'" },
-    { name = "agiwo", extras = ["anthropic", "bedrock", "web", "feishu", "mongo", "observability"], marker = "extra == 'all'" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.34.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.59" },
+    { name = "anthropic", specifier = ">=0.34.0" },
+    { name = "boto3", specifier = ">=1.42.59" },
     { name = "browser-control-and-automation-cli", specifier = ">=0.1.3" },
-    { name = "bs4", marker = "extra == 'web'", specifier = ">=0.0.2" },
-    { name = "curl-cffi", marker = "extra == 'web'", specifier = ">=0.14.0" },
+    { name = "bs4", specifier = ">=0.0.2" },
+    { name = "curl-cffi", specifier = ">=0.14.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3" },
-    { name = "motor", marker = "extra == 'mongo'", specifier = ">=3.7.1" },
+    { name = "lark-oapi", specifier = ">=1.5.3" },
+    { name = "motor", specifier = ">=3.7.1" },
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "opentelemetry-distro", marker = "extra == 'observability'", specifier = ">=0.60b1" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'observability'", specifier = ">=1.39.1" },
+    { name = "opentelemetry-distro", specifier = ">=0.60b1" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -115,9 +81,9 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
-    { name = "trafilatura", marker = "extra == 'web'", specifier = ">=2.0.0" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
 ]
-provides-extras = ["anthropic", "bedrock", "web", "feishu", "mongo", "observability", "all", "dev"]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "agiwo", extras = ["dev"] }]


### PR DESCRIPTION
## Summary
- prepare the 0.1.0 publish surface for `agiwo` and `agiwo-console`
- make `agiwo` install with the full runtime dependency set by default
- support `OpenAIModel(name="gpt-5.4")` as the public ergonomic constructor
- align README/docs/examples/changelog with the released behavior and lower Console positioning
- add release gates for package build, fresh-install smoke, and `console/web` verification
- add the packaged `agiwo-console serve` entrypoint and document it as the startup path

## Verification
- `uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 agiwo/ console/server/ tests/ console/tests/ scripts/`
- `uv run ruff format --check agiwo/ console/server/ tests/ console/tests/ scripts/`
- `uv run python scripts/lint.py imports`
- `uv run python scripts/repo_guard.py`
- `uv run pytest tests/ -q`
- `cd console && uv run pytest tests/ -q`
- `cd console/web && npm run lint`
- `cd console/web && npm test`
- `cd console/web && npm run build`
- `uv build`
- `cd console && uv build`
- `uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl`
- `uv run python scripts/smoke_release_install.py dist/agiwo-0.1.0-py3-none-any.whl console/dist/agiwo_console-0.1.0-py3-none-any.whl`
- `cd console && uv run pytest tests/test_cli.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packaged console CLI: installable agiwo-console with a serve command (host/port/env/reload).

* **Changes**
  * Console repositioned as an optional, self-hosted control plane and marked not production-ready.
  * OpenAIModel can be constructed with name-only (e.g., OpenAIModel(name="gpt-5.4")).
  * Core SDK now installs major providers by default.

* **Documentation**
  * Updated README, guides, examples, and console docs to reflect install, CLI, and model changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->