### PR TITLE
feat: add dynamic skill discovery

### DIFF
--- a/agiwo/config/settings.py
+++ b/agiwo/config/settings.py
@@ -240,6 +240,19 @@ class AgiwoSettings(BaseSettings):
         default_factory=lambda: ["examples/skills", "skills"],
         description="Skill directories to scan (relative to root_path if not absolute)",
     )
+    default_prompt_skills: list[str] = Field(
+        default_factory=list,
+        description="Explicit skill names rendered into the agent system prompt",
+    )
+    skill_search_enabled: bool = Field(
+        default=True,
+        description="Whether runtime skill recommendation is enabled",
+    )
+    skill_search_top_k: int = Field(
+        default=6,
+        ge=1,
+        description="How many skill metadata candidates to send to the search judge",
+    )
 
     # === Scheduler ===
     event_debounce_min_count: int = Field(

--- a/agiwo/skill/__init__.py
+++ b/agiwo/skill/__init__.py
@@ -27,6 +27,11 @@ from agiwo.skill.prompt_catalog import (
 )
 from agiwo.skill.skill_tool import SkillTool
 from agiwo.skill.registry import SkillMetadata, SkillRegistry
+from agiwo.skill.search import (
+    SkillSearchCandidate,
+    SkillSearchRecommendation,
+    SkillSearchService,
+)
 
 
 __all__ = [
@@ -49,4 +54,7 @@ __all__ = [
     "validate_expanded_allowed_skills",
     "SkillPromptCatalog",
     "SkillPromptProvider",
+    "SkillSearchCandidate",
+    "SkillSearchRecommendation",
+    "SkillSearchService",
 ]

--- a/agiwo/skill/manager.py
+++ b/agiwo/skill/manager.py
@@ -20,6 +20,7 @@ from agiwo.skill.config import SkillDiscoveryConfig, resolve_skill_dirs
 from agiwo.skill.loader import SkillLoader
 from agiwo.skill.prompt_catalog import SkillPromptCatalog
 from agiwo.skill.registry import SkillMetadata, SkillRegistry
+from agiwo.skill.search import SkillSearchRecommendation, SkillSearchService
 from agiwo.skill.skill_tool import SkillTool
 from agiwo.utils.logging import get_logger
 
@@ -87,6 +88,7 @@ class SkillManager:
         self.loader = SkillLoader(self.registry)
         self._prompt_catalog = SkillPromptCatalog()
         self._skill_tool: SkillTool | None = None
+        self._search_service: SkillSearchService | None = None
         self._metadata_cache: list[SkillMetadata] = []
         self._change_token = ""
         self._initialized = False
@@ -105,6 +107,7 @@ class SkillManager:
             return
         skills_dirs = self.get_resolved_skills_dirs()
         self._metadata_cache = self.registry.discover_skills_sync(skills_dirs)
+        self._resolve_default_prompt_skill_names()
         self._change_token = self._prompt_catalog.compute_change_token(skills_dirs)
         self._initialized = True
         logger.info("skill_manager_initialized", skill_count=len(self._metadata_cache))
@@ -117,23 +120,68 @@ class SkillManager:
             registry=self.registry,
             loader=self.loader,
             allowed_skills=allowed_skills,
+            search_service=self._get_search_service(),
         )
+
+    def _resolve_default_prompt_skill_names(self) -> list[str]:
+        runtime_settings = get_settings()
+        return self.validate_explicit_allowed_skills(
+            runtime_settings.default_prompt_skills,
+            available_skill_names=self.list_available_skill_names(),
+        ) or []
+
+    def _select_prompt_metadata(
+        self,
+        allowed_skills: list[str] | None = None,
+    ) -> list[SkillMetadata]:
+        default_names = set(self._resolve_default_prompt_skill_names())
+        items = [item for item in self._metadata_cache if item.name in default_names]
+        if allowed_skills is None:
+            return items
+        allowed_set = set(allowed_skills)
+        return [item for item in items if item.name in allowed_set]
 
     def render_skills_section(
         self,
         allowed_skills: list[str] | None = None,
     ) -> str:
-        items = self._metadata_cache
-        if allowed_skills is not None:
-            allowed_set = set(allowed_skills)
-            items = [item for item in items if item.name in allowed_set]
-        return self._prompt_catalog.render_section(items)
+        return self._prompt_catalog.render_section(
+            self._select_prompt_metadata(allowed_skills)
+        )
 
     def list_available_skills(self) -> list[SkillMetadata]:
         return list(self._metadata_cache)
 
     def list_available_skill_names(self) -> list[str]:
         return [item.name for item in self._metadata_cache]
+
+    def _get_search_service(self) -> SkillSearchService:
+        if self._search_service is None:
+            self._search_service = SkillSearchService()
+        return self._search_service
+
+    async def search_skills(
+        self,
+        *,
+        query: str,
+        allowed_skills: list[str] | None,
+    ) -> SkillSearchRecommendation:
+        self.initialize_sync()
+        runtime_settings = get_settings()
+        if not runtime_settings.skill_search_enabled:
+            return SkillSearchRecommendation(decision="no_recommendation")
+
+        metadata_items = self._metadata_cache
+        if allowed_skills is not None:
+            allowed_set = set(allowed_skills)
+            metadata_items = [
+                item for item in metadata_items if item.name in allowed_set
+            ]
+
+        return await self._get_search_service().search(
+            query=query,
+            metadata_items=metadata_items,
+        )
 
     def expand_allowed_skills(
         self,
@@ -174,6 +222,7 @@ class SkillManager:
         """
         skills_dirs = self.get_resolved_skills_dirs()
         self._metadata_cache = await self.registry.discover_skills(skills_dirs)
+        self._resolve_default_prompt_skill_names()
         self._change_token = self._prompt_catalog.compute_change_token(skills_dirs)
         self._initialized = True
         logger.info("skills_reloaded", skill_count=len(self._metadata_cache))

--- a/agiwo/skill/manager.py
+++ b/agiwo/skill/manager.py
@@ -125,10 +125,13 @@ class SkillManager:
 
     def _resolve_default_prompt_skill_names(self) -> list[str]:
         runtime_settings = get_settings()
-        return self.validate_explicit_allowed_skills(
-            runtime_settings.default_prompt_skills,
-            available_skill_names=self.list_available_skill_names(),
-        ) or []
+        return (
+            self.validate_explicit_allowed_skills(
+                runtime_settings.default_prompt_skills,
+                available_skill_names=self.list_available_skill_names(),
+            )
+            or []
+        )
 
     def _select_prompt_metadata(
         self,

--- a/agiwo/skill/manager.py
+++ b/agiwo/skill/manager.py
@@ -125,13 +125,13 @@ class SkillManager:
 
     def _resolve_default_prompt_skill_names(self) -> list[str]:
         runtime_settings = get_settings()
-        return (
-            self.validate_explicit_allowed_skills(
-                runtime_settings.default_prompt_skills,
-                available_skill_names=self.list_available_skill_names(),
-            )
-            or []
+        normalized = normalize_allowed_skills(runtime_settings.default_prompt_skills)
+        validate_expanded_allowed_skills(normalized)
+        validate_known_allowed_skills(
+            normalized,
+            self.list_available_skill_names(),
         )
+        return list(normalized) if normalized is not None else []
 
     def _select_prompt_metadata(
         self,

--- a/agiwo/skill/prompt_catalog.py
+++ b/agiwo/skill/prompt_catalog.py
@@ -19,14 +19,12 @@ class SkillPromptCatalog:
         if not metadata_items:
             return ""
 
-        lines = ["## Available Skills"]
-        lines.append("\n")
+        lines = ["## Skills", ""]
         lines.append(
-            "Skills are tools. Use them quietly. The user doesn't need to see the machinery."
+            "Skills are optional. Do not use one unless it is clearly helpful."
         )
         lines.append(
-            "These skills are discovered at startup. Each entry includes a name and description. "
-            "Use the Skill tool to activate it when needed."
+            "If you are unsure, call `skill.search` with the user's original request before activating any skill."
         )
         lines.append("")
         lines.append("<available_skills>")
@@ -34,26 +32,8 @@ class SkillPromptCatalog:
             lines.append("  <skill>")
             lines.append(f"    <name>{metadata.name}</name>")
             lines.append(f"    <description>{metadata.description}</description>")
-            lines.append(f"    <location>{metadata.path}</location>")
             lines.append("  </skill>")
         lines.append("</available_skills>")
-        lines.append("")
-        lines.append("### How to use skills:")
-        lines.append(
-            "1. When a user task matches a skill's description, use the Skill tool to activate it."
-        )
-        lines.append(
-            "2. After activation, follow the instructions in the skill's SKILL.md file."
-        )
-        lines.append(
-            "3. Load reference files (references/) only when needed for specific steps."
-        )
-        lines.append(
-            "4. Execute scripts (scripts/) only when the skill instructions require it."
-        )
-        lines.append(
-            "5. Use assets (assets/) as templates or resources, don't load their content."
-        )
         return "\n".join(lines)
 
     def compute_change_token(self, skills_dirs: list[Path]) -> str:

--- a/agiwo/skill/search.py
+++ b/agiwo/skill/search.py
@@ -140,7 +140,9 @@ class SkillSearchService:
 
         skill_name = payload.get("skill_name")
         if not isinstance(skill_name, str):
-            return SkillSearchRecommendation(decision="no_recommendation", reason=reason)
+            return SkillSearchRecommendation(
+                decision="no_recommendation", reason=reason
+            )
         if any(candidate.metadata.name == skill_name for candidate in candidates):
             return SkillSearchRecommendation(
                 decision="recommend",

--- a/agiwo/skill/search.py
+++ b/agiwo/skill/search.py
@@ -1,0 +1,187 @@
+"""Runtime skill recommendation based on metadata recall and LLM judgment."""
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from agiwo.config.settings import get_settings
+from agiwo.embedding import EmbeddingFactory
+from agiwo.embedding.base import EmbeddingModel
+from agiwo.llm import Model, ModelSpec, create_model
+from agiwo.skill.registry import SkillMetadata
+
+
+DEFAULT_NO_RECOMMENDATION_REASON = (
+    "No available skill is necessary or clearly matched for this request."
+)
+
+
+@dataclass(frozen=True)
+class SkillSearchRecommendation:
+    decision: Literal["recommend", "no_recommendation"]
+    skill_name: str | None = None
+    reason: str = DEFAULT_NO_RECOMMENDATION_REASON
+
+
+@dataclass(frozen=True)
+class SkillSearchCandidate:
+    metadata: SkillMetadata
+    score: float
+
+
+class SkillSearchService:
+    def __init__(
+        self,
+        *,
+        embedding_model: EmbeddingModel | None = None,
+        judge_model: Model | None = None,
+        top_k: int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._embedding_model = embedding_model
+        self._judge_model = judge_model
+        self._top_k = top_k or settings.skill_search_top_k
+
+    async def search(
+        self,
+        *,
+        query: str,
+        metadata_items: list[SkillMetadata],
+    ) -> SkillSearchRecommendation:
+        if not query.strip() or not metadata_items:
+            return SkillSearchRecommendation(decision="no_recommendation")
+
+        try:
+            candidates = await self._recall_top_k(
+                query=query,
+                metadata_items=metadata_items,
+            )
+        except Exception:  # noqa: BLE001 - search should degrade, not fail hard
+            return SkillSearchRecommendation(decision="no_recommendation")
+
+        if not candidates:
+            return SkillSearchRecommendation(decision="no_recommendation")
+
+        try:
+            return await self._judge_candidates(query=query, candidates=candidates)
+        except Exception:  # noqa: BLE001 - judge failures should downgrade safely
+            return SkillSearchRecommendation(decision="no_recommendation")
+
+    async def _recall_top_k(
+        self,
+        *,
+        query: str,
+        metadata_items: list[SkillMetadata],
+    ) -> list[SkillSearchCandidate]:
+        embedding_model = self._embedding_model or EmbeddingFactory.create()
+        if embedding_model is None:
+            raise RuntimeError("embedding unavailable")
+
+        corpus = [self._build_search_text(item) for item in metadata_items]
+        vectors = await embedding_model.embed([query, *corpus])
+        query_vector = vectors[0]
+        scored = [
+            SkillSearchCandidate(
+                metadata=item,
+                score=self._cosine_similarity(query_vector, vector),
+            )
+            for item, vector in zip(metadata_items, vectors[1:], strict=False)
+        ]
+        scored.sort(key=lambda candidate: candidate.score, reverse=True)
+        return scored[: self._top_k]
+
+    async def _judge_candidates(
+        self,
+        *,
+        query: str,
+        candidates: list[SkillSearchCandidate],
+    ) -> SkillSearchRecommendation:
+        model = self._judge_model or self._build_default_judge_model()
+        content_parts: list[str] = []
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You recommend at most one skill. Return JSON only with "
+                    '"decision", optional "skill_name", and "reason". Use '
+                    '"no_recommendation" if no skill should be used.'
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "query": query,
+                        "candidates": [
+                            {
+                                "name": candidate.metadata.name,
+                                "description": candidate.metadata.description,
+                                "metadata": candidate.metadata.metadata,
+                            }
+                            for candidate in candidates
+                        ],
+                    }
+                ),
+            },
+        ]
+        async for chunk in model.arun_stream(messages=messages, tools=None):
+            if chunk.content:
+                content_parts.append(chunk.content)
+
+        payload = json.loads("".join(content_parts))
+        decision = payload.get("decision")
+        reason = str(payload.get("reason", DEFAULT_NO_RECOMMENDATION_REASON))
+        if decision != "recommend":
+            return SkillSearchRecommendation(
+                decision="no_recommendation",
+                reason=reason,
+            )
+
+        skill_name = payload.get("skill_name")
+        if not isinstance(skill_name, str):
+            return SkillSearchRecommendation(decision="no_recommendation", reason=reason)
+        if any(candidate.metadata.name == skill_name for candidate in candidates):
+            return SkillSearchRecommendation(
+                decision="recommend",
+                skill_name=skill_name,
+                reason=reason,
+            )
+        return SkillSearchRecommendation(decision="no_recommendation", reason=reason)
+
+    def _build_default_judge_model(self) -> Model:
+        settings = get_settings()
+        return create_model(
+            ModelSpec(
+                provider=settings.tool_default_model_provider,
+                model_name=settings.get_tool_model_name(),
+                api_key_env_name=settings.get_tool_model_api_key_env_name(),
+                base_url=settings.tool_default_model_base_url,
+                temperature=0.0,
+                top_p=1.0,
+                max_output_tokens=256,
+            )
+        )
+
+    def _build_search_text(self, metadata: SkillMetadata) -> str:
+        parts = [metadata.name, metadata.description]
+        parts.extend(
+            f"{key}:{value}" for key, value in sorted(metadata.metadata.items())
+        )
+        return "\n".join(parts)
+
+    def _cosine_similarity(self, left: list[float], right: list[float]) -> float:
+        numerator = sum(a * b for a, b in zip(left, right, strict=False))
+        left_norm = math.sqrt(sum(value * value for value in left))
+        right_norm = math.sqrt(sum(value * value for value in right))
+        if left_norm == 0.0 or right_norm == 0.0:
+            return 0.0
+        return numerator / (left_norm * right_norm)
+
+
+__all__ = [
+    "DEFAULT_NO_RECOMMENDATION_REASON",
+    "SkillSearchCandidate",
+    "SkillSearchRecommendation",
+    "SkillSearchService",
+]

--- a/agiwo/skill/search.py
+++ b/agiwo/skill/search.py
@@ -8,7 +8,8 @@ from typing import Literal
 from agiwo.config.settings import get_settings
 from agiwo.embedding import EmbeddingFactory
 from agiwo.embedding.base import EmbeddingModel
-from agiwo.llm import Model, ModelSpec, create_model
+from agiwo.llm import Model, ModelSpec
+from agiwo.llm.factory import create_model
 from agiwo.skill.registry import SkillMetadata
 
 
@@ -41,7 +42,10 @@ class SkillSearchService:
         settings = get_settings()
         self._embedding_model = embedding_model
         self._judge_model = judge_model
-        self._top_k = top_k or settings.skill_search_top_k
+        resolved_top_k = settings.skill_search_top_k if top_k is None else int(top_k)
+        if resolved_top_k < 1:
+            raise ValueError("top_k must be at least 1")
+        self._top_k = resolved_top_k
 
     async def search(
         self,

--- a/agiwo/skill/skill_tool.py
+++ b/agiwo/skill/skill_tool.py
@@ -126,13 +126,13 @@ class SkillTool(BaseTool):
         if not get_settings().skill_search_enabled:
             recommendation = SkillSearchRecommendation(decision="no_recommendation")
         else:
-            recommendation = (
-                await self._search_service.search(
-                    query=query,
-                    metadata_items=self._searchable_metadata(),
+            if self._search_service is None:
+                raise RuntimeError(
+                    "skill search is enabled but SkillTool was created without a search_service"
                 )
-                if self._search_service is not None
-                else SkillSearchRecommendation(decision="no_recommendation")
+            recommendation = await self._search_service.search(
+                query=query,
+                metadata_items=self._searchable_metadata(),
             )
 
         payload = {

--- a/agiwo/skill/skill_tool.py
+++ b/agiwo/skill/skill_tool.py
@@ -231,8 +231,7 @@ class SkillTool(BaseTool):
 
     def _searchable_metadata(self) -> list[SkillMetadata]:
         metadata_items = [
-            self.registry.get_metadata(name)
-            for name in self.registry.list_available()
+            self.registry.get_metadata(name) for name in self.registry.list_available()
         ]
         filtered = [item for item in metadata_items if item is not None]
         if self._allowed_skills is None:

--- a/agiwo/skill/skill_tool.py
+++ b/agiwo/skill/skill_tool.py
@@ -5,12 +5,15 @@ This module provides a tool implementation that allows agents to activate
 skills by loading their complete SKILL.md content into the context.
 """
 
+import json
 import time
 from typing import Any
 
+from agiwo.config.settings import get_settings
 from agiwo.skill.exceptions import SkillNotFoundError
 from agiwo.skill.loader import SkillLoader
-from agiwo.skill.registry import SkillRegistry
+from agiwo.skill.registry import SkillMetadata, SkillRegistry
+from agiwo.skill.search import SkillSearchRecommendation, SkillSearchService
 from agiwo.tool.base import BaseTool, ToolResult
 from agiwo.tool.context import ToolContext
 from agiwo.utils.abort_signal import AbortSignal
@@ -34,19 +37,21 @@ class SkillTool(BaseTool):
         registry: SkillRegistry,
         loader: SkillLoader,
         allowed_skills: list[str] | None = None,
+        search_service: SkillSearchService | None = None,
     ) -> None:
         super().__init__()
         self.registry = registry
         self.loader = loader
+        self._search_service = search_service
         self._allowed_skills = (
             frozenset(allowed_skills) if allowed_skills is not None else None
         )
 
     name = "skill"
     description = (
-        "Activate an Agent Skill by loading its complete instructions. "
-        "Use this tool when a user task matches a skill's description or user explicitly requests a skill."
-        "After activation, follow the instructions in the skill's SKILL.md file."
+        "Search for a matching skill or activate a specific skill. "
+        "Use mode=search with the user's original request when you are unsure whether a skill is needed. "
+        "Use mode=activate only after you have chosen a specific skill."
     )
 
     def get_parameters(self) -> dict[str, Any]:
@@ -54,12 +59,21 @@ class SkillTool(BaseTool):
         return {
             "type": "object",
             "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["search", "activate"],
+                    "description": "Search for a recommended skill or activate one by name",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Original user request when mode=search",
+                },
                 "skill_name": {
                     "type": "string",
-                    "description": "Name of the skill to activate",
+                    "description": "Name of the skill to activate when mode=activate",
                 },
             },
-            "required": ["skill_name"],
+            "required": ["mode"],
         }
 
     async def execute(
@@ -81,6 +95,68 @@ class SkillTool(BaseTool):
             in 'content_for_user' field
         """
         start_time = time.time()
+        mode = parameters.get("mode")
+        if mode == "search":
+            return await self._execute_search(parameters, context, start_time)
+        if mode == "activate":
+            return await self._execute_activate(parameters, context, start_time)
+        return ToolResult.failed(
+            tool_name=self.name,
+            error=f"Invalid mode: {mode}",
+            tool_call_id=context.tool_call_id,
+            input_args=parameters,
+            start_time=start_time,
+        )
+
+    async def _execute_search(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+        start_time: float,
+    ) -> ToolResult:
+        query = parameters.get("query")
+        if not isinstance(query, str) or not query.strip():
+            return ToolResult.failed(
+                tool_name=self.name,
+                error="Missing required parameter: query",
+                tool_call_id=context.tool_call_id,
+                input_args=parameters,
+                start_time=start_time,
+            )
+        if not get_settings().skill_search_enabled:
+            recommendation = SkillSearchRecommendation(decision="no_recommendation")
+        else:
+            recommendation = (
+                await self._search_service.search(
+                    query=query,
+                    metadata_items=self._searchable_metadata(),
+                )
+                if self._search_service is not None
+                else SkillSearchRecommendation(decision="no_recommendation")
+            )
+
+        payload = {
+            "decision": recommendation.decision,
+            "skill_name": recommendation.skill_name,
+            "reason": recommendation.reason,
+        }
+
+        return ToolResult.success(
+            tool_name=self.name,
+            tool_call_id=context.tool_call_id,
+            input_args=parameters,
+            content=json.dumps(payload),
+            content_for_user="Skill search completed.",
+            output=payload,
+            start_time=start_time,
+        )
+
+    async def _execute_activate(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+        start_time: float,
+    ) -> ToolResult:
         skill_name = parameters.get("skill_name")
         error: str | None = None
 
@@ -152,3 +228,13 @@ class SkillTool(BaseTool):
                 input_args=parameters,
                 start_time=start_time,
             )
+
+    def _searchable_metadata(self) -> list[SkillMetadata]:
+        metadata_items = [
+            self.registry.get_metadata(name)
+            for name in self.registry.list_available()
+        ]
+        filtered = [item for item in metadata_items if item is not None]
+        if self._allowed_skills is None:
+            return filtered
+        return [item for item in filtered if item.name in self._allowed_skills]

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,91 +1,75 @@
 # Skills
 
-Skills are file-based instruction sets that extend an agent's capabilities. They're discovered from directories and loaded at runtime.
+Skills are file-based instruction sets that extend an agent's capabilities. Agiwo discovers them from configured directories, keeps their metadata in memory, and loads full `SKILL.md` content only when the agent explicitly activates a skill.
 
 ## How Skills Work
 
 A skill is a directory containing:
 
-```
+```text
 my_skill/
-├── SKILL.md          # Required: instructions for the agent
-├── script.py         # Optional: executable scripts
-├── reference.md      # Optional: reference documentation
-└── config.yaml       # Optional: skill configuration
+├── SKILL.md
+├── scripts/
+├── references/
+└── assets/
 ```
 
-The `SKILL.md` file is the core — its contents are injected into the agent's system prompt when the skill is active.
+`SKILL.md` is required. Its frontmatter provides the discovery metadata, and its body contains the instructions that are loaded when the skill is activated.
 
-## Skill Discovery
+## Prompt-Time Visibility
 
-Skills are discovered from configured directories:
+The agent system prompt no longer includes the full discovered skill catalog.
+
+Instead:
+
+1. `AGIWO_DEFAULT_PROMPT_SKILLS` controls the small subset rendered into the prompt
+2. that subset is still filtered by the agent's `allowed_skills`
+3. if skills are disabled with `allowed_skills=[]`, no skill section is rendered
+
+This keeps prompt size stable even when `skills_dirs` contains many skills.
+
+## Runtime Discovery
+
+Runtime discovery happens through the `skill` tool:
+
+- `mode="search"` recommends one skill or `no_recommendation`
+- `mode="activate"` loads the full `SKILL.md` body for a chosen skill
+
+The normal flow is:
+
+1. the model reads the user request
+2. if a skill might help, it calls `skill` with `mode="search"` and the original user request
+3. if search recommends a specific skill, the model calls `skill` again with `mode="activate"`
+4. if search returns `no_recommendation`, the model continues without a skill
+
+Discovery and activation both respect `allowed_skills`.
+
+## Skill Discovery Config
+
+Skills are discovered from the SDK-level `skills_dirs` setting:
 
 ```python
-from agiwo.skill import SkillManager, SkillConfig
+from agiwo.skill.config import SkillDiscoveryConfig
+from agiwo.skill.manager import SkillManager
 
-config = SkillConfig(
-    skill_dirs=["./skills", "~/.agiwo/skills"],
+config = SkillDiscoveryConfig(
+    skills_dirs=["skills", "~/.agiwo/skills"],
+    root_path=".agiwo",
 )
 
 manager = SkillManager(config)
-await manager.discover()
+await manager.initialize()
 
-# List available skills
-for skill in manager.list_skills():
-    print(f"{skill.name}: {skill.description}")
+for skill in manager.list_available_skills():
+    print(skill.name, skill.description)
 ```
 
-## Skill Loading
+Relevant SDK settings:
 
-Skills are loaded on demand when the agent decides to use them:
-
-```python
-# The agent's LLM sees available skills and can request one
-# SkillManager.load_skill() reads SKILL.md and returns the content
-# The content is injected into the system prompt
-```
-
-## Skill Configuration
-
-```python
-@dataclass
-class SkillConfig:
-    skill_dirs: list[str]           # Directories to scan for skills
-    auto_load: bool = False         # Auto-load all discovered skills
-    max_skill_tokens: int = 4096    # Max tokens per skill's SKILL.md
-```
-
-## Creating a Skill
-
-### Minimal skill
-
-```markdown
-<!-- skills/weather/SKILL.md -->
-# Weather Skill
-
-You can check the weather using the weather_check script.
-
-## Usage
-
-```bash
-python script.py --city "Beijing"
-```
-
-## Output Format
-
-Return temperature, condition, and humidity.
-```
-
-### With configuration
-
-```yaml
-# skills/my_skill/config.yaml
-name: my_skill
-version: "1.0"
-description: Does something useful
-dependencies:
-  - requests
-```
+- `AGIWO_SKILLS_DIRS`
+- `AGIWO_DEFAULT_PROMPT_SKILLS`
+- `AGIWO_SKILL_SEARCH_ENABLED`
+- `AGIWO_SKILL_SEARCH_TOP_K`
 
 ## Skill Tool
 
@@ -94,21 +78,28 @@ The `SkillTool` bridges skills to the agent runtime:
 ```python
 from agiwo.skill import SkillTool
 
-# Skills are registered as tools
-# The agent can invoke skill_tool(skill_name, action, params)
+# mode="search" => recommend a skill or no skill
+# mode="activate" => load the chosen SKILL.md body
 ```
 
-## Built-in Skills
+The tool never auto-activates a skill during search.
 
-Agiwo can load skills from:
-- Project-local `./skills/` directory
-- User-global `~/.agiwo/skills/` directory
-- Any directory specified in `SkillConfig.skill_dirs`
+## Creating A Skill
 
-## Best Practices
+Minimal example:
 
-1. **Keep SKILL.md focused** — Clear instructions, not essays
-2. **Use examples** — Show the agent how to use the skill
-3. **Include error handling** — What to do when things go wrong
-4. **Version your skills** — Use `config.yaml` to track versions
-5. **Test skills independently** — Scripts should work standalone before integrating
+```markdown
+---
+name: weather
+description: Check weather conditions and summarize results.
+---
+
+Use the weather helper script when the user asks for weather information.
+```
+
+Best practices:
+
+1. Keep `SKILL.md` focused and procedural.
+2. Put long reference material in `references/` instead of the main skill body.
+3. Keep scripts standalone so they can be run directly when the skill requires them.
+4. Make the frontmatter description concrete, because discovery depends on metadata quality.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -46,23 +46,28 @@ Discovery and activation both respect `allowed_skills`.
 
 ## Skill Discovery Config
 
-Skills are discovered from the SDK-level `skills_dirs` setting:
+Skills are discovered from the SDK-level `settings.skills_dirs` configuration, not from per-agent skill directory options:
 
 ```python
-from agiwo.skill.config import SkillDiscoveryConfig
-from agiwo.skill.manager import SkillManager
+from agiwo.config.settings import settings
+from agiwo.skill.manager import get_global_skill_manager
 
-config = SkillDiscoveryConfig(
-    skills_dirs=["skills", "~/.agiwo/skills"],
-    root_path=".agiwo",
-)
+print(settings.skills_dirs)
 
-manager = SkillManager(config)
+manager = get_global_skill_manager()
 await manager.initialize()
 
 for skill in manager.list_available_skills():
     print(skill.name, skill.description)
 ```
+
+For code references:
+
+- `settings.skills_dirs` is the SDK-level source of truth
+- `get_global_skill_manager()` is the normal runtime entrypoint
+- `SkillManager` and `SkillDiscoveryConfig` are internal building blocks for that flow
+
+Do not add per-agent skill directories or legacy `enable_skill` style toggles. Agent-level control should stay on `allowed_skills`.
 
 Relevant SDK settings:
 

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agiwo.agent.prompt import build_system_prompt
+from agiwo.workspace.documents import WorkspaceDocumentStore
+from agiwo.workspace.layout import build_agent_workspace
+
+
+class NoopBootstrapper:
+    async def ensure_prompt_ready(self, workspace) -> None:
+        workspace.workspace.mkdir(parents=True, exist_ok=True)
+        workspace.work_dir.mkdir(parents=True, exist_ok=True)
+        workspace.memory_dir.mkdir(parents=True, exist_ok=True)
+
+
+class StubSkillManager:
+    async def initialize(self) -> None:
+        return None
+
+    async def refresh_if_changed(self) -> None:
+        return None
+
+    def render_skills_section(self, allowed_skills=None) -> str:
+        assert allowed_skills == ["brainstorming"]
+        return (
+            "## Skills\n\n"
+            "If you are unsure, call `skill.search` with the user's original request before activating any skill.\n\n"
+            "<available_skills>\n"
+            "  <skill>\n"
+            "    <name>brainstorming</name>\n"
+            "    <description>Explore design before implementation.</description>\n"
+            "  </skill>\n"
+            "</available_skills>"
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_uses_reduced_skill_section(tmp_path: Path) -> None:
+    workspace = build_agent_workspace(root_path=tmp_path, agent_name="planner")
+
+    with patch(
+        "agiwo.agent.prompt.get_global_skill_manager",
+        return_value=StubSkillManager(),
+    ):
+        prompt = await build_system_prompt(
+            base_prompt="Base system prompt",
+            workspace=workspace,
+            tools=[],
+            allowed_skills=["brainstorming"],
+            bootstrapper=NoopBootstrapper(),
+            document_store=WorkspaceDocumentStore(),
+        )
+
+    assert "brainstorming" in prompt
+    assert "<location>" not in prompt
+    assert "skill.search" in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_skips_skill_section_when_disabled(
+    tmp_path: Path,
+) -> None:
+    workspace = build_agent_workspace(root_path=tmp_path, agent_name="planner")
+
+    prompt = await build_system_prompt(
+        base_prompt="Base system prompt",
+        workspace=workspace,
+        tools=[],
+        allowed_skills=[],
+        bootstrapper=NoopBootstrapper(),
+        document_store=WorkspaceDocumentStore(),
+    )
+
+    assert "## Skills" not in prompt

--- a/tests/config/test_settings_env.py
+++ b/tests/config/test_settings_env.py
@@ -67,3 +67,17 @@ def test_tool_model_name_allows_explicit_name_for_compatible_provider(
 
     assert settings.tool_default_model_provider == "openai-compatible"
     assert settings.get_tool_model_name() == "MiniMax-M2.5"
+
+
+def test_skill_search_settings_are_loaded(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "AGIWO_DEFAULT_PROMPT_SKILLS", '["brainstorming","writing-plans"]'
+    )
+    monkeypatch.setenv("AGIWO_SKILL_SEARCH_ENABLED", "false")
+    monkeypatch.setenv("AGIWO_SKILL_SEARCH_TOP_K", "4")
+
+    settings = load_settings(include_env_file=False)
+
+    assert settings.default_prompt_skills == ["brainstorming", "writing-plans"]
+    assert settings.skill_search_enabled is False
+    assert settings.skill_search_top_k == 4

--- a/tests/skill/test_manager.py
+++ b/tests/skill/test_manager.py
@@ -67,9 +67,17 @@ async def test_search_skills_applies_allowed_skill_filter() -> None:
 
     manager._search_service = StubSearchService()
 
-    result = await manager.search_skills(
-        query="help me plan",
-        allowed_skills=["brainstorming"],
+    fake_settings = SimpleNamespace(
+        default_prompt_skills=[],
+        skill_search_enabled=True,
+        skill_search_top_k=6,
+        root_path="/tmp",
+        skills_dirs=[],
     )
+    with patch("agiwo.skill.manager.get_settings", return_value=fake_settings):
+        result = await manager.search_skills(
+            query="help me plan",
+            allowed_skills=["brainstorming"],
+        )
 
     assert result.skill_name == "brainstorming"

--- a/tests/skill/test_manager.py
+++ b/tests/skill/test_manager.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agiwo.skill.config import SkillDiscoveryConfig
+from agiwo.skill.manager import SkillManager
+from agiwo.skill.registry import SkillMetadata
+
+
+def _meta(name: str, description: str) -> SkillMetadata:
+    path = Path(f"/tmp/{name}/SKILL.md")
+    return SkillMetadata(
+        name=name,
+        description=description,
+        path=path,
+        base_dir=path.parent,
+    )
+
+
+def test_render_skills_section_uses_only_default_prompt_skills() -> None:
+    manager = SkillManager(SkillDiscoveryConfig(skills_dirs=[], root_path="/tmp"))
+    manager._metadata_cache = [
+        _meta("brainstorming", "Explore design before implementation."),
+        _meta("writing-plans", "Write implementation plans."),
+        _meta("imagegen", "Generate raster images."),
+    ]
+    manager._initialized = True
+
+    fake_settings = SimpleNamespace(
+        default_prompt_skills=["brainstorming", "writing-plans"],
+        skill_search_enabled=True,
+        skill_search_top_k=6,
+        root_path="/tmp",
+        skills_dirs=[],
+    )
+
+    with patch("agiwo.skill.manager.get_settings", return_value=fake_settings):
+        rendered = manager.render_skills_section(allowed_skills=["brainstorming"])
+
+    assert "brainstorming" in rendered
+    assert "writing-plans" not in rendered
+    assert "imagegen" not in rendered
+    assert "skill.search" in rendered
+    assert "<location>" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_search_skills_applies_allowed_skill_filter() -> None:
+    manager = SkillManager(SkillDiscoveryConfig(skills_dirs=[], root_path="/tmp"))
+    manager._metadata_cache = [
+        _meta("brainstorming", "Explore design before implementation."),
+        _meta("writing-plans", "Write implementation plans."),
+    ]
+    manager._initialized = True
+
+    class StubSearchService:
+        async def search(self, *, query: str, metadata_items: list[SkillMetadata]):
+            assert query == "help me plan"
+            assert [item.name for item in metadata_items] == ["brainstorming"]
+            return SimpleNamespace(
+                decision="recommend",
+                skill_name="brainstorming",
+                reason="design task",
+            )
+
+    manager._search_service = StubSearchService()
+
+    result = await manager.search_skills(
+        query="help me plan",
+        allowed_skills=["brainstorming"],
+    )
+
+    assert result.skill_name == "brainstorming"

--- a/tests/skill/test_search.py
+++ b/tests/skill/test_search.py
@@ -88,7 +88,9 @@ async def test_search_downgrades_to_no_recommendation_when_embedding_fails() -> 
 
     result = await service.search(
         query="help me design this change",
-        metadata_items=[_meta("brainstorming", "Explore design before implementation.")],
+        metadata_items=[
+            _meta("brainstorming", "Explore design before implementation.")
+        ],
     )
 
     assert result.decision == "no_recommendation"

--- a/tests/skill/test_search.py
+++ b/tests/skill/test_search.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+
+from agiwo.embedding.base import EmbeddingError, EmbeddingModel
+from agiwo.llm.base import Model, StreamChunk
+from agiwo.skill.registry import SkillMetadata
+from agiwo.skill.search import SkillSearchRecommendation, SkillSearchService
+
+
+def _meta(name: str, description: str) -> SkillMetadata:
+    path = Path(f"/tmp/{name}/SKILL.md")
+    return SkillMetadata(
+        name=name,
+        description=description,
+        path=path,
+        base_dir=path.parent,
+    )
+
+
+class StubEmbedding(EmbeddingModel):
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        super().__init__(id="stub", name="stub", dimensions=3)
+        self.mapping = mapping
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [self.mapping[text] for text in texts]
+
+
+class FailingEmbedding(EmbeddingModel):
+    def __init__(self) -> None:
+        super().__init__(id="stub", name="stub", dimensions=3)
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        raise EmbeddingError("boom")
+
+
+class StubJudgeModel(Model):
+    def __init__(self, payload: str) -> None:
+        super().__init__(id="judge", name="judge", provider="openai")
+        self.payload = payload
+
+    async def arun_stream(self, messages, tools=None):
+        del messages, tools
+        yield StreamChunk(content=self.payload)
+
+
+@pytest.mark.asyncio
+async def test_search_returns_specific_skill_from_top_k() -> None:
+    service = SkillSearchService(
+        embedding_model=StubEmbedding(
+            {
+                "help me design this change": [1.0, 0.0, 0.0],
+                "brainstorming\nExplore design before implementation.": [0.9, 0.0, 0.0],
+                "writing-plans\nWrite implementation plans.": [0.5, 0.0, 0.0],
+            }
+        ),
+        judge_model=StubJudgeModel(
+            '{"decision":"recommend","skill_name":"brainstorming","reason":"design task"}'
+        ),
+        top_k=2,
+    )
+
+    result = await service.search(
+        query="help me design this change",
+        metadata_items=[
+            _meta("brainstorming", "Explore design before implementation."),
+            _meta("writing-plans", "Write implementation plans."),
+        ],
+    )
+
+    assert result == SkillSearchRecommendation(
+        decision="recommend",
+        skill_name="brainstorming",
+        reason="design task",
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_downgrades_to_no_recommendation_when_embedding_fails() -> None:
+    service = SkillSearchService(
+        embedding_model=FailingEmbedding(),
+        judge_model=StubJudgeModel(
+            '{"decision":"recommend","skill_name":"brainstorming","reason":"design task"}'
+        ),
+        top_k=2,
+    )
+
+    result = await service.search(
+        query="help me design this change",
+        metadata_items=[_meta("brainstorming", "Explore design before implementation.")],
+    )
+
+    assert result.decision == "no_recommendation"
+    assert result.skill_name is None

--- a/tests/skill/test_search.py
+++ b/tests/skill/test_search.py
@@ -45,6 +45,11 @@ class StubJudgeModel(Model):
         yield StreamChunk(content=self.payload)
 
 
+def test_search_service_rejects_non_positive_top_k() -> None:
+    with pytest.raises(ValueError, match="top_k must be at least 1"):
+        SkillSearchService(top_k=0)
+
+
 @pytest.mark.asyncio
 async def test_search_returns_specific_skill_from_top_k() -> None:
     service = SkillSearchService(

--- a/tests/skill/test_skill_tool.py
+++ b/tests/skill/test_skill_tool.py
@@ -102,6 +102,39 @@ async def test_skill_tool_search_respects_disabled_runtime_setting(
 
 
 @pytest.mark.asyncio
+async def test_skill_tool_search_requires_search_service_when_enabled(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "brainstorming"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: brainstorming\ndescription: Explore design first.\n---\n\nUse this skill.",
+        encoding="utf-8",
+    )
+
+    registry = SkillRegistry()
+    registry.discover_skills_sync([tmp_path])
+    loader = SkillLoader(registry)
+    tool = SkillTool(
+        registry=registry,
+        loader=loader,
+        allowed_skills=["brainstorming"],
+    )
+
+    fake_settings = SimpleNamespace(skill_search_enabled=True)
+    with patch("agiwo.skill.skill_tool.get_settings", return_value=fake_settings):
+        with pytest.raises(
+            RuntimeError,
+            match="skill search is enabled but SkillTool was created without a search_service",
+        ):
+            await tool.execute(
+                {"mode": "search", "query": "help me explore this change"},
+                build_tool_context(),
+            )
+
+
+@pytest.mark.asyncio
 async def test_skill_tool_activate_keeps_existing_behavior(tmp_path: Path) -> None:
     skill_dir = tmp_path / "brainstorming"
     skill_dir.mkdir()

--- a/tests/skill/test_skill_tool.py
+++ b/tests/skill/test_skill_tool.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agiwo.skill.loader import SkillLoader
+from agiwo.skill.registry import SkillRegistry
+from agiwo.skill.search import SkillSearchRecommendation
+from agiwo.skill.skill_tool import SkillTool
+from tests.utils.agent_context import build_tool_context
+
+
+class StubSearchService:
+    def __init__(self, result: SkillSearchRecommendation) -> None:
+        self.result = result
+
+    async def search(self, *, query: str, metadata_items):
+        assert query == "help me explore this change"
+        assert [item.name for item in metadata_items] == ["brainstorming"]
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_search_returns_structured_recommendation(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "brainstorming"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: brainstorming\ndescription: Explore design first.\n---\n\nUse this skill.",
+        encoding="utf-8",
+    )
+
+    registry = SkillRegistry()
+    registry.discover_skills_sync([tmp_path])
+    loader = SkillLoader(registry)
+    tool = SkillTool(
+        registry=registry,
+        loader=loader,
+        allowed_skills=["brainstorming"],
+        search_service=StubSearchService(
+            SkillSearchRecommendation(
+                decision="recommend",
+                skill_name="brainstorming",
+                reason="design task",
+            )
+        ),
+    )
+
+    result = await tool.execute(
+        {"mode": "search", "query": "help me explore this change"},
+        build_tool_context(),
+    )
+
+    payload = json.loads(result.content)
+    assert result.is_success is True
+    assert payload["decision"] == "recommend"
+    assert payload["skill_name"] == "brainstorming"
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_search_respects_disabled_runtime_setting(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "brainstorming"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: brainstorming\ndescription: Explore design first.\n---\n\nUse this skill.",
+        encoding="utf-8",
+    )
+
+    registry = SkillRegistry()
+    registry.discover_skills_sync([tmp_path])
+    loader = SkillLoader(registry)
+    tool = SkillTool(
+        registry=registry,
+        loader=loader,
+        allowed_skills=["brainstorming"],
+        search_service=StubSearchService(
+            SkillSearchRecommendation(
+                decision="recommend",
+                skill_name="brainstorming",
+                reason="design task",
+            )
+        ),
+    )
+
+    fake_settings = SimpleNamespace(skill_search_enabled=False)
+    with patch("agiwo.skill.skill_tool.get_settings", return_value=fake_settings):
+        result = await tool.execute(
+            {"mode": "search", "query": "help me explore this change"},
+            build_tool_context(),
+        )
+
+    payload = json.loads(result.content)
+    assert payload["decision"] == "no_recommendation"
+    assert payload["skill_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_activate_keeps_existing_behavior(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "brainstorming"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: brainstorming\ndescription: Explore design first.\n---\n\nUse this skill.",
+        encoding="utf-8",
+    )
+
+    registry = SkillRegistry()
+    registry.discover_skills_sync([tmp_path])
+    loader = SkillLoader(registry)
+    tool = SkillTool(
+        registry=registry,
+        loader=loader,
+        allowed_skills=["brainstorming"],
+    )
+
+    result = await tool.execute(
+        {"mode": "activate", "skill_name": "brainstorming"},
+        build_tool_context(),
+    )
+
+    assert result.is_success is True
+    assert "Use this skill." in result.content


### PR DESCRIPTION
## Summary
- shrink prompt-time skill rendering to a configured default subset
- add in-memory skill search with embedding recall plus LLM judgment
- extend the skill tool to support search and activate modes, with new tests and docs

## Testing
- uv run pytest tests/agent/test_prompt.py tests/skill/test_manager.py tests/skill/test_search.py tests/skill/test_skill_tool.py tests/config/test_settings_env.py tests/tool/test_tool_manager.py -q
- uv run python scripts/lint.py changed

## Notes
- repo guard still reports the existing settings file size warning for agiwo/config/settings.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skill search functionality enabling agents to discover skills using natural language queries with intelligent recommendations
  * Configurable default skills appearing in agent prompts with controllable search behavior through new environment variables
  * New skill tool modes supporting both skill search and activation workflows

* **Documentation**
  * Updated skill guides documenting new discovery and activation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->