### PR TITLE
Fix scheduler state persistence and align console agent config

### DIFF
--- a/agiwo/scheduler/store/sqlite.py
+++ b/agiwo/scheduler/store/sqlite.py
@@ -81,6 +81,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                     depth INTEGER DEFAULT 0,
                     wake_count INTEGER DEFAULT 0,
                     rollback_count INTEGER DEFAULT 0,
+                    no_progress INTEGER DEFAULT 0,
                     agent_config_id TEXT,
                     explain TEXT,
                     created_at TEXT NOT NULL,
@@ -159,6 +160,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
             depth=row.get("depth", 0) or 0,
             wake_count=row.get("wake_count", 0) or 0,
             rollback_count=row.get("rollback_count", 0) or 0,
+            no_progress=bool(row.get("no_progress", 0)),
             explain=row.get("explain"),
             last_run_result=last_run_result,
             created_at=datetime.fromisoformat(row["created_at"]),
@@ -216,8 +218,8 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                  last_run_id, last_run_termination_reason, last_run_summary, last_run_error,
                  last_run_completed_at,
                  signal_propagated, is_persistent, depth, wake_count, rollback_count,
-                 agent_config_id, explain, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 no_progress, agent_config_id, explain, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 state.id,
@@ -239,6 +241,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                 state.depth,
                 state.wake_count,
                 state.rollback_count,
+                1 if state.no_progress else 0,
                 state.agent_config_id,
                 state.explain,
                 state.created_at.isoformat(),

--- a/console/server/app.py
+++ b/console/server/app.py
@@ -20,7 +20,7 @@ from server.channels.utils import safe_close_all
 from server.channels.feishu import FeishuChannelService
 from server.services.session_store import create_session_store
 from server.config import ConsoleConfig
-from server.services.agent_registry import AgentRegistry
+from server.services.agent_registry import AgentRegistry, build_default_agent_record
 from server.services.runtime import AgentRuntimeCache
 from server.services.runtime_config import RuntimeConfigService
 from server.services.storage_wiring import (
@@ -85,7 +85,7 @@ async def lifespan(app: FastAPI):
         )
         if base_agent is None:
             # 使用 .env 中的默认 Agent（不持久化到 DB）
-            base_agent = agent_registry._build_default_agent_record()
+            base_agent = build_default_agent_record(config.default_agent)
             logger.info("using_default_agent_from_env", name=base_agent.name)
 
         feishu_channel_service = FeishuChannelService(
@@ -125,7 +125,9 @@ async def lifespan(app: FastAPI):
     closables: list[object] = []
     if feishu_channel_service is not None:
         closables.append(feishu_channel_service)
-    closables.extend([agent_runtime_cache, agent_registry, run_step_storage])
+    closables.extend(
+        [agent_runtime_cache, console_session_store, agent_registry, run_step_storage]
+    )
     if trace_storage is not None:
         closables.append(trace_storage)
     try:

--- a/console/server/app.py
+++ b/console/server/app.py
@@ -69,8 +69,7 @@ def _validate_feishu_config(config: ConsoleConfig) -> None:
         missing.append("AGIWO_CONSOLE_FEISHU_DEFAULT_AGENT_NAME")
     if missing:
         raise RuntimeError(
-            "Feishu channel enabled but missing required config: "
-            + ", ".join(missing)
+            "Feishu channel enabled but missing required config: " + ", ".join(missing)
         )
 
 

--- a/console/server/app.py
+++ b/console/server/app.py
@@ -3,6 +3,7 @@ Agiwo Console — FastAPI application entry point.
 """
 
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -42,99 +43,160 @@ from agiwo.utils.logging import get_logger
 logger = get_logger("app")
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    config = ConsoleConfig()
-    run_step_storage = create_run_step_storage(config)
-    trace_storage = create_trace_storage(config)
-    agent_registry = AgentRegistry(config)
-    await agent_registry.initialize()
-    runtime_config_service = RuntimeConfigService(config)
+@dataclass
+class LifespanResources:
+    run_step_storage: object | None = None
+    trace_storage: object | None = None
+    agent_registry: AgentRegistry | None = None
+    scheduler: Scheduler | None = None
+    scheduler_started: bool = False
+    console_session_store: object | None = None
+    feishu_channel_service: FeishuChannelService | None = None
+    agent_runtime_cache: AgentRuntimeCache | None = None
+
+
+def _validate_feishu_config(config: ConsoleConfig) -> None:
+    if not config.channels.feishu.enabled:
+        logger.info("feishu_channel_disabled", enabled=False)
+        return
+    logger.info("feishu_channel_enabled", enabled=True)
+    missing: list[str] = []
+    if not config.channels.feishu.app_id:
+        missing.append("AGIWO_CONSOLE_FEISHU_APP_ID")
+    if not config.channels.feishu.app_secret:
+        missing.append("AGIWO_CONSOLE_FEISHU_APP_SECRET")
+    if not config.channels.feishu.default_agent_name:
+        missing.append("AGIWO_CONSOLE_FEISHU_DEFAULT_AGENT_NAME")
+    if missing:
+        raise RuntimeError(
+            "Feishu channel enabled but missing required config: "
+            + ", ".join(missing)
+        )
+
+
+async def _build_feishu_channel_service(
+    config: ConsoleConfig,
+    sched: Scheduler,
+    agent_registry: AgentRegistry,
+) -> FeishuChannelService | None:
+    _validate_feishu_config(config)
+    if not config.channels.feishu.enabled:
+        return None
+    base_agent = await agent_registry.get_agent_by_name(
+        config.channels.feishu.default_agent_name
+    )
+    if base_agent is None:
+        # 使用 .env 中的默认 Agent（不持久化到 DB）
+        base_agent = build_default_agent_record(config.default_agent)
+        logger.info("using_default_agent_from_env", name=base_agent.name)
+
+    feishu_channel_service = FeishuChannelService(
+        config=config,
+        scheduler=sched,
+        agent_registry=agent_registry,
+    )
+    await feishu_channel_service.initialize()
+    return feishu_channel_service
+
+
+async def _close_runtime_resources(resources: LifespanResources) -> None:
+    closables: list[object] = []
+    if resources.feishu_channel_service is not None:
+        closables.append(resources.feishu_channel_service)
+    if resources.agent_runtime_cache is not None:
+        closables.append(resources.agent_runtime_cache)
+    if resources.console_session_store is not None:
+        closables.append(resources.console_session_store)
+    if resources.agent_registry is not None:
+        closables.append(resources.agent_registry)
+    if resources.run_step_storage is not None:
+        closables.append(resources.run_step_storage)
+    if resources.trace_storage is not None:
+        closables.append(resources.trace_storage)
+    if resources.scheduler is not None and resources.scheduler_started:
+        try:
+            await resources.scheduler.stop()
+        except Exception:  # noqa: BLE001
+            logger.warning("resource_close_failed", resource="Scheduler", exc_info=True)
+    await safe_close_all(*closables)
+
+
+async def _startup_console_runtime(
+    app: FastAPI,
+    config: ConsoleConfig,
+    runtime_config_service: RuntimeConfigService,
+    resources: LifespanResources,
+) -> None:
+    resources.run_step_storage = create_run_step_storage(config)
+    resources.trace_storage = create_trace_storage(config)
+    resources.agent_registry = AgentRegistry(config)
+    await resources.agent_registry.initialize()
 
     scheduler_config = SchedulerConfig(
         state_storage=build_agent_state_storage_config(config),
     )
-    sched = Scheduler(scheduler_config)
-    await sched.start()
+    resources.scheduler = Scheduler(scheduler_config)
+    await resources.scheduler.start()
+    resources.scheduler_started = True
 
     await get_global_skill_manager().initialize()
 
-    console_session_store = create_session_store(
+    resources.console_session_store = create_session_store(
         db_path=config.sqlite_db_path,
         use_persistent_store=config.storage.metadata_type == "sqlite",
     )
-    await console_session_store.connect()
+    await resources.console_session_store.connect()
 
-    feishu_channel_service: FeishuChannelService | None = None
-    if config.channels.feishu.enabled:
-        logger.info("feishu_channel_enabled", enabled=True)
-        missing: list[str] = []
-        if not config.channels.feishu.app_id:
-            missing.append("AGIWO_CONSOLE_FEISHU_APP_ID")
-        if not config.channels.feishu.app_secret:
-            missing.append("AGIWO_CONSOLE_FEISHU_APP_SECRET")
-        if not config.channels.feishu.default_agent_name:
-            missing.append("AGIWO_CONSOLE_FEISHU_DEFAULT_AGENT_NAME")
-        if missing:
-            raise RuntimeError(
-                "Feishu channel enabled but missing required config: "
-                + ", ".join(missing)
-            )
-        base_agent = await agent_registry.get_agent_by_name(
-            config.channels.feishu.default_agent_name
-        )
-        if base_agent is None:
-            # 使用 .env 中的默认 Agent（不持久化到 DB）
-            base_agent = build_default_agent_record(config.default_agent)
-            logger.info("using_default_agent_from_env", name=base_agent.name)
-
-        feishu_channel_service = FeishuChannelService(
-            config=config,
-            scheduler=sched,
-            agent_registry=agent_registry,
-        )
-        await feishu_channel_service.initialize()
-    else:
-        logger.info("feishu_channel_disabled", enabled=False)
-
-    agent_runtime_cache = AgentRuntimeCache(
-        scheduler=sched,
-        agent_registry=agent_registry,
+    resources.feishu_channel_service = await _build_feishu_channel_service(
+        config,
+        resources.scheduler,
+        resources.agent_registry,
+    )
+    resources.agent_runtime_cache = AgentRuntimeCache(
+        scheduler=resources.scheduler,
+        agent_registry=resources.agent_registry,
         console_config=config,
-        session_store=console_session_store,
+        session_store=resources.console_session_store,
     )
 
     bind_console_runtime(
         app,
         ConsoleRuntime(
             config=config,
-            run_step_storage=run_step_storage,
-            trace_storage=trace_storage,
-            agent_registry=agent_registry,
-            scheduler=sched,
-            feishu_channel_service=feishu_channel_service,
-            session_store=console_session_store,
-            agent_runtime_cache=agent_runtime_cache,
+            run_step_storage=resources.run_step_storage,
+            trace_storage=resources.trace_storage,
+            agent_registry=resources.agent_registry,
+            scheduler=resources.scheduler,
+            feishu_channel_service=resources.feishu_channel_service,
+            session_store=resources.console_session_store,
+            agent_runtime_cache=resources.agent_runtime_cache,
             runtime_config_service=runtime_config_service,
         ),
     )
 
-    yield
 
-    clear_console_runtime(app)
-    closables: list[object] = []
-    if feishu_channel_service is not None:
-        closables.append(feishu_channel_service)
-    closables.extend(
-        [agent_runtime_cache, console_session_store, agent_registry, run_step_storage]
-    )
-    if trace_storage is not None:
-        closables.append(trace_storage)
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    config = ConsoleConfig()
+    runtime_config_service = RuntimeConfigService(config)
+    resources = LifespanResources()
+
     try:
-        await sched.stop()
-    except Exception:  # noqa: BLE001
-        logger.warning("resource_close_failed", resource="Scheduler", exc_info=True)
-    await safe_close_all(*closables)
+        await _startup_console_runtime(
+            app,
+            config,
+            runtime_config_service,
+            resources,
+        )
+    except Exception:
+        await _close_runtime_resources(resources)
+        raise
+
+    try:
+        yield
+    finally:
+        clear_console_runtime(app)
+        await _close_runtime_resources(resources)
 
 
 def create_app() -> FastAPI:

--- a/console/server/models/agent_config.py
+++ b/console/server/models/agent_config.py
@@ -28,6 +28,11 @@ class AgentOptionsInput(BaseModel):
     relevant_memory_max_token: int = Field(default=2048, ge=1)
     stream_cleanup_timeout: float = Field(default=300.0, gt=0)
     compact_prompt: str = ""
+    enable_context_rollback: bool = True
+    enable_tool_retrospect: bool = True
+    retrospect_token_threshold: int = Field(default=1024, ge=1)
+    retrospect_round_interval: int = Field(default=5, ge=1)
+    retrospect_accumulated_token_threshold: int = Field(default=8192, ge=1)
 
     @model_validator(mode="before")
     @classmethod

--- a/console/server/services/agent_registry/__init__.py
+++ b/console/server/services/agent_registry/__init__.py
@@ -1,9 +1,11 @@
 """Agent registry: configuration CRUD, persistence, and domain models."""
 
+from server.services.agent_registry.defaults import build_default_agent_record
 from server.services.agent_registry.models import AgentConfigRecord
 from server.services.agent_registry.registry import AgentRegistry
 
 __all__ = [
     "AgentConfigRecord",
     "AgentRegistry",
+    "build_default_agent_record",
 ]

--- a/console/server/services/agent_registry/defaults.py
+++ b/console/server/services/agent_registry/defaults.py
@@ -1,0 +1,34 @@
+"""Shared helpers for building Console default agent records."""
+
+from server.config import DefaultAgentConfig
+from server.models.agent_config import AgentOptionsInput, ModelParamsInput
+
+from agiwo.skill.manager import get_global_skill_manager
+
+from server.services.agent_registry.models import AgentConfigRecord
+
+
+def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecord:
+    """Build a normalized default agent record from Console config."""
+    allowed_skills = get_global_skill_manager().expand_allowed_skills(
+        template.allowed_skills
+    )
+    return AgentConfigRecord(
+        id=template.id,
+        name=template.name,
+        description=template.description,
+        model_provider=template.model_provider,
+        model_name=template.model_name,
+        system_prompt=template.system_prompt,
+        allowed_tools=(
+            list(template.allowed_tools) if template.allowed_tools is not None else None
+        ),
+        allowed_skills=allowed_skills,
+        options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
+        model_params=ModelParamsInput.model_validate(
+            template.model_params or {}
+        ).model_dump(exclude_none=True),
+    )
+
+
+__all__ = ["build_default_agent_record"]

--- a/console/server/services/agent_registry/defaults.py
+++ b/console/server/services/agent_registry/defaults.py
@@ -24,7 +24,7 @@ def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecor
             list(template.allowed_tools) if template.allowed_tools is not None else None
         ),
         allowed_skills=allowed_skills,
-        options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
+        options=AgentOptionsInput().model_dump(exclude_none=True),
         model_params=ModelParamsInput.model_validate(
             template.model_params or {}
         ).model_dump(exclude_none=True),

--- a/console/server/services/agent_registry/registry.py
+++ b/console/server/services/agent_registry/registry.py
@@ -3,11 +3,11 @@
 from datetime import datetime
 
 from agiwo.llm.config_policy import validate_provider_model_params
-from agiwo.skill.manager import get_global_skill_manager
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from server.config import ConsoleConfig
 from server.models.agent_config import AgentOptionsInput, ModelParamsInput
+from server.services.agent_registry.defaults import build_default_agent_record
 from server.services.agent_registry.models import AgentConfigRecord
 from server.services.agent_registry.store import (
     AgentRegistryStore,
@@ -92,7 +92,7 @@ class AgentRegistry:
 
         if offset == 0:
             records = await store.list_agents(limit=max(limit - 1, 0), offset=0)
-            return [self._build_default_agent_record(), *records]
+            return [build_default_agent_record(self._config.default_agent), *records]
 
         return await store.list_agents(limit=limit, offset=offset - 1)
 
@@ -104,30 +104,9 @@ class AgentRegistry:
 
         # DB 中没有，检查是否是默认 Agent
         if agent_id == self._config.default_agent.id:
-            return self._build_default_agent_record()
+            return build_default_agent_record(self._config.default_agent)
 
         return None
-
-    def _build_default_agent_record(self) -> AgentConfigRecord:
-        """Build default agent from .env config (not persisted to DB)."""
-        template = self._config.default_agent
-        allowed_skills = get_global_skill_manager().expand_allowed_skills(
-            template.allowed_skills
-        )
-        return AgentConfigRecord(
-            id=template.id,
-            name=template.name,
-            description=template.description,
-            model_provider=template.model_provider,
-            model_name=template.model_name,
-            system_prompt=template.system_prompt,
-            allowed_tools=template.allowed_tools,
-            allowed_skills=allowed_skills,
-            options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
-            model_params=ModelParamsInput.model_validate(
-                template.model_params or {}
-            ).model_dump(exclude_none=True),
-        )
 
     async def get_agent_by_name(self, agent_name: str) -> AgentConfigRecord | None:
         """Get agent by name. Returns default agent from .env if not in DB."""
@@ -137,7 +116,7 @@ class AgentRegistry:
 
         # DB 中没有，检查是否是默认 Agent 的名称
         if agent_name == self._config.default_agent.name:
-            return self._build_default_agent_record()
+            return build_default_agent_record(self._config.default_agent)
 
         return None
 

--- a/console/server/services/runtime/agent_factory.py
+++ b/console/server/services/runtime/agent_factory.py
@@ -11,14 +11,17 @@ from agiwo.llm import create_model_from_dict
 from agiwo.llm.base import Model
 from agiwo.scheduler.engine import Scheduler
 from agiwo.scheduler.models import AgentState
-from agiwo.skill.manager import get_global_skill_manager
 from agiwo.tool.base import BaseTool
 from agiwo.tool.manager import get_global_tool_manager
 from agiwo.tool.reference import AgentToolReference
 
 from server.config import ConsoleConfig, DefaultAgentConfig
 from server.models.agent_config import AgentOptionsInput, ModelParamsInput
-from server.services.agent_registry import AgentConfigRecord, AgentRegistry
+from server.services.agent_registry import (
+    AgentConfigRecord,
+    AgentRegistry,
+    build_default_agent_record as _build_default_agent_record,
+)
 from server.services.storage_wiring import (
     build_citation_store_config,
     build_run_step_storage_config,
@@ -59,29 +62,7 @@ def agent_options_input_to_agent_options(
 
 
 def build_default_agent_record(template: DefaultAgentConfig) -> AgentConfigRecord:
-    allowed_skills = get_global_skill_manager().expand_allowed_skills(
-        template.allowed_skills
-    )
-    # Expand default tools using ToolManager
-    tool_manager = get_global_tool_manager()
-    default_tools = tool_manager.list_default_tool_names()
-    allowed_tools = (
-        default_tools
-        if template.allowed_tools is None
-        else list(template.allowed_tools)
-    )
-    return AgentConfigRecord(
-        id=template.id,
-        name=template.name,
-        description=template.description,
-        model_provider=template.model_provider,
-        model_name=template.model_name,
-        system_prompt=template.system_prompt,
-        allowed_tools=allowed_tools,
-        allowed_skills=allowed_skills,
-        options=AgentOptionsInput.model_validate({}).model_dump(exclude_none=True),
-        model_params=dict(template.model_params),
-    )
+    return _build_default_agent_record(template)
 
 
 def build_model(config: AgentConfigRecord) -> Model:

--- a/console/tests/test_app_smoke.py
+++ b/console/tests/test_app_smoke.py
@@ -1,8 +1,13 @@
 """Smoke test: create_app() succeeds and basic health endpoint responds."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+import server.app as app_module
 from server.app import create_app
 from server.config import ConsoleConfig
 from server.dependencies import (
@@ -47,3 +52,65 @@ async def test_create_app_starts_and_lists_agents() -> None:
     clear_console_runtime(app)
     await registry.close()
     await run_step_storage.close()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_closes_session_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ConsoleConfig(
+        run_step_storage_type="memory",
+        trace_storage_type="memory",
+        metadata_storage_type="memory",
+    )
+    run_step_storage = SimpleNamespace(close=AsyncMock())
+    trace_storage = SimpleNamespace(close=AsyncMock())
+    session_store = SimpleNamespace(connect=AsyncMock(), close=AsyncMock())
+    agent_registry = SimpleNamespace(
+        initialize=AsyncMock(),
+        close=AsyncMock(),
+        get_agent_by_name=AsyncMock(return_value=None),
+    )
+    scheduler = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    agent_runtime_cache = SimpleNamespace(close=AsyncMock())
+    skill_manager = SimpleNamespace(initialize=AsyncMock())
+
+    async def fake_safe_close_all(*closables: object) -> None:
+        for obj in closables:
+            close = getattr(obj, "close", None)
+            if close is not None:
+                await close()
+
+    monkeypatch.setattr(app_module, "ConsoleConfig", lambda: config)
+    monkeypatch.setattr(
+        app_module, "create_run_step_storage", lambda _cfg: run_step_storage
+    )
+    monkeypatch.setattr(app_module, "create_trace_storage", lambda _cfg: trace_storage)
+    monkeypatch.setattr(app_module, "AgentRegistry", lambda _cfg: agent_registry)
+    monkeypatch.setattr(
+        app_module, "RuntimeConfigService", lambda _cfg: SimpleNamespace()
+    )
+    monkeypatch.setattr(app_module, "Scheduler", lambda _cfg: scheduler)
+    monkeypatch.setattr(app_module, "get_global_skill_manager", lambda: skill_manager)
+    monkeypatch.setattr(
+        app_module, "create_session_store", lambda **_kwargs: session_store
+    )
+    monkeypatch.setattr(
+        app_module,
+        "AgentRuntimeCache",
+        lambda **_kwargs: agent_runtime_cache,
+    )
+    monkeypatch.setattr(
+        app_module, "bind_console_runtime", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        app_module, "clear_console_runtime", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(app_module, "safe_close_all", fake_safe_close_all)
+
+    async with app_module.lifespan(FastAPI()):
+        pass
+
+    session_store.connect.assert_awaited_once()
+    session_store.close.assert_awaited_once()
+    scheduler.stop.assert_awaited_once()

--- a/console/tests/test_app_smoke.py
+++ b/console/tests/test_app_smoke.py
@@ -114,3 +114,62 @@ async def test_lifespan_closes_session_store(
     session_store.connect.assert_awaited_once()
     session_store.close.assert_awaited_once()
     scheduler.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_closes_partial_startup_resources_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ConsoleConfig(
+        run_step_storage_type="memory",
+        trace_storage_type="memory",
+        metadata_storage_type="memory",
+        channels={
+            "feishu": {
+                "enabled": True,
+            }
+        },
+    )
+    run_step_storage = SimpleNamespace(close=AsyncMock())
+    trace_storage = SimpleNamespace(close=AsyncMock())
+    session_store = SimpleNamespace(connect=AsyncMock(), close=AsyncMock())
+    agent_registry = SimpleNamespace(
+        initialize=AsyncMock(),
+        close=AsyncMock(),
+        get_agent_by_name=AsyncMock(return_value=None),
+    )
+    scheduler = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    skill_manager = SimpleNamespace(initialize=AsyncMock())
+
+    async def fake_safe_close_all(*closables: object) -> None:
+        for obj in closables:
+            close = getattr(obj, "close", None)
+            if close is not None:
+                await close()
+
+    monkeypatch.setattr(app_module, "ConsoleConfig", lambda: config)
+    monkeypatch.setattr(
+        app_module, "create_run_step_storage", lambda _cfg: run_step_storage
+    )
+    monkeypatch.setattr(app_module, "create_trace_storage", lambda _cfg: trace_storage)
+    monkeypatch.setattr(app_module, "AgentRegistry", lambda _cfg: agent_registry)
+    monkeypatch.setattr(
+        app_module, "RuntimeConfigService", lambda _cfg: SimpleNamespace()
+    )
+    monkeypatch.setattr(app_module, "Scheduler", lambda _cfg: scheduler)
+    monkeypatch.setattr(app_module, "get_global_skill_manager", lambda: skill_manager)
+    monkeypatch.setattr(
+        app_module, "create_session_store", lambda **_kwargs: session_store
+    )
+    monkeypatch.setattr(app_module, "safe_close_all", fake_safe_close_all)
+
+    with pytest.raises(RuntimeError, match="Feishu channel enabled but missing"):
+        async with app_module.lifespan(FastAPI()):
+            pass
+
+    session_store.connect.assert_awaited_once()
+    session_store.close.assert_awaited_once()
+    agent_registry.close.assert_awaited_once()
+    run_step_storage.close.assert_awaited_once()
+    trace_storage.close.assert_awaited_once()
+    scheduler.stop.assert_awaited_once()

--- a/console/tests/test_config_env.py
+++ b/console/tests/test_config_env.py
@@ -3,7 +3,9 @@ from pydantic import ValidationError
 
 import agiwo.agent.agent as agent_module
 import agiwo.skill as skill_module
+import server.services.agent_registry.defaults as registry_defaults_module
 import server.services.agent_registry.models as registry_models_module
+from agiwo.agent.models.config import AgentOptions as SDKAgentOptions
 from agiwo.agent import AgentOptions
 from agiwo.llm.base import Model
 from agiwo.llm.openai import OpenAIModel
@@ -14,13 +16,17 @@ import server.services.runtime.agent_factory as agent_factory_module
 from server.config import ConsoleConfig, DefaultAgentConfig
 from server.models.agent_config import AgentOptionsInput
 from server.models.view import AgentConfigPayload
+from server.services.agent_registry import (
+    AgentConfigRecord,
+    AgentRegistry,
+    build_default_agent_record as build_registry_default_agent_record,
+)
 from server.services.runtime.agent_factory import (
     agent_options_input_to_agent_options,
     build_agent,
     build_default_agent_record,
     build_model,
 )
-from server.services.agent_registry import AgentConfigRecord, AgentRegistry
 from server.services.storage_wiring import (
     build_run_step_storage_config,
     build_trace_storage_config,
@@ -87,7 +93,7 @@ def stub_skill_manager(monkeypatch: pytest.MonkeyPatch) -> DummySkillManager:
         lambda: manager,
     )
     monkeypatch.setattr(
-        agent_factory_module,
+        registry_defaults_module,
         "get_global_skill_manager",
         lambda: manager,
     )
@@ -244,6 +250,11 @@ def test_agent_options_input_maps_all_fields() -> None:
             "relevant_memory_max_token": 1024,
             "stream_cleanup_timeout": 90.5,
             "compact_prompt": "Compact the context",
+            "enable_context_rollback": False,
+            "enable_tool_retrospect": False,
+            "retrospect_token_threshold": 2049,
+            "retrospect_round_interval": 7,
+            "retrospect_accumulated_token_threshold": 16384,
         }
     )
     options = agent_options_input_to_agent_options(
@@ -262,6 +273,53 @@ def test_agent_options_input_maps_all_fields() -> None:
     assert options.relevant_memory_max_token == 1024
     assert options.stream_cleanup_timeout == 90.5
     assert options.compact_prompt == "Compact the context"
+    assert options.enable_context_rollback is False
+    assert options.enable_tool_retrospect is False
+    assert options.retrospect_token_threshold == 2049
+    assert options.retrospect_round_interval == 7
+    assert options.retrospect_accumulated_token_threshold == 16384
+
+
+def test_console_agent_options_input_matches_sdk_agent_options() -> None:
+    expected = set(SDKAgentOptions.model_fields) - {"storage"}
+    actual = set(AgentOptionsInput.model_fields)
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_default_agent_record_is_consistent_across_entrypoints(
+    stub_skill_manager: DummySkillManager,
+) -> None:
+    del stub_skill_manager
+    config = ConsoleConfig(
+        run_step_storage_type="memory",
+        trace_storage_type="memory",
+        metadata_storage_type="memory",
+        default_agent={
+            "model_provider": "openai",
+            "model_name": "gpt-4o-mini",
+            "allowed_tools": None,
+            "allowed_skills": ["alpha", "beta"],
+            "model_params": {"max_output_tokens": 128},
+        },
+    )
+    registry = AgentRegistry(config)
+    await registry.initialize()
+    try:
+        shared = build_registry_default_agent_record(config.default_agent)
+        runtime = build_default_agent_record(config.default_agent)
+        by_id = await registry.get_agent(config.default_agent.id)
+        by_name = await registry.get_agent_by_name(config.default_agent.name)
+    finally:
+        await registry.close()
+
+    exclude_timestamps = {"created_at", "updated_at"}
+    shared_payload = shared.model_dump(exclude=exclude_timestamps)
+    assert runtime.model_dump(exclude=exclude_timestamps) == shared_payload
+    assert by_id is not None
+    assert by_name is not None
+    assert by_id.model_dump(exclude=exclude_timestamps) == shared_payload
+    assert by_name.model_dump(exclude=exclude_timestamps) == shared_payload
 
 
 def test_console_tool_catalog_parses_builtin_and_agent_refs() -> None:

--- a/console/web/src/components/agent-form.tsx
+++ b/console/web/src/components/agent-form.tsx
@@ -376,6 +376,25 @@ export function AgentForm({
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
+  const setBoundedIntegerField = (
+    key:
+      | "retrospectTokenThreshold"
+      | "retrospectRoundInterval"
+      | "retrospectAccumulatedTokenThreshold",
+    rawValue: string,
+    min: number,
+    max: number,
+  ) => {
+    if (rawValue.trim() === "") {
+      return;
+    }
+    const parsed = Number.parseInt(rawValue, 10);
+    if (Number.isNaN(parsed)) {
+      return;
+    }
+    setField(key, Math.min(max, Math.max(min, parsed)));
+  };
+
   const toggleTool = (toolName: string) => {
     setLocalError(null);
     setForm((prev) => ({
@@ -814,7 +833,12 @@ export function AgentForm({
                 type="number"
                 value={form.retrospectTokenThreshold}
                 onChange={(event) =>
-                  setField("retrospectTokenThreshold", Number(event.target.value))
+                  setBoundedIntegerField(
+                    "retrospectTokenThreshold",
+                    event.target.value,
+                    1,
+                    131072,
+                  )
                 }
                 min={1}
                 max={131072}
@@ -832,7 +856,12 @@ export function AgentForm({
                 type="number"
                 value={form.retrospectRoundInterval}
                 onChange={(event) =>
-                  setField("retrospectRoundInterval", Number(event.target.value))
+                  setBoundedIntegerField(
+                    "retrospectRoundInterval",
+                    event.target.value,
+                    1,
+                    100,
+                  )
                 }
                 min={1}
                 max={100}
@@ -850,9 +879,11 @@ export function AgentForm({
                 type="number"
                 value={form.retrospectAccumulatedTokenThreshold}
                 onChange={(event) =>
-                  setField(
+                  setBoundedIntegerField(
                     "retrospectAccumulatedTokenThreshold",
-                    Number(event.target.value),
+                    event.target.value,
+                    1,
+                    262144,
                   )
                 }
                 min={1}

--- a/console/web/src/components/agent-form.tsx
+++ b/console/web/src/components/agent-form.tsx
@@ -45,6 +45,11 @@ type AgentFormState = {
   relevantMemoryMaxToken: number;
   streamCleanupTimeout: number;
   compactPrompt: string;
+  enableContextRollback: boolean;
+  enableToolRetrospect: boolean;
+  retrospectTokenThreshold: number;
+  retrospectRoundInterval: number;
+  retrospectAccumulatedTokenThreshold: number;
   maxOutputTokens: number;
   maxContextWindow: number;
   temperature: number;
@@ -76,6 +81,11 @@ const DEFAULT_FORM_STATE: AgentFormState = {
   relevantMemoryMaxToken: 2048,
   streamCleanupTimeout: 300,
   compactPrompt: "",
+  enableContextRollback: true,
+  enableToolRetrospect: true,
+  retrospectTokenThreshold: 1024,
+  retrospectRoundInterval: 5,
+  retrospectAccumulatedTokenThreshold: 8192,
   maxOutputTokens: 4096,
   maxContextWindow: 200000,
   temperature: 0.7,
@@ -130,6 +140,12 @@ function buildFormState(agent?: AgentConfig | null): AgentFormState {
     relevantMemoryMaxToken: agent.options?.relevant_memory_max_token ?? 2048,
     streamCleanupTimeout: agent.options?.stream_cleanup_timeout ?? 300,
     compactPrompt: agent.options?.compact_prompt ?? "",
+    enableContextRollback: agent.options?.enable_context_rollback ?? true,
+    enableToolRetrospect: agent.options?.enable_tool_retrospect ?? true,
+    retrospectTokenThreshold: agent.options?.retrospect_token_threshold ?? 1024,
+    retrospectRoundInterval: agent.options?.retrospect_round_interval ?? 5,
+    retrospectAccumulatedTokenThreshold:
+      agent.options?.retrospect_accumulated_token_threshold ?? 8192,
     maxOutputTokens: agent.model_params?.max_output_tokens ?? 4096,
     maxContextWindow: agent.model_params?.max_context_window ?? 200000,
     temperature: agent.model_params?.temperature ?? 0.7,
@@ -424,6 +440,12 @@ export function AgentForm({
         relevant_memory_max_token: form.relevantMemoryMaxToken,
         stream_cleanup_timeout: form.streamCleanupTimeout,
         compact_prompt: form.compactPrompt,
+        enable_context_rollback: form.enableContextRollback,
+        enable_tool_retrospect: form.enableToolRetrospect,
+        retrospect_token_threshold: form.retrospectTokenThreshold,
+        retrospect_round_interval: form.retrospectRoundInterval,
+        retrospect_accumulated_token_threshold:
+          form.retrospectAccumulatedTokenThreshold,
       },
       model_params: {
         base_url: form.baseUrl.trim() === "" ? null : form.baseUrl.trim(),
@@ -453,7 +475,9 @@ export function AgentForm({
   const openCompatibilitySection = compatibilityRequired || hasCompatibilitySettings;
   const openWorkflowSection =
     form.terminationSummaryPrompt.trim() !== "" ||
-    form.compactPrompt.trim() !== "";
+    form.compactPrompt.trim() !== "" ||
+    !form.enableContextRollback ||
+    !form.enableToolRetrospect;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
@@ -759,6 +783,85 @@ export function AgentForm({
             placeholder="Optional compact prompt"
           />
         </Field>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <ToggleCard
+            id={fieldId("enable-context-rollback")}
+            label="Enable Context Rollback"
+            description="Drop no-progress periodic rounds so long-running loops do not keep useless context."
+            checked={form.enableContextRollback}
+            onChange={(checked) => setField("enableContextRollback", checked)}
+          />
+
+          <ToggleCard
+            id={fieldId("enable-tool-retrospect")}
+            label="Enable Tool Retrospect"
+            description="Condense bulky tool outputs before they start dominating the prompt window."
+            checked={form.enableToolRetrospect}
+            onChange={(checked) => setField("enableToolRetrospect", checked)}
+          />
+        </div>
+
+        {form.enableToolRetrospect && (
+          <div className="grid gap-4 md:grid-cols-3">
+            <Field
+              id={fieldId("retrospect-token-threshold")}
+              label="Retrospect Token Threshold"
+              hint="Retrospect once a single tool result exceeds this token estimate."
+            >
+              <input
+                id={fieldId("retrospect-token-threshold")}
+                type="number"
+                value={form.retrospectTokenThreshold}
+                onChange={(event) =>
+                  setField("retrospectTokenThreshold", Number(event.target.value))
+                }
+                min={1}
+                max={131072}
+                className="ui-input"
+              />
+            </Field>
+
+            <Field
+              id={fieldId("retrospect-round-interval")}
+              label="Retrospect Round Interval"
+              hint="Force a retrospect pass every N rounds when tool usage keeps growing."
+            >
+              <input
+                id={fieldId("retrospect-round-interval")}
+                type="number"
+                value={form.retrospectRoundInterval}
+                onChange={(event) =>
+                  setField("retrospectRoundInterval", Number(event.target.value))
+                }
+                min={1}
+                max={100}
+                className="ui-input"
+              />
+            </Field>
+
+            <Field
+              id={fieldId("retrospect-accumulated-token-threshold")}
+              label="Retrospect Accumulated Token Threshold"
+              hint="Retrospect once multiple tool results together exceed this token estimate."
+            >
+              <input
+                id={fieldId("retrospect-accumulated-token-threshold")}
+                type="number"
+                value={form.retrospectAccumulatedTokenThreshold}
+                onChange={(event) =>
+                  setField(
+                    "retrospectAccumulatedTokenThreshold",
+                    Number(event.target.value),
+                  )
+                }
+                min={1}
+                max={262144}
+                className="ui-input"
+              />
+            </Field>
+          </div>
+        )}
       </DisclosureSection>
 
       <DisclosureSection

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -456,6 +456,11 @@ export interface AgentOptionsPayload {
   relevant_memory_max_token: number;
   stream_cleanup_timeout: number;
   compact_prompt: string;
+  enable_context_rollback: boolean;
+  enable_tool_retrospect: boolean;
+  retrospect_token_threshold: number;
+  retrospect_round_interval: number;
+  retrospect_accumulated_token_threshold: number;
 }
 
 export interface ModelParamsPayload {

--- a/console/web/vitest.config.ts
+++ b/console/web/vitest.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/tests/scheduler/test_context_rollback.py
+++ b/tests/scheduler/test_context_rollback.py
@@ -1,5 +1,7 @@
 """Tests for scheduler context rollback — signal propagation and gating."""
 
+import pytest
+
 from agiwo.agent.models.config import AgentOptions
 from agiwo.agent.models.run import RunLedger, RunOutput
 from agiwo.scheduler.commands import SleepRequest
@@ -10,6 +12,7 @@ from agiwo.scheduler.models import (
     WakeCondition,
     WakeType,
 )
+from agiwo.scheduler.store.sqlite import SQLiteAgentStateStorage
 
 
 class TestSleepRequestNoProgress:
@@ -76,6 +79,32 @@ class TestAgentOptionsRollbackConfig:
     def test_can_disable(self):
         opts = AgentOptions(enable_context_rollback=False)
         assert opts.enable_context_rollback is False
+
+
+class TestNoProgressPersistence:
+    @pytest.mark.asyncio
+    async def test_sqlite_round_trip_preserves_no_progress(self, tmp_path):
+        store = SQLiteAgentStateStorage(str(tmp_path / "scheduler.db"))
+        state = AgentState(
+            id="a1",
+            session_id="s1",
+            status=AgentStateStatus.WAITING,
+            task="root",
+            no_progress=True,
+            wake_condition=WakeCondition(
+                type=WakeType.PERIODIC,
+                time_value=60,
+                time_unit=TimeUnit.SECONDS,
+            ),
+        )
+
+        await store.save_state(state)
+        restored = await store.get_state("a1")
+
+        assert restored is not None
+        assert restored.no_progress is True
+
+        await store.close()
 
 
 class TestRunOutputMetadata:

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -198,6 +198,9 @@ class TestSQLiteAgentStateStorage:
             status=AgentStateStatus.WAITING,
             explain="waiting for child",
             pending_input="next input",
+            wake_count=2,
+            rollback_count=1,
+            no_progress=True,
             wake_condition=WakeCondition(
                 type=WakeType.WAITSET,
                 wait_for=["child-1"],
@@ -218,10 +221,26 @@ class TestSQLiteAgentStateStorage:
         assert retrieved.status == AgentStateStatus.WAITING
         assert retrieved.pending_input == "next input"
         assert retrieved.explain == "waiting for child"
+        assert retrieved.wake_count == 2
+        assert retrieved.rollback_count == 1
+        assert retrieved.no_progress is True
         assert retrieved.wake_condition is not None
         assert retrieved.wake_condition.completed_ids == ("child-1",)
         assert retrieved.last_run_result is not None
         assert retrieved.last_run_result.summary == "done"
+
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_save_and_get_round_trip_with_default_no_progress(self, tmp_path):
+        store = SQLiteAgentStateStorage(str(tmp_path / "scheduler.db"))
+        state = _make_state(id="sqlite-no-progress", no_progress=False)
+
+        await store.save_state(state)
+        retrieved = await store.get_state("sqlite-no-progress")
+
+        assert retrieved is not None
+        assert retrieved.no_progress is False
 
         await store.close()
 


### PR DESCRIPTION
## Summary
- persist `no_progress` in scheduler SQLite state and add regression coverage
- unify Console default-agent construction and close the session store during app shutdown
- align Console agent options across backend and web, including the new advanced runtime fields
- remove the `vite-tsconfig-paths` test warning by switching Vitest config to Vite's native tsconfig path support

## Testing
- `uv run pytest tests/scheduler/test_store.py tests/scheduler/test_context_rollback.py -q`
- `cd console && uv run pytest tests/test_config_env.py tests/test_app_smoke.py tests/test_agent_runtime_components.py -q`
- `uv run ruff check agiwo/scheduler/store/sqlite.py tests/scheduler/test_store.py tests/scheduler/test_context_rollback.py console/server/models/agent_config.py console/server/services/agent_registry/__init__.py console/server/services/agent_registry/defaults.py console/server/services/agent_registry/registry.py console/server/services/runtime/agent_factory.py console/server/app.py console/tests/test_config_env.py console/tests/test_app_smoke.py`
- `cd console/web && npm run lint`
- `cd console/web && npm test`
- `cd console/web && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added context rollback and tool retrospect workflow helpers for agents with configurable thresholds and intervals
  * Enhanced agent state tracking with no-progress detection capability
  * Extended agent configuration options to support new workflow helper settings via the agent form

* **Tests**
  * Added comprehensive test coverage for agent state persistence and new workflow configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->