### PR TITLE
ci: derive release versions from github tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Apply release metadata from tag
+        run: uv run python scripts/check_release_metadata.py --apply "${{ needs.prepare.outputs.release_version }}"
+
       - name: Install dependencies
         run: uv sync
-
-      - name: Validate release metadata
-        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
 
       - name: Build SDK package
         run: uv build
@@ -99,14 +99,14 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Apply release metadata from tag
+        run: uv run python scripts/check_release_metadata.py --apply "${{ needs.prepare.outputs.release_version }}"
+
       - name: Install SDK dependencies
         run: uv sync
 
       - name: Install Console dependencies
         run: (cd console && uv sync)
-
-      - name: Validate release metadata
-        run: uv run python scripts/check_release_metadata.py "${{ needs.prepare.outputs.release_version }}"
 
       - name: Build SDK package
         run: uv build

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,13 +26,13 @@ Do not publish releases with bare tags like `0.1.0`.
 ## Publish Flow
 
 1. Merge the release-ready changes into `main`.
-2. Confirm the root `pyproject.toml` version matches the intended release version.
-3. Confirm `console/pyproject.toml` uses the same version and still depends on the matching `agiwo` release line.
-4. Create a GitHub Release with tag `vX.Y.Z`.
-5. Publish the release.
-6. Open the `Release Publish` workflow in GitHub Actions and confirm all jobs succeed.
+2. Create a GitHub Release with tag `vX.Y.Z`.
+3. Publish the release.
+4. Open the `Release Publish` workflow in GitHub Actions and confirm all jobs succeed.
 
-The workflow will normalize the `v` tag, validate package metadata, build both packages, run the release smoke checks, publish `agiwo`, and then publish `agiwo-console`.
+The GitHub Release tag is the single version source for package publishing. The workflow normalizes the `v` tag, rewrites the package metadata in CI to match the release version, builds both packages, runs the release smoke checks, publishes `agiwo`, and then publishes `agiwo-console`.
+
+You do not need to manually edit the package version in `pyproject.toml` or `console/pyproject.toml` before creating the release.
 
 ## Failure Handling
 

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,6 +1,10 @@
+import re
 import sys
 import tomllib
 from pathlib import Path
+
+VERSION_PATTERN = re.compile(r"^(version\s*=\s*)(['\"])([^'\"]+)(['\"])$", re.MULTILINE)
+CONSOLE_DEP_PATTERN = re.compile(r"agiwo\s*~=\s*\d+\.\d+\.\d+")
 
 
 def load_project(pyproject_path: Path) -> dict[str, object]:
@@ -12,14 +16,72 @@ def load_project(pyproject_path: Path) -> dict[str, object]:
     return project
 
 
-def expected_console_dependency(release_version: str) -> str:
+def parse_release_version(release_version: str) -> tuple[str, str, str]:
     parts = release_version.split(".")
     if len(parts) != 3 or any(not part.isdigit() for part in parts):
         raise SystemExit(
             f"Release version must be in the form X.Y.Z, got: {release_version}"
         )
-    major, minor, _patch = parts
+    return parts[0], parts[1], parts[2]
+
+
+def expected_console_dependency(release_version: str) -> str:
+    major, minor, _patch = parse_release_version(release_version)
     return f"agiwo ~= {major}.{minor}.0"
+
+
+def replace_single_pattern(
+    *,
+    content: str,
+    pattern: re.Pattern[str],
+    replacement: str | re.Match[str] | object,
+    path: Path,
+    error_label: str,
+) -> str:
+    updated_content, replacements = pattern.subn(replacement, content, count=1)
+    if replacements != 1:
+        raise SystemExit(f"Could not update {error_label} in {path}")
+    return updated_content
+
+
+def update_project_version(pyproject_path: Path, release_version: str) -> None:
+    content = pyproject_path.read_text(encoding="utf-8")
+    updated_content = replace_single_pattern(
+        content=content,
+        pattern=VERSION_PATTERN,
+        replacement=lambda match: (
+            f"{match.group(1)}{match.group(2)}{release_version}{match.group(4)}"
+        ),
+        path=pyproject_path,
+        error_label="project version",
+    )
+    pyproject_path.write_text(updated_content, encoding="utf-8")
+
+
+def update_console_dependency(
+    console_pyproject_path: Path, release_version: str
+) -> None:
+    content = console_pyproject_path.read_text(encoding="utf-8")
+    updated_content = replace_single_pattern(
+        content=content,
+        pattern=CONSOLE_DEP_PATTERN,
+        replacement=expected_console_dependency(release_version),
+        path=console_pyproject_path,
+        error_label="console agiwo dependency",
+    )
+    console_pyproject_path.write_text(updated_content, encoding="utf-8")
+
+
+def apply_release_metadata(
+    *,
+    release_version: str,
+    root_pyproject_path: Path,
+    console_pyproject_path: Path,
+) -> None:
+    parse_release_version(release_version)
+    update_project_version(root_pyproject_path, release_version)
+    update_project_version(console_pyproject_path, release_version)
+    update_console_dependency(console_pyproject_path, release_version)
 
 
 def validate_release_metadata(
@@ -58,17 +120,35 @@ def validate_release_metadata(
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
+    apply_changes = False
+    if args and args[0] == "--apply":
+        apply_changes = True
+        args = args[1:]
+
     if len(args) != 1:
         raise SystemExit(
-            "Usage: python scripts/check_release_metadata.py <release-version>"
+            "Usage: python scripts/check_release_metadata.py [--apply] <release-version>"
+        )
+
+    release_version = args[0]
+    root_pyproject_path = Path("pyproject.toml")
+    console_pyproject_path = Path("console/pyproject.toml")
+
+    if apply_changes:
+        apply_release_metadata(
+            release_version=release_version,
+            root_pyproject_path=root_pyproject_path,
+            console_pyproject_path=console_pyproject_path,
         )
 
     validate_release_metadata(
-        release_version=args[0],
-        root_pyproject_path=Path("pyproject.toml"),
-        console_pyproject_path=Path("console/pyproject.toml"),
+        release_version=release_version,
+        root_pyproject_path=root_pyproject_path,
+        console_pyproject_path=console_pyproject_path,
     )
-    print(f"release metadata ok: {args[0]}")
+
+    action = "applied and validated" if apply_changes else "validated"
+    print(f"release metadata {action}: {release_version}")
     return 0
 
 

--- a/tests/scripts/test_check_release_metadata.py
+++ b/tests/scripts/test_check_release_metadata.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from scripts.check_release_metadata import (
+    apply_release_metadata,
     expected_console_dependency,
     validate_release_metadata,
 )
@@ -10,6 +11,27 @@ from scripts.check_release_metadata import (
 
 ROOT_PYPROJECT = Path("pyproject.toml")
 CONSOLE_PYPROJECT = Path("console/pyproject.toml")
+
+
+def write_release_fixture(
+    *,
+    root_pyproject: Path,
+    console_pyproject: Path,
+    root_version: str,
+    console_version: str,
+    console_dependency: str,
+) -> None:
+    root_pyproject.write_text(
+        f"[project]\nname = 'agiwo'\nversion = '{root_version}'\n",
+        encoding="utf-8",
+    )
+    console_pyproject.write_text(
+        "[project]\n"
+        "name = 'agiwo-console'\n"
+        f"version = '{console_version}'\n"
+        f"dependencies = ['{console_dependency}']\n",
+        encoding="utf-8",
+    )
 
 
 def test_expected_console_dependency_uses_major_minor_release_line() -> None:
@@ -26,22 +48,45 @@ def test_validate_release_metadata_accepts_current_release_surface() -> None:
     )
 
 
+def test_apply_release_metadata_updates_versions_and_dependency(tmp_path: Path) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    console_dir = tmp_path / "console"
+    console_dir.mkdir()
+    console_pyproject = console_dir / "pyproject.toml"
+    write_release_fixture(
+        root_pyproject=root_pyproject,
+        console_pyproject=console_pyproject,
+        root_version="0.1.0",
+        console_version="0.1.0",
+        console_dependency="agiwo ~= 0.1.0",
+    )
+
+    apply_release_metadata(
+        release_version="0.0.1",
+        root_pyproject_path=root_pyproject,
+        console_pyproject_path=console_pyproject,
+    )
+
+    validate_release_metadata(
+        release_version="0.0.1",
+        root_pyproject_path=root_pyproject,
+        console_pyproject_path=console_pyproject,
+    )
+
+
 def test_validate_release_metadata_rejects_root_version_mismatch(
     tmp_path: Path,
 ) -> None:
     root_pyproject = tmp_path / "pyproject.toml"
-    root_pyproject.write_text(
-        "[project]\nname = 'agiwo'\nversion = '0.1.1'\n",
-        encoding="utf-8",
-    )
-
     console_dir = tmp_path / "console"
     console_dir.mkdir()
     console_pyproject = console_dir / "pyproject.toml"
-    console_pyproject.write_text(
-        "[project]\nname = 'agiwo-console'\nversion = '0.1.0'\n"
-        "dependencies = ['agiwo ~= 0.1.0']\n",
-        encoding="utf-8",
+    write_release_fixture(
+        root_pyproject=root_pyproject,
+        console_pyproject=console_pyproject,
+        root_version="0.1.1",
+        console_version="0.1.0",
+        console_dependency="agiwo ~= 0.1.0",
     )
 
     with pytest.raises(SystemExit, match="Root package version mismatch"):
@@ -56,18 +101,15 @@ def test_validate_release_metadata_rejects_console_dependency_drift(
     tmp_path: Path,
 ) -> None:
     root_pyproject = tmp_path / "pyproject.toml"
-    root_pyproject.write_text(
-        "[project]\nname = 'agiwo'\nversion = '0.2.1'\n",
-        encoding="utf-8",
-    )
-
     console_dir = tmp_path / "console"
     console_dir.mkdir()
     console_pyproject = console_dir / "pyproject.toml"
-    console_pyproject.write_text(
-        "[project]\nname = 'agiwo-console'\nversion = '0.2.1'\n"
-        "dependencies = ['agiwo ~= 0.1.0']\n",
-        encoding="utf-8",
+    write_release_fixture(
+        root_pyproject=root_pyproject,
+        console_pyproject=console_pyproject,
+        root_version="0.2.1",
+        console_version="0.2.1",
+        console_dependency="agiwo ~= 0.1.0",
     )
 
     with pytest.raises(SystemExit, match="Console dependency mismatch"):


### PR DESCRIPTION
## Summary
- make the GitHub Release tag the single version source for package publishing
- apply the release version to both pyproject files in CI before build/publish
- document that maintainers no longer need to hand-edit package versions before creating a release

## Testing
- uv run pytest tests/scripts/test_check_release_metadata.py -v
- uv run python scripts/check_release_metadata.py --apply 0.1.0
- uv run ruff check --ignore C901 --ignore PLR0911 --ignore PLR0912 scripts/check_release_metadata.py tests/scripts/test_check_release_metadata.py
- uv run ruff format --check scripts/check_release_metadata.py tests/scripts/test_check_release_metadata.py
