### PR TITLE
fix(scheduler): cancel/urgent/persistent reuse/cleanup/multimodal input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,16 +107,21 @@
 ### Scheduler
 
 - `Scheduler` 是 Agent 之上的编排层；依赖方向保持 `scheduler -> agent`。
-- Scheduler runtime tools（`SpawnAgentTool`、`SleepAndWaitTool` 等）通过 `Agent(system_tools=...)` 注入，不混入 `tools`（extra_tools），不受 `allowed_tools` 约束。
+- Scheduler runtime tools（`SpawnAgentTool`、`SleepAndWaitTool` 等）通过 `Agent._inject_system_tools(...)` 注入，不混入 `tools`（extra_tools），不受 `allowed_tools` 约束。
 - 子 Agent 的 system_tools 由 `SchedulerRunner` 从父 Agent 的 `system_tools` 派生；非 fork 模式排除 `spawn_agent`，fork 模式继承全部（gate 检查仍阻止实际 spawn）。
 - 当前公开编排接口包括：`run`、`submit`、`enqueue_input`、`route_root_input`、`stream`、`wait_for`、`steer`、`cancel`、`shutdown`，以及查询面 `list_states`、`list_events`、`get_stats`、`rebind_agent`。
-- `Scheduler` 只做 facade 和 lifecycle；所有编排语义统一收口到 `SchedulerEngine`。
-- `SchedulerEngine` 是唯一编排 owner；`SchedulerRunner` 只负责单次执行；`TaskGuard` 是 spawn/wake 的唯一护栏入口。
+- `Scheduler` 只做 facade 和 lifecycle；所有编排语义统一收口到 engine 层（facade 直接委托给 `_tick`、`_stream`、`_tree_ops` 等同包 helper）。
+- `SchedulerRunner` 只负责单次 dispatch action；`TaskGuard` 是 spawn/wake 的唯一护栏入口。
 - scheduler 状态现在显式区分 `WAITING`、`IDLE`、`QUEUED`；不要再把待命/排队语义塞回一个泛化 `SLEEPING`。
 - 当前唤醒路径包括 `WAITSET`、`TIMER`、`PERIODIC`、`PENDING_EVENTS`。
 - scheduler state storage 当前支持 memory/sqlite/mongodb，由 `Scheduler` 自己创建和持有。
 - `Scheduler` 的外部流式协议直接复用 `AgentStreamItem`；不要在 SDK core 再维护第二套 live-output protocol。
 - `route_root_input` 对所有非 RUNNING 路径（submitted / enqueued / steered+WAITING / steered+QUEUED）都返回带 stream 的 `RouteResult`；只有 steered+RUNNING 不带 stream（原 stream subscriber 仍在消费）。下游不需要为 steered 场景单独维护 deferred reply 补丁。
+- **Root runtime 严格复用**：`_ensure_root_runtime_agent` 以"canonical Agent 身份"为键缓存 scheduler-managed runtime agent；`submit` / `enqueue_input(agent=same)` 不再每次 clone，persistent 会话下 `run_step_storage` / `trace_storage` / workspace 贯穿所有轮次。只有 `rebind_agent` 或传入新 canonical agent 才会 close 旧 runtime 并重建。
+- **非 persistent root 自动收口**：`_cleanup_after_run` 对非 persistent 且进入 terminal 的 root 立即 `pop + await close`；persistent root 与 child 仍按原语义。`Scheduler.stop()` 在关闭前会批量 close 所有残留 runtime agent。
+- **Cancel/Shutdown 写终态结果**：`cancel_subtree` / `shutdown_subtree` 写 `with_failed(...)` 时一并写入 `last_run_result=SchedulerRunResult(termination_reason=CANCELLED, ...)`；`wait_for()` 依赖该字段，能够在 cancel 完成那一刻直接返回 `RunOutput(error, termination_reason=CANCELLED)` 而非等到 timeout。runner 只在终态未写 `last_run_result` 时兜底补一条。
+- **Urgent steer bypass**：`PendingEvent.urgent` 标志位让 `plan_tick` 在 WAITING 分支跳过 `event_debounce_*` 限制；`Scheduler.steer(..., urgent=True)` 据此令 WAITING root 立即 WAKE_EVENTS。非 urgent 事件继续遵循 debounce。
+- **结构化 `UserInput` 贯通**：`Scheduler.steer()` 不再 `extract_text()`；`PendingEvent.USER_HINT payload` 统一写 `{"user_input": UserMessage.to_storage_value(...)}`；`build_mailbox_input` / `build_events_message` 返回 `UserMessage`，保留 `ContentPart`（图片/文件等）与 `ChannelContext`（Feishu 等 channel metadata）。
 
 ### Context Optimization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Scheduler upgrade note: `PendingEvent.USER_HINT` payloads are now stored as `{"user_input": UserMessage.to_storage_value(...)}` instead of the legacy plain-text shape.
+
+### Upgrade Notes
+- Scheduler SQLite users must recreate `scheduler.db` before upgrading to builds that add `PendingEvent.urgent` and the structured `PendingEvent.USER_HINT` payload. Existing `pending_events` tables created by older versions do not have the new `urgent` column, so the first scheduler `save_event()` write will fail with `no column named urgent`. Delete `scheduler.db`, or back it up and recreate it, before starting the upgraded build.
+
 ### Added
 - Comprehensive English documentation (`docs/`)
 - MIT License

--- a/agiwo/scheduler/_tick.py
+++ b/agiwo/scheduler/_tick.py
@@ -154,16 +154,16 @@ def plan_tick(
                 continue
 
         key = (state.id, state.session_id)
-        if key in debounced_targets:
-            grouped_events = tuple(event_groups.get(key, []))
-            if grouped_events:
-                actions.append(
-                    DispatchAction(
-                        state=state,
-                        reason=DispatchReason.WAKE_EVENTS,
-                        events=grouped_events,
-                    )
+        grouped_events = tuple(event_groups.get(key, []))
+        has_urgent_event = any(event.urgent for event in grouped_events)
+        if grouped_events and (has_urgent_event or key in debounced_targets):
+            actions.append(
+                DispatchAction(
+                    state=state,
+                    reason=DispatchReason.WAKE_EVENTS,
+                    events=grouped_events,
                 )
+            )
 
     return actions
 

--- a/agiwo/scheduler/_tree_ops.py
+++ b/agiwo/scheduler/_tree_ops.py
@@ -1,11 +1,10 @@
 """Subtree cancel/shutdown logic extracted from Scheduler."""
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
+from agiwo.agent import TerminationReason
 from agiwo.scheduler.formatting import SHUTDOWN_SUMMARY_TASK
-from agiwo.scheduler.models import AgentState, AgentStateStatus
+from agiwo.scheduler.models import AgentState, AgentStateStatus, SchedulerRunResult
 from agiwo.scheduler.stream import finish_stream_channel
 from agiwo.utils.abort_signal import AbortSignal
 
@@ -13,7 +12,7 @@ if TYPE_CHECKING:
     from agiwo.scheduler.engine import Scheduler
 
 
-async def cancel_subtree(sched: Scheduler, state_id: str, reason: str) -> None:
+async def cancel_subtree(sched: "Scheduler", state_id: str, reason: str) -> None:
     abort_runtime_state(sched, state_id, reason)
     for child in await active_children(sched, state_id):
         await cancel_subtree(sched, child.id, reason)
@@ -21,12 +20,19 @@ async def cancel_subtree(sched: Scheduler, state_id: str, reason: str) -> None:
     state = await sched._store.get_state(state_id)
     if state is None:
         return
-    await sched._save_state(state.with_failed(reason))
+    cancelled_result = SchedulerRunResult(
+        run_id=None,
+        termination_reason=TerminationReason.CANCELLED,
+        error=reason,
+    )
+    await sched._save_state(
+        state.with_failed(reason).with_updates(last_run_result=cancelled_result)
+    )
     if state.is_root:
         await finish_stream_channel(sched._rt.stream_channels, state.id)
 
 
-async def shutdown_subtree(sched: Scheduler, state_id: str) -> None:
+async def shutdown_subtree(sched: "Scheduler", state_id: str) -> None:
     for child in await active_children(sched, state_id):
         await shutdown_subtree(sched, child.id)
 
@@ -42,12 +48,12 @@ async def shutdown_subtree(sched: Scheduler, state_id: str) -> None:
     await shutdown_passive_state(sched, state)
 
 
-async def active_children(sched: Scheduler, state_id: str) -> list[AgentState]:
+async def active_children(sched: "Scheduler", state_id: str) -> list[AgentState]:
     children = await sched._store.list_states(parent_id=state_id, limit=1000)
     return [child for child in children if child.is_active()]
 
 
-def abort_runtime_state(sched: Scheduler, state_id: str, reason: str) -> None:
+def abort_runtime_state(sched: "Scheduler", state_id: str, reason: str) -> None:
     signal = sched._rt.abort_signals.get(state_id)
     if signal is None:
         signal = AbortSignal()
@@ -60,15 +66,15 @@ def abort_runtime_state(sched: Scheduler, state_id: str, reason: str) -> None:
         handle.cancel(reason)
 
 
-async def shutdown_running_state(sched: Scheduler, state: AgentState) -> None:
+async def shutdown_running_state(sched: "Scheduler", state: AgentState) -> None:
     if state.is_root and state.is_persistent:
         sched._rt.shutdown_requested.add(state.id)
         await sched._save_state(state.with_queued(pending_input=SHUTDOWN_SUMMARY_TASK))
         return
-    await sched._save_state(state.with_failed("Shutdown before completion"))
+    await _save_shutdown_failed(sched, state)
 
 
-async def shutdown_passive_state(sched: Scheduler, state: AgentState) -> None:
+async def shutdown_passive_state(sched: "Scheduler", state: AgentState) -> None:
     if state.is_root and state.status in (
         AgentStateStatus.WAITING,
         AgentStateStatus.IDLE,
@@ -81,6 +87,18 @@ async def shutdown_passive_state(sched: Scheduler, state: AgentState) -> None:
         AgentStateStatus.PENDING,
         AgentStateStatus.QUEUED,
     ):
-        await sched._save_state(state.with_failed("Shutdown before completion"))
+        await _save_shutdown_failed(sched, state)
         if state.is_root:
             await finish_stream_channel(sched._rt.stream_channels, state.id)
+
+
+async def _save_shutdown_failed(sched: "Scheduler", state: AgentState) -> None:
+    reason = "Shutdown before completion"
+    shutdown_result = SchedulerRunResult(
+        run_id=None,
+        termination_reason=TerminationReason.CANCELLED,
+        error=reason,
+    )
+    await sched._save_state(
+        state.with_failed(reason).with_updates(last_run_result=shutdown_result)
+    )

--- a/agiwo/scheduler/engine.py
+++ b/agiwo/scheduler/engine.py
@@ -129,6 +129,19 @@ class Scheduler:
                     task.cancel()
                 await asyncio.gather(*pending, return_exceptions=True)
 
+        remaining_agents = list(self._rt.agents.values())
+        self._rt.agents.clear()
+        self._rt.canonical_agents.clear()
+        self._rt.execution_handles.clear()
+        if remaining_agents:
+            results = await asyncio.gather(
+                *[agent.close() for agent in remaining_agents],
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.error("scheduler_stop_agent_close_failed", error=str(result))
+
         await self._store.close()
         logger.info("scheduler_stopped")
 
@@ -199,18 +212,17 @@ class Scheduler:
         persistent: bool = False,
         agent_config_id: str | None = None,
     ) -> str:
-        prepared_agent = await self._prepare_root_agent(agent, agent.id)
-        existing = await self._store.get_state(prepared_agent.id)
+        existing = await self._store.get_state(agent.id)
         if existing is not None and existing.status in ACTIVE_AGENT_STATUSES:
             raise RuntimeError(
-                f"Agent '{prepared_agent.id}' is already active (status={existing.status.value}). "
+                f"Agent '{agent.id}' is already active (status={existing.status.value}). "
                 f"Cannot submit concurrently. Use a different agent_id or enqueue_input()."
             )
 
-        self._rt.agents[prepared_agent.id] = prepared_agent
+        runtime_agent = await self._ensure_root_runtime_agent(agent, agent.id)
         resolved_session_id = session_id or str(uuid4())
         state = AgentState(
-            id=prepared_agent.id,
+            id=runtime_agent.id,
             session_id=resolved_session_id,
             status=AgentStateStatus.RUNNING,
             task=user_input,
@@ -253,8 +265,7 @@ class Scheduler:
                 f"Cannot enqueue input (expected IDLE or FAILED)."
             )
         if agent is not None:
-            prepared = await self._prepare_root_agent(agent, state_id)
-            await self._rebind_registered_agent(state_id, prepared)
+            await self._ensure_root_runtime_agent(agent, state_id)
 
         await self._save_state(state.with_queued(pending_input=user_input))
         self.nudge()
@@ -585,8 +596,8 @@ class Scheduler:
         *,
         urgent: bool = False,
     ) -> bool:
-        message = UserMessage.from_value(user_input).extract_text()
-        if not message:
+        message = UserMessage.from_value(user_input)
+        if not message.has_content():
             return False
 
         state = await self._store.get_state(state_id)
@@ -604,13 +615,12 @@ class Scheduler:
             target_agent_id=state_id,
             session_id=state.session_id,
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": message},
+            payload={"user_input": UserMessage.to_storage_value(message)},
             created_at=datetime.now(timezone.utc),
+            urgent=urgent,
         )
         await self._store.save_event(event)
         self.nudge()
-        if urgent and state.status == AgentStateStatus.WAITING:
-            self.nudge()
         return True
 
     async def shutdown(self, state_id: str) -> bool:
@@ -630,8 +640,7 @@ class Scheduler:
         ):
             return False
 
-        prepared = await self._prepare_root_agent(agent, state_id)
-        await self._rebind_registered_agent(state_id, prepared)
+        await self._ensure_root_runtime_agent(agent, state_id)
         return True
 
     async def tick(self) -> None:
@@ -705,25 +714,46 @@ class Scheduler:
                 if not waiters:
                     self._rt.waiters.pop(state_id, None)
 
-    async def _prepare_root_agent(self, agent: Agent, state_id: str) -> Agent:
-        clone = Agent(
-            agent.config,
-            id=state_id,
-            model=agent.model,
-            tools=list(agent.extra_tools) or None,
-            hooks=agent.hooks,
-        )
-        clone._inject_system_tools(list(self._scheduling_tools))
-        return clone
+    async def _ensure_root_runtime_agent(
+        self,
+        canonical_agent: Agent,
+        state_id: str,
+    ) -> Agent:
+        """Ensure a scheduler-managed runtime agent exists for ``state_id``.
 
-    async def _rebind_registered_agent(self, state_id: str, agent: Agent) -> None:
-        previous = self._rt.agents.get(state_id)
-        self._rt.agents[state_id] = agent
-        if previous is not None and previous is not agent:
+        **Identity rule (strict reuse):** if the cached canonical agent for
+        ``state_id`` is the *same Python object* as the caller-supplied one,
+        we reuse the existing runtime agent (preserving its ``run_step_storage``
+        / ``trace_storage`` / workspace state across turns).  Otherwise we
+        build a new runtime agent (clone + inject scheduler system tools),
+        close the previous runtime agent, and record the new canonical.
+        """
+        cached_canonical = self._rt.canonical_agents.get(state_id)
+        cached_runtime = self._rt.agents.get(state_id)
+        if cached_canonical is canonical_agent and cached_runtime is not None:
+            return cached_runtime
+
+        runtime_agent = Agent(
+            canonical_agent.config,
+            id=state_id,
+            model=canonical_agent.model,
+            tools=list(canonical_agent.extra_tools) or None,
+            hooks=canonical_agent.hooks,
+        )
+        runtime_agent._inject_system_tools(list(self._scheduling_tools))
+
+        previous_runtime = self._rt.agents.get(state_id)
+        self._rt.agents[state_id] = runtime_agent
+        self._rt.canonical_agents[state_id] = canonical_agent
+        if previous_runtime is not None and previous_runtime is not runtime_agent:
             try:
-                await previous.close()
+                await previous_runtime.close()
             except Exception:  # noqa: BLE001
-                logger.exception("scheduler_rebind_close_failed", state_id=state_id)
+                logger.exception(
+                    "scheduler_root_runtime_agent_close_failed",
+                    state_id=state_id,
+                )
+        return runtime_agent
 
     async def _enqueue_and_return_state_id(
         self,

--- a/agiwo/scheduler/engine.py
+++ b/agiwo/scheduler/engine.py
@@ -219,10 +219,10 @@ class Scheduler:
                 f"Cannot submit concurrently. Use a different agent_id or enqueue_input()."
             )
 
-        runtime_agent = await self._ensure_root_runtime_agent(agent, agent.id)
+        await self._ensure_root_runtime_agent(agent, agent.id)
         resolved_session_id = session_id or str(uuid4())
         state = AgentState(
-            id=runtime_agent.id,
+            id=agent.id,
             session_id=resolved_session_id,
             status=AgentStateStatus.RUNNING,
             task=user_input,
@@ -727,6 +727,13 @@ class Scheduler:
         / ``trace_storage`` / workspace state across turns).  Otherwise we
         build a new runtime agent (clone + inject scheduler system tools),
         close the previous runtime agent, and record the new canonical.
+
+        Common same-``state_id`` races are already constrained by
+        ``submit()`` rejecting concurrent roots in ``ACTIVE_AGENT_STATUSES``
+        and by ``_cleanup_after_run()`` eagerly closing non-persistent roots.
+        A rare concurrent rebind/pop edge case would still need a per-state
+        runtime lock if future changes keep returned runtime-agent references
+        alive across canonical swaps.
         """
         cached_canonical = self._rt.canonical_agents.get(state_id)
         cached_runtime = self._rt.agents.get(state_id)
@@ -744,7 +751,7 @@ class Scheduler:
 
         self._rt.agents[state_id] = runtime_agent
         self._rt.canonical_agents[state_id] = canonical_agent
-        if cached_runtime is not None and cached_runtime is not runtime_agent:
+        if cached_runtime is not None:
             try:
                 await cached_runtime.close()
             except Exception:  # noqa: BLE001

--- a/agiwo/scheduler/engine.py
+++ b/agiwo/scheduler/engine.py
@@ -742,12 +742,11 @@ class Scheduler:
         )
         runtime_agent._inject_system_tools(list(self._scheduling_tools))
 
-        previous_runtime = self._rt.agents.get(state_id)
         self._rt.agents[state_id] = runtime_agent
         self._rt.canonical_agents[state_id] = canonical_agent
-        if previous_runtime is not None and previous_runtime is not runtime_agent:
+        if cached_runtime is not None and cached_runtime is not runtime_agent:
             try:
-                await previous_runtime.close()
+                await cached_runtime.close()
             except Exception:  # noqa: BLE001
                 logger.exception(
                     "scheduler_root_runtime_agent_close_failed",

--- a/agiwo/scheduler/formatting.py
+++ b/agiwo/scheduler/formatting.py
@@ -142,8 +142,9 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
         child_id = event.payload.get(
             "child_agent_id", event.source_agent_id or "unknown"
         )
-        lines.append(f"### {event_label} - Agent: {child_id}")
+        header = f"### {event_label} - Agent: {child_id}"
         if event.event_type == SchedulerEventType.CHILD_SLEEP_RESULT:
+            lines.append(header)
             lines.extend(
                 build_child_result_detail_lines(
                     result=event.payload.get("result", ""),
@@ -153,6 +154,7 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
                 )
             )
         elif event.event_type == SchedulerEventType.CHILD_COMPLETED:
+            lines.append(header)
             lines.extend(
                 build_child_result_detail_lines(
                     result=event.payload.get("result", ""),
@@ -160,6 +162,7 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
                 )
             )
         elif event.event_type == SchedulerEventType.CHILD_FAILED:
+            lines.append(header)
             lines.extend(
                 build_child_result_detail_lines(
                     failure_reason=event.payload.get("reason", "Unknown failure")
@@ -168,6 +171,7 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
         elif event.event_type == SchedulerEventType.USER_HINT:
             hint_message = _decode_user_hint_message(event)
             if hint_message is not None:
+                lines.append(header)
                 for part in hint_message.content:
                     if part.type == ContentType.TEXT:
                         if part.text and part.text.strip():
@@ -176,7 +180,13 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
                         extra_parts.append(part)
                 if channel_context is None and hint_message.context is not None:
                     channel_context = hint_message.context
-        lines.append("")
+                lines.append("")
+        else:
+            lines.append(header)
+            lines.append("")
+            continue
+        if event.event_type != SchedulerEventType.USER_HINT:
+            lines.append("")
     lines.append(
         "Please review these notifications and take appropriate action "
         "(e.g., summarize results for the user, cancel stuck agents, etc.)."

--- a/agiwo/scheduler/formatting.py
+++ b/agiwo/scheduler/formatting.py
@@ -134,7 +134,7 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
     events are rendered into the narrative text block; USER_HINT events
     contribute both text and non-text ``ContentPart`` entries.
     """
-    lines = [f"You have {len(events)} new notification(s):\n"]
+    lines = [f"You have {len(events)} new notification(s):", ""]
     extra_parts: list[ContentPart] = []
     channel_context: ChannelContext | None = None
     for event in events:
@@ -169,9 +169,11 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
                 )
             )
         elif event.event_type == SchedulerEventType.USER_HINT:
+            lines.append(header)
             hint_message = _decode_user_hint_message(event)
-            if hint_message is not None:
-                lines.append(header)
+            if hint_message is None:
+                lines.append("User hint: (undecodable payload)")
+            else:
                 for part in hint_message.content:
                     if part.type == ContentType.TEXT:
                         if part.text and part.text.strip():
@@ -180,7 +182,7 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
                         extra_parts.append(part)
                 if channel_context is None and hint_message.context is not None:
                     channel_context = hint_message.context
-                lines.append("")
+            lines.append("")
         else:
             lines.append(header)
             lines.append("")

--- a/agiwo/scheduler/formatting.py
+++ b/agiwo/scheduler/formatting.py
@@ -1,13 +1,29 @@
 """Shared formatting helpers for scheduler-facing child-agent text."""
 
-from agiwo.agent import UserInput, UserMessage
-from agiwo.agent.prompt import system_notice
+from agiwo.agent import (
+    ChannelContext,
+    ContentPart,
+    ContentType,
+    UserInput,
+    UserMessage,
+)
 from agiwo.scheduler.models import (
     PendingEvent,
     SchedulerEventType,
     WakeCondition,
     WakeType,
 )
+
+
+def _system_notice(content: str) -> str:
+    """Render a ``<system-notice>`` tag.
+
+    Local mirror of ``agiwo.agent.prompt.system_notice`` so the scheduler
+    layer does not reach into internal agent execution modules (enforced by
+    ``repo_guard AGW003``).
+    """
+    return f"<system-notice>{content}</system-notice>"
+
 
 SHUTDOWN_SUMMARY_TASK = (
     "System shutdown requested. Please produce a final summary "
@@ -110,9 +126,17 @@ def build_timeout_message(
     )
 
 
-def build_events_message(events: tuple[PendingEvent, ...]) -> str:
-    """Build the user-facing message for pending event notifications."""
+def build_events_message(events: tuple[PendingEvent, ...]) -> UserMessage:
+    """Build the user-facing message for pending event notifications.
+
+    Returns a ``UserMessage`` so that attachments and ``ChannelContext``
+    carried by USER_HINT events survive into the next run.  Child-agent
+    events are rendered into the narrative text block; USER_HINT events
+    contribute both text and non-text ``ContentPart`` entries.
+    """
     lines = [f"You have {len(events)} new notification(s):\n"]
+    extra_parts: list[ContentPart] = []
+    channel_context: ChannelContext | None = None
     for event in events:
         event_label = event.event_type.value.replace("_", " ").title()
         child_id = event.payload.get(
@@ -142,15 +166,36 @@ def build_events_message(events: tuple[PendingEvent, ...]) -> str:
                 )
             )
         elif event.event_type == SchedulerEventType.USER_HINT:
-            hint = event.payload.get("hint", "")
-            if hint:
-                lines.append(f"User hint: {hint}")
+            hint_message = _decode_user_hint_message(event)
+            if hint_message is not None:
+                for part in hint_message.content:
+                    if part.type == ContentType.TEXT:
+                        if part.text and part.text.strip():
+                            lines.append(f"User hint: {part.text.strip()}")
+                    else:
+                        extra_parts.append(part)
+                if channel_context is None and hint_message.context is not None:
+                    channel_context = hint_message.context
         lines.append("")
     lines.append(
         "Please review these notifications and take appropriate action "
         "(e.g., summarize results for the user, cancel stuck agents, etc.)."
     )
-    return "\n".join(lines)
+    text_body = "\n".join(lines)
+    parts: list[ContentPart] = [ContentPart(type=ContentType.TEXT, text=text_body)]
+    parts.extend(extra_parts)
+    return UserMessage(content=parts, context=channel_context)
+
+
+def _decode_user_hint_message(event: PendingEvent) -> UserMessage | None:
+    stored = event.payload.get("user_input")
+    if stored is None:
+        return None
+    decoded = UserMessage.from_storage_value(stored)
+    if decoded is None:
+        return None
+    message = UserMessage.from_value(decoded)
+    return message if message.has_content() else None
 
 
 def summarize_text(text: str | None, limit: int) -> str | None:
@@ -162,7 +207,7 @@ def summarize_text(text: str | None, limit: int) -> str | None:
     return text[:limit] + "..."
 
 
-_FORK_NOTICE = system_notice(
+_FORK_NOTICE = _system_notice(
     "You are a forked child agent. Your conversation history has been "
     "inherited from the parent agent. Do NOT use spawn_agent — it is "
     "unavailable to you. Complete the following task directly."

--- a/agiwo/scheduler/models.py
+++ b/agiwo/scheduler/models.py
@@ -5,10 +5,9 @@ This module owns the persisted scheduler state snapshot plus related enums and
 configuration models.
 """
 
-import copy
 from collections.abc import Collection, Mapping
 from copy import deepcopy
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 from enum import Enum
 from types import MappingProxyType
@@ -22,12 +21,20 @@ from agiwo.skill.allowlist import (
 
 
 def _deepcopy_mapping_proxy(
-    x: MappingProxyType, memo: dict[int, Any]
+    value: MappingProxyType, memo: dict[int, object]
 ) -> MappingProxyType:
-    return MappingProxyType(deepcopy(dict(x), memo))
+    """Deepcopy helper for ``MappingProxyType``.
 
-
-copy._deepcopy_dispatch[MappingProxyType] = _deepcopy_mapping_proxy
+    Python 3.10 / 3.11 cannot natively ``deepcopy`` a ``MappingProxyType``
+    (support landed in 3.12).  We handle it explicitly inside the
+    ``__deepcopy__`` methods of the data classes that carry frozen proxies,
+    rather than mutating the global ``copy._deepcopy_dispatch`` table.
+    Nested values are routed through :func:`_deepcopy_frozen_field` so that
+    inner ``MappingProxyType`` / ``tuple`` structures are cloned correctly.
+    """
+    return MappingProxyType(
+        {key: _deepcopy_frozen_field(item, memo) for key, item in value.items()}
+    )
 
 
 class AgentStateStatus(str, Enum):
@@ -119,6 +126,35 @@ def thaw_value(value: object) -> object:
     if isinstance(value, tuple):
         return [thaw_value(item) for item in value]
     return value
+
+
+def _deepcopy_frozen_field(value: object, memo: dict[int, object]) -> object:
+    """Deepcopy a field, handling ``MappingProxyType`` / frozen tuples explicitly.
+
+    The stdlib ``deepcopy`` cannot clone ``MappingProxyType`` on Python 3.10
+    / 3.11, and frozen tuples may contain further ``MappingProxyType`` items
+    after ``_freeze_value`` normalization.  This helper recurses through
+    both structures so that we do not need the old global
+    ``copy._deepcopy_dispatch`` monkey-patch.
+    """
+    if isinstance(value, MappingProxyType):
+        return _deepcopy_mapping_proxy(value, memo)
+    if isinstance(value, tuple):
+        return tuple(_deepcopy_frozen_field(item, memo) for item in value)
+    return deepcopy(value, memo)
+
+
+def _deepcopy_dataclass_with_frozen_mappings(
+    instance: object, memo: dict[int, object]
+) -> object:
+    """Deepcopy helper for frozen-slots dataclasses carrying ``MappingProxyType``."""
+    cls = type(instance)
+    new = cls.__new__(cls)
+    memo[id(instance)] = new
+    for f in fields(instance):
+        cloned = _deepcopy_frozen_field(getattr(instance, f.name), memo)
+        object.__setattr__(new, f.name, cloned)
+    return new
 
 
 @dataclass(frozen=True, slots=True)
@@ -257,6 +293,9 @@ class AgentState:
             if isinstance(self.config_overrides, MappingProxyType)
             else _freeze_value(self.config_overrides),
         )
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "AgentState":
+        return _deepcopy_dataclass_with_frozen_mappings(self, memo)  # type: ignore[return-value]
 
     @property
     def is_root(self) -> bool:
@@ -402,7 +441,12 @@ class AgentState:
 
 @dataclass(frozen=True, slots=True)
 class PendingEvent:
-    """An event in an agent's pending event queue."""
+    """An event in an agent's pending event queue.
+
+    ``urgent`` marks events that must bypass tick-level debounce (e.g. a
+    user-initiated steer to a WAITING root). Non-urgent events continue to
+    follow the normal ``event_debounce_*`` rules.
+    """
 
     id: str
     target_agent_id: str
@@ -411,6 +455,7 @@ class PendingEvent:
     payload: Mapping[str, Any]
     created_at: datetime
     source_agent_id: str | None = None
+    urgent: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -420,6 +465,9 @@ class PendingEvent:
             if isinstance(self.payload, MappingProxyType)
             else _freeze_value(self.payload),
         )
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "PendingEvent":
+        return _deepcopy_dataclass_with_frozen_mappings(self, memo)  # type: ignore[return-value]
 
     def with_payload(self, payload: Mapping[str, Any]) -> "PendingEvent":
         return replace(self, payload=_freeze_value(payload))
@@ -440,6 +488,9 @@ class AgentStateStorageConfig:
             if isinstance(self.config, MappingProxyType)
             else _freeze_value(self.config),
         )
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "AgentStateStorageConfig":
+        return _deepcopy_dataclass_with_frozen_mappings(self, memo)  # type: ignore[return-value]
 
 
 @dataclass(frozen=True, slots=True)

--- a/agiwo/scheduler/runner.py
+++ b/agiwo/scheduler/runner.py
@@ -412,7 +412,7 @@ class SchedulerRunner:
         if current_state is None:
             return
 
-        if await self._maybe_preserve_or_finalize_aborted_terminal(current_state):
+        if await self._finalize_if_aborted_terminal(current_state):
             return
 
         text = output.response
@@ -598,11 +598,11 @@ class SchedulerRunner:
                 failed[child_id] = f"Not finished: status={child.status.value}"
         return succeeded, failed
 
-    async def _maybe_preserve_or_finalize_aborted_terminal(
+    async def _finalize_if_aborted_terminal(
         self,
         state: AgentState,
     ) -> bool:
-        """Short-circuit when a state is already terminal due to abort.
+        """Finalize terminal aborted states before further result handling.
 
         Returns ``True`` when the caller should stop further result handling.
 

--- a/agiwo/scheduler/runner.py
+++ b/agiwo/scheduler/runner.py
@@ -94,7 +94,11 @@ class SchedulerRunner:
                     session_id=state.resolve_runtime_session_id(),
                     abort_signal=abort_signal,
                 )
-                await self._handle_agent_output(action, output)
+                # ``_finalize_if_aborted_terminal()`` relies on the abort signal
+                # surviving until output handling finishes; the map entry is
+                # only removed in the ``finally`` block below via
+                # ``abort_signals.pop(...)``.
+                await self._handle_agent_output(action, output, abort_signal)
         except Exception as error:  # noqa: BLE001
             logger.exception(
                 "scheduler_dispatch_failed",
@@ -406,13 +410,14 @@ class SchedulerRunner:
         self,
         action: DispatchAction,
         output: RunOutput,
+        abort_signal: AbortSignal | None,
     ) -> None:
         state = action.state
         current_state = await self._ctx.store.get_state(state.id)
         if current_state is None:
             return
 
-        if await self._finalize_if_aborted_terminal(current_state):
+        if await self._finalize_if_aborted_terminal(current_state, abort_signal):
             return
 
         text = output.response
@@ -601,18 +606,27 @@ class SchedulerRunner:
     async def _finalize_if_aborted_terminal(
         self,
         state: AgentState,
+        abort_signal: AbortSignal | None,
     ) -> bool:
         """Finalize terminal aborted states before further result handling.
 
         Returns ``True`` when the caller should stop further result handling.
 
         - If the state is already terminal and aborted, preserve whatever
-          ``last_run_result`` was written by the cancel/shutdown path.
+          ``last_run_result`` was written by the cancel/shutdown path so
+          ``wait_for()`` can return immediately with ``SchedulerRunResult``
+          carrying ``termination_reason=CANCELLED``.
         - As a defensive fallback, if the terminal+aborted state has no
           ``last_run_result`` yet, write a ``CANCELLED`` record so that
           ``wait_for()`` returns promptly instead of waiting on timeout.
         """
-        abort_signal = self._ctx.rt.abort_signals.get(state.id)
+        cached_abort_signal = self._ctx.rt.abort_signals.get(state.id)
+        if abort_signal is None:
+            abort_signal = cached_abort_signal
+        elif cached_abort_signal is not None:
+            assert cached_abort_signal is abort_signal, (
+                "abort_signals cache diverged before output finalization"
+            )
         if not (
             state.is_terminal()
             and abort_signal is not None

--- a/agiwo/scheduler/runner.py
+++ b/agiwo/scheduler/runner.py
@@ -412,7 +412,7 @@ class SchedulerRunner:
         if current_state is None:
             return
 
-        if self._should_preserve_terminal_abort(current_state):
+        if await self._maybe_preserve_or_finalize_aborted_terminal(current_state):
             return
 
         text = output.response
@@ -516,21 +516,34 @@ class SchedulerRunner:
 
     async def _cleanup_after_run(self, state: AgentState) -> None:
         self._ctx.rt.dispatched.discard(state.id)
+        refreshed = await self._ctx.store.get_state(state.id)
+
         if state.is_root:
-            refreshed = await self._ctx.store.get_state(state.id)
             if self._should_finish_root_stream_channel(state.id, refreshed):
                 await self._finish_stream_channel(state.id)
+            if not state.is_persistent and (
+                refreshed is None
+                or refreshed.status
+                in (AgentStateStatus.COMPLETED, AgentStateStatus.FAILED)
+            ):
+                await self._pop_and_close_agent(state.id)
             return
 
-        refreshed = await self._ctx.store.get_state(state.id)
         if refreshed is None or refreshed.status in (
             AgentStateStatus.COMPLETED,
             AgentStateStatus.FAILED,
         ):
-            agent = self._ctx.rt.agents.pop(state.id, None)
-            self._ctx.rt.execution_handles.pop(state.id, None)
-            if agent is not None:
+            await self._pop_and_close_agent(state.id)
+
+    async def _pop_and_close_agent(self, state_id: str) -> None:
+        agent = self._ctx.rt.agents.pop(state_id, None)
+        self._ctx.rt.canonical_agents.pop(state_id, None)
+        self._ctx.rt.execution_handles.pop(state_id, None)
+        if agent is not None:
+            try:
                 await agent.close()
+            except Exception:  # noqa: BLE001
+                logger.exception("scheduler_agent_close_failed", state_id=state_id)
 
     async def _finish_stream_channel(self, state_id: str) -> None:
         channel = self._ctx.rt.stream_channels.get(state_id)
@@ -585,13 +598,40 @@ class SchedulerRunner:
                 failed[child_id] = f"Not finished: status={child.status.value}"
         return succeeded, failed
 
-    def _should_preserve_terminal_abort(self, state: AgentState) -> bool:
+    async def _maybe_preserve_or_finalize_aborted_terminal(
+        self,
+        state: AgentState,
+    ) -> bool:
+        """Short-circuit when a state is already terminal due to abort.
+
+        Returns ``True`` when the caller should stop further result handling.
+
+        - If the state is already terminal and aborted, preserve whatever
+          ``last_run_result`` was written by the cancel/shutdown path.
+        - As a defensive fallback, if the terminal+aborted state has no
+          ``last_run_result`` yet, write a ``CANCELLED`` record so that
+          ``wait_for()`` returns promptly instead of waiting on timeout.
+        """
         abort_signal = self._ctx.rt.abort_signals.get(state.id)
-        return (
+        if not (
             state.is_terminal()
             and abort_signal is not None
             and abort_signal.is_aborted()
-        )
+        ):
+            return False
+
+        if state.last_run_result is None:
+            reason = abort_signal.reason or "Cancelled"
+            await self._save_state(
+                state.with_updates(
+                    last_run_result=self._build_last_run_result(
+                        termination_reason=TerminationReason.CANCELLED,
+                        run_id=None,
+                        error=reason,
+                    )
+                )
+            )
+        return True
 
     async def _handle_shutdown_requested(
         self,

--- a/agiwo/scheduler/runtime_state.py
+++ b/agiwo/scheduler/runtime_state.py
@@ -7,7 +7,16 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
-from agiwo.agent import Agent, AgentStreamItem, RunOutput, UserInput, UserMessage
+from agiwo.agent import (
+    Agent,
+    AgentStreamItem,
+    ChannelContext,
+    ContentPart,
+    ContentType,
+    RunOutput,
+    UserInput,
+    UserMessage,
+)
 from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
@@ -58,28 +67,107 @@ def build_mailbox_input(
     pending_input: UserInput | None,
     events: tuple[PendingEvent, ...],
 ) -> UserInput | None:
-    if not events:
+    """Merge a pending root input with queued USER_HINT events.
+
+    The result preserves structured content:
+
+    - ``ContentPart`` entries from the pending input and each hint ``UserMessage``
+      are combined (text parts are flattened into a single "Additional queued
+      user input" block; non-text parts are appended intact so attachments
+      survive into the next run).
+    - ``ChannelContext`` from the pending input takes precedence; otherwise we
+      fall back to the first USER_HINT with a ``ChannelContext``.
+    """
+    hint_messages = _extract_hint_messages(events)
+    if not hint_messages and pending_input is None:
+        return None
+    if not hint_messages:
         return pending_input
 
-    base_text = ""
-    if pending_input is not None:
-        base_text = UserMessage.from_value(pending_input).extract_text() or str(
-            pending_input
+    base_message = (
+        UserMessage.from_value(pending_input) if pending_input is not None else None
+    )
+    base_text_parts, base_media_parts = _split_content_parts(base_message)
+
+    hint_text_fragments: list[str] = []
+    hint_media_parts: list[ContentPart] = []
+    hint_context: ChannelContext | None = None
+    for hint_message in hint_messages:
+        text_parts, media_parts = _split_content_parts(hint_message)
+        for text_part in text_parts:
+            if text_part.text and text_part.text.strip():
+                hint_text_fragments.append(text_part.text.strip())
+        hint_media_parts.extend(media_parts)
+        if hint_context is None and hint_message.context is not None:
+            hint_context = hint_message.context
+
+    if not hint_text_fragments and not hint_media_parts:
+        return pending_input
+
+    merged_parts: list[ContentPart] = []
+    base_text = "\n".join(part.text for part in base_text_parts if part.text).strip()
+    hint_block = "\n".join(f"- {fragment}" for fragment in hint_text_fragments)
+    if base_text and hint_block:
+        merged_parts.append(
+            ContentPart(
+                type=ContentType.TEXT,
+                text=f"{base_text}\n\nAdditional queued user input:\n{hint_block}",
+            )
         )
+    elif hint_block:
+        merged_parts.append(
+            ContentPart(
+                type=ContentType.TEXT,
+                text=f"Additional queued user input:\n{hint_block}",
+            )
+        )
+    elif base_text:
+        merged_parts.append(ContentPart(type=ContentType.TEXT, text=base_text))
 
-    hints = [
-        event.payload.get("hint", "").strip()
-        for event in events
-        if event.event_type == SchedulerEventType.USER_HINT
-        and event.payload.get("hint", "").strip()
-    ]
-    if not hints:
-        return pending_input
+    merged_parts.extend(base_media_parts)
+    merged_parts.extend(hint_media_parts)
 
-    hint_block = "\n".join(f"- {hint}" for hint in hints)
-    if not base_text:
-        return f"Additional queued user input:\n{hint_block}"
-    return f"{base_text}\n\nAdditional queued user input:\n{hint_block}"
+    context = None
+    if base_message is not None and base_message.context is not None:
+        context = base_message.context
+    elif hint_context is not None:
+        context = hint_context
+
+    return UserMessage(content=merged_parts, context=context)
+
+
+def _extract_hint_messages(
+    events: tuple[PendingEvent, ...],
+) -> list[UserMessage]:
+    messages: list[UserMessage] = []
+    for event in events:
+        if event.event_type != SchedulerEventType.USER_HINT:
+            continue
+        stored = event.payload.get("user_input")
+        if stored is None:
+            continue
+        decoded = UserMessage.from_storage_value(stored)
+        if decoded is None:
+            continue
+        message = UserMessage.from_value(decoded)
+        if message.has_content():
+            messages.append(message)
+    return messages
+
+
+def _split_content_parts(
+    message: UserMessage | None,
+) -> tuple[list[ContentPart], list[ContentPart]]:
+    if message is None:
+        return [], []
+    text_parts: list[ContentPart] = []
+    media_parts: list[ContentPart] = []
+    for part in message.content:
+        if part.type == ContentType.TEXT:
+            text_parts.append(part)
+        else:
+            media_parts.append(part)
+    return text_parts, media_parts
 
 
 async def list_all_states(
@@ -115,9 +203,17 @@ class ExecutionHandleLike(Protocol):
 
 @dataclass
 class RuntimeState:
-    """Process-local runtime state only."""
+    """Process-local runtime state only.
+
+    ``agents`` holds the scheduler-managed runtime agents (clones of the
+    caller-supplied canonical Agent with scheduler system tools injected).
+    ``canonical_agents`` records the last canonical Agent *identity* mapped
+    to each state_id so the scheduler can decide whether a ``submit`` /
+    ``enqueue_input`` call should reuse the cached runtime agent or rebind.
+    """
 
     agents: dict[str, Agent] = field(default_factory=dict)
+    canonical_agents: dict[str, Agent] = field(default_factory=dict)
     execution_handles: dict[str, ExecutionHandleLike] = field(default_factory=dict)
     abort_signals: dict[str, AbortSignal] = field(default_factory=dict)
     waiters: dict[str, set[asyncio.Event]] = field(default_factory=dict)

--- a/agiwo/scheduler/store/sqlite.py
+++ b/agiwo/scheduler/store/sqlite.py
@@ -99,7 +99,8 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                     event_type TEXT NOT NULL,
                     payload_json TEXT NOT NULL DEFAULT '{}',
                     source_agent_id TEXT,
-                    created_at TEXT NOT NULL
+                    created_at TEXT NOT NULL,
+                    urgent INTEGER NOT NULL DEFAULT 0
                 )
                 """,
                 "CREATE INDEX IF NOT EXISTS idx_pending_events_target ON pending_events(target_agent_id, session_id)",
@@ -176,6 +177,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
             payload=json.loads(row["payload_json"]),
             source_agent_id=row.get("source_agent_id"),
             created_at=datetime.fromisoformat(row["created_at"]),
+            urgent=bool(row.get("urgent", 0)),
         )
 
     def _wake_condition_columns(self) -> list[str]:
@@ -320,8 +322,9 @@ class SQLiteAgentStateStorage(AgentStateStorage):
         await conn.execute(
             """
             INSERT OR REPLACE INTO pending_events
-                (id, target_agent_id, session_id, event_type, payload_json, source_agent_id, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (id, target_agent_id, session_id, event_type, payload_json,
+                 source_agent_id, created_at, urgent)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 event.id,
@@ -331,6 +334,7 @@ class SQLiteAgentStateStorage(AgentStateStorage):
                 json.dumps(thaw_value(event.payload)),
                 event.source_agent_id,
                 event.created_at.isoformat(),
+                1 if event.urgent else 0,
             ),
         )
         await conn.commit()

--- a/console/tests/test_scheduler_api.py
+++ b/console/tests/test_scheduler_api.py
@@ -24,7 +24,7 @@ from agiwo.scheduler.models import (
     WakeType,
     TimeUnit,
 )
-from agiwo.agent import TerminationReason
+from agiwo.agent import TerminationReason, UserMessage
 from agiwo.scheduler.engine import Scheduler
 
 from server.app import create_app
@@ -244,7 +244,7 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             target_agent_id="root-tree",
             session_id="sess-tree",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "Root hint"},
+            payload={"user_input": UserMessage.to_storage_value("Root hint")},
             created_at=base_time.replace(minute=10),
         ),
         PendingEvent(
@@ -261,7 +261,7 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             target_agent_id="child-running",
             session_id="sess-tree",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "Second hint"},
+            payload={"user_input": UserMessage.to_storage_value("Second hint")},
             created_at=base_time.replace(minute=12),
         ),
         PendingEvent(
@@ -269,7 +269,7 @@ async def _seed_tree_states(client: AsyncClient) -> None:
             target_agent_id="grandchild-completed",
             session_id="sess-tree",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "Nested hint"},
+            payload={"user_input": UserMessage.to_storage_value("Nested hint")},
             created_at=base_time.replace(minute=13),
         ),
     ]

--- a/tests/scheduler/test_models.py
+++ b/tests/scheduler/test_models.py
@@ -1,6 +1,8 @@
 """Tests for scheduler data models."""
 
+import copy
 from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
 
 from agiwo.agent import TerminationReason
 from agiwo.scheduler.models import (
@@ -232,6 +234,67 @@ class TestPendingEvent:
         assert event.event_type == SchedulerEventType.CHILD_COMPLETED
         assert event.payload["result"] == "done"
         assert event.source_agent_id == "child-agent"
+        assert event.urgent is False
+
+    def test_urgent_flag_defaults_false_and_can_be_set(self):
+        now = datetime.now(timezone.utc)
+        urgent_event = PendingEvent(
+            id="evt-u",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={"user_input": "hi"},
+            created_at=now,
+            urgent=True,
+        )
+        normal_event = PendingEvent(
+            id="evt-n",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={"user_input": "hi"},
+            created_at=now,
+        )
+        assert urgent_event.urgent is True
+        assert normal_event.urgent is False
+
+
+class TestMappingProxyDeepcopy:
+    """Regression guard against the old ``copy._deepcopy_dispatch`` hack."""
+
+    def test_agent_state_deepcopy_preserves_frozen_mapping(self):
+        state = AgentState(
+            id="deep-1",
+            session_id="sess",
+            status=AgentStateStatus.RUNNING,
+            task="task",
+            config_overrides={"nested": {"key": "value"}, "list": [1, 2]},
+        )
+        cloned = copy.deepcopy(state)
+        assert cloned is not state
+        assert cloned.config_overrides["nested"]["key"] == "value"
+        assert tuple(cloned.config_overrides["list"]) == (1, 2)
+
+    def test_pending_event_deepcopy_preserves_payload(self):
+        now = datetime.now(timezone.utc)
+        event = PendingEvent(
+            id="deep-2",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={"user_input": "hi", "nested": {"k": "v"}},
+            created_at=now,
+        )
+        cloned = copy.deepcopy(event)
+        assert cloned is not event
+        assert cloned.payload["user_input"] == "hi"
+        assert cloned.payload["nested"]["k"] == "v"
+
+    def test_mapping_proxy_not_in_global_dispatch(self):
+        """The scheduler.models import must not mutate ``copy._deepcopy_dispatch``."""
+        # Importing models already triggered any side effects; the dispatch
+        # table should not carry a scheduler-specific handler anymore.
+        assert MappingProxyType not in copy._deepcopy_dispatch
 
 
 class TestSchedulerConfig:

--- a/tests/scheduler/test_models.py
+++ b/tests/scheduler/test_models.py
@@ -294,7 +294,8 @@ class TestMappingProxyDeepcopy:
         """The scheduler.models import must not mutate ``copy._deepcopy_dispatch``."""
         # Importing models already triggered any side effects; the dispatch
         # table should not carry a scheduler-specific handler anymore.
-        assert MappingProxyType not in copy._deepcopy_dispatch
+        dispatch = getattr(copy, "_deepcopy_dispatch", {})
+        assert MappingProxyType not in dispatch
 
 
 class TestSchedulerConfig:

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -12,6 +12,7 @@ from agiwo.agent import Agent
 from agiwo.agent import AgentConfig, AgentOptions
 from agiwo.agent import AgentHooks
 from agiwo.agent import AgentStreamItem, RunCompletedEvent, TerminationReason
+from agiwo.agent import ChannelContext, ContentPart, ContentType
 from agiwo.agent.models.step import MessageRole, StepRecord, UserMessage
 from agiwo.utils.abort_signal import AbortSignal
 from agiwo.llm.base import Model, StreamChunk
@@ -1096,6 +1097,32 @@ class TestSchedulerCancel:
             s = await store.get_state(sid)
             assert s.status == AgentStateStatus.FAILED
             assert s.result_summary == "test cancel"
+            assert s.last_run_result is not None
+            assert s.last_run_result.termination_reason == TerminationReason.CANCELLED
+            assert s.last_run_result.error == "test cancel"
+
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_cancel_releases_wait_for_immediately(self):
+        """wait_for() must return promptly with CANCELLED once cancel completes."""
+        scheduler = Scheduler(_fast_config())
+        store = scheduler._store
+
+        root = AgentState(
+            id="wait-cancel",
+            session_id="sess",
+            status=AgentStateStatus.RUNNING,
+            task="root",
+            parent_id=None,
+        )
+        await store.save_state(root)
+
+        await scheduler.cancel("wait-cancel", "stop it")
+
+        output = await scheduler.wait_for("wait-cancel", timeout=2.0)
+        assert output.termination_reason == TerminationReason.CANCELLED
+        assert output.error == "stop it"
 
         await scheduler.stop()
 
@@ -1172,7 +1199,7 @@ class TestSchedulerDebounce:
             target_agent_id="agent-running",
             session_id="sess",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "check this"},
+            payload={"user_input": UserMessage.to_storage_value("check this")},
             source_agent_id=None,
             created_at=datetime.now(timezone.utc),
         )
@@ -1294,7 +1321,7 @@ class TestSchedulerDebounce:
                 target_agent_id="parent-timeout",
                 session_id="sess",
                 event_type=SchedulerEventType.USER_HINT,
-                payload={"hint": "still here"},
+                payload={"user_input": UserMessage.to_storage_value("still here")},
                 source_agent_id=None,
                 created_at=datetime.now(timezone.utc),
             )
@@ -1418,3 +1445,220 @@ class TestSchedulerWaiters:
         assert first.termination_reason == TerminationReason.COMPLETED
         assert second.termination_reason == TerminationReason.COMPLETED
         assert first.response == second.response
+
+
+class TestSchedulerSteer:
+    @pytest.mark.asyncio
+    async def test_steer_urgent_writes_urgent_pending_event(self):
+        """steer(..., urgent=True) on WAITING state must set PendingEvent.urgent."""
+        scheduler = Scheduler(_fast_config())
+        await scheduler._store.save_state(
+            AgentState(
+                id="waiting-root",
+                session_id="sess",
+                status=AgentStateStatus.WAITING,
+                task="root",
+                parent_id=None,
+            )
+        )
+
+        ok = await scheduler.steer("waiting-root", "please continue", urgent=True)
+        assert ok is True
+
+        events = await scheduler._store.list_events(
+            target_agent_id="waiting-root",
+            session_id="sess",
+        )
+        assert len(events) == 1
+        event = events[0]
+        assert event.event_type == SchedulerEventType.USER_HINT
+        assert event.urgent is True
+        # Payload uses the new structured ``user_input`` key only.
+        assert "hint" not in event.payload
+        decoded = UserMessage.from_storage_value(event.payload["user_input"])
+        assert UserMessage.from_value(decoded).extract_text() == "please continue"
+
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_steer_defaults_to_non_urgent(self):
+        scheduler = Scheduler(_fast_config())
+        await scheduler._store.save_state(
+            AgentState(
+                id="waiting-root",
+                session_id="sess",
+                status=AgentStateStatus.WAITING,
+                task="root",
+                parent_id=None,
+            )
+        )
+
+        await scheduler.steer("waiting-root", "just a hint")
+
+        events = await scheduler._store.list_events(
+            target_agent_id="waiting-root",
+            session_id="sess",
+        )
+        assert len(events) == 1
+        assert events[0].urgent is False
+
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_steer_preserves_structured_user_input(self):
+        """Multimodal UserMessage must round-trip through the PendingEvent payload."""
+        scheduler = Scheduler(_fast_config())
+        await scheduler._store.save_state(
+            AgentState(
+                id="waiting-root",
+                session_id="sess",
+                status=AgentStateStatus.WAITING,
+                task="root",
+                parent_id=None,
+            )
+        )
+
+        user_input = UserMessage(
+            content=[
+                ContentPart(type=ContentType.TEXT, text="look at this image"),
+                ContentPart(
+                    type=ContentType.IMAGE,
+                    url="/tmp/image.png",
+                    mime_type="image/png",
+                    metadata={"name": "image.png"},
+                ),
+            ],
+            context=ChannelContext(source="feishu", metadata={"chat_id": "oc-1"}),
+        )
+
+        await scheduler.steer("waiting-root", user_input, urgent=True)
+
+        events = await scheduler._store.list_events(
+            target_agent_id="waiting-root",
+            session_id="sess",
+        )
+        assert len(events) == 1
+        payload_user_input = events[0].payload["user_input"]
+        decoded = UserMessage.from_value(
+            UserMessage.from_storage_value(payload_user_input)
+        )
+        # Text, image, and ChannelContext must all survive persistence.
+        assert decoded.extract_text() == "look at this image"
+        image_parts = [p for p in decoded.content if p.type == ContentType.IMAGE]
+        assert len(image_parts) == 1
+        assert image_parts[0].url == "/tmp/image.png"
+        assert decoded.context is not None
+        assert decoded.context.source == "feishu"
+        assert decoded.context.metadata["chat_id"] == "oc-1"
+
+        await scheduler.stop()
+
+
+class TestSchedulerRuntimeAgentReuse:
+    @pytest.mark.asyncio
+    async def test_persistent_root_reuses_runtime_agent_across_turns(self):
+        """Persistent roots must preserve their run_step_storage across turns.
+
+        This guards against the earlier bug where ``submit`` / ``enqueue_input``
+        cloned the ``Agent`` on every call and, under the default in-memory
+        storage backend, silently lost prior step history.
+        """
+        async with Scheduler(_fast_config()) as scheduler:
+            model = MockModel(
+                [
+                    _simple_completion("first response"),
+                    _simple_completion("second response"),
+                ]
+            )
+            canonical = _make_agent(
+                name="persist",
+                model=model,
+                id="persist",
+                tools=[],
+            )
+
+            state_id = await scheduler.submit(
+                canonical,
+                "first turn",
+                session_id="sess-persist",
+                persistent=True,
+            )
+            first_output = await scheduler.wait_for(state_id, timeout=_TEST_RUN_TIMEOUT)
+            assert first_output.termination_reason == TerminationReason.COMPLETED
+            runtime_after_first = scheduler.get_registered_agent(state_id)
+            assert runtime_after_first is not None
+
+            storage_after_first = runtime_after_first.run_step_storage
+            steps_after_first = await storage_after_first.get_steps(
+                session_id="sess-persist",
+                agent_id=state_id,
+            )
+
+            await scheduler.enqueue_input(
+                state_id,
+                "second turn",
+                agent=canonical,
+            )
+            second_output = await scheduler.wait_for(
+                state_id, timeout=_TEST_RUN_TIMEOUT
+            )
+            assert second_output.termination_reason == TerminationReason.COMPLETED
+
+            runtime_after_second = scheduler.get_registered_agent(state_id)
+            # Strict reuse: same Python runtime agent, same storage instance.
+            assert runtime_after_second is runtime_after_first
+            assert runtime_after_second.run_step_storage is storage_after_first
+
+            steps_after_second = await storage_after_first.get_steps(
+                session_id="sess-persist",
+                agent_id=state_id,
+            )
+            assert len(steps_after_second) > len(steps_after_first)
+
+    @pytest.mark.asyncio
+    async def test_non_persistent_root_closed_after_terminal(self):
+        """Non-persistent roots must be popped + closed after reaching terminal."""
+        async with Scheduler(_fast_config()) as scheduler:
+            model = MockModel([_simple_completion("ok")])
+            agent = _make_agent(name="simple", model=model, id="simple", tools=[])
+
+            state_id = await scheduler.submit(agent, "hello")
+            output = await scheduler.wait_for(state_id, timeout=_TEST_RUN_TIMEOUT)
+            assert output.termination_reason == TerminationReason.COMPLETED
+
+            # Allow _cleanup_after_run to run.
+            await asyncio.sleep(_TEST_SETTLE_WAIT)
+
+            assert scheduler.get_registered_agent(state_id) is None
+            assert state_id not in scheduler._rt.agents
+            assert state_id not in scheduler._rt.canonical_agents
+            assert state_id not in scheduler._rt.execution_handles
+
+    @pytest.mark.asyncio
+    async def test_rebind_replaces_runtime_agent(self):
+        """Passing a different canonical Agent to rebind must refresh the runtime."""
+        async with Scheduler(_fast_config()) as scheduler:
+            model_one = MockModel([_simple_completion("first")])
+            first_canonical = _make_agent(
+                name="persist", model=model_one, id="persist", tools=[]
+            )
+            state_id = await scheduler.submit(
+                first_canonical,
+                "first",
+                session_id="sess-rebind",
+                persistent=True,
+            )
+            await scheduler.wait_for(state_id, timeout=_TEST_RUN_TIMEOUT)
+
+            first_runtime = scheduler.get_registered_agent(state_id)
+
+            model_two = MockModel([_simple_completion("second")])
+            second_canonical = _make_agent(
+                name="persist", model=model_two, id="persist", tools=[]
+            )
+            rebound = await scheduler.rebind_agent(state_id, second_canonical)
+            assert rebound is True
+
+            new_runtime = scheduler.get_registered_agent(state_id)
+            assert new_runtime is not None
+            assert new_runtime is not first_runtime

--- a/tests/scheduler/test_selectors.py
+++ b/tests/scheduler/test_selectors.py
@@ -284,6 +284,7 @@ def test_build_events_message_preserves_multimodal_and_channel_context() -> None
 
     assert isinstance(merged, UserMessage)
     text = merged.extract_text()
+    assert text.startswith("You have 2 new notification(s):\n\n### User Hint")
     assert "User hint: see attachment" in text
     assert "Child Completed" in text
     assert any(p.type == ContentType.FILE for p in merged.content)
@@ -291,7 +292,7 @@ def test_build_events_message_preserves_multimodal_and_channel_context() -> None
     assert merged.context.source == "feishu"
 
 
-def test_build_events_message_skips_empty_user_hint_header() -> None:
+def test_build_events_message_marks_undecodable_user_hint() -> None:
     events = (
         PendingEvent(
             id="hint-empty",
@@ -315,5 +316,6 @@ def test_build_events_message_skips_empty_user_hint_header() -> None:
     merged = build_events_message(events)
 
     text = merged.extract_text()
-    assert "### User Hint - Agent: unknown" not in text
+    assert "### User Hint - Agent: unknown" in text
+    assert "User hint: (undecodable payload)" in text
     assert "### Child Completed - Agent: worker-1" in text

--- a/tests/scheduler/test_selectors.py
+++ b/tests/scheduler/test_selectors.py
@@ -3,9 +3,11 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 
+from agiwo.agent import ChannelContext, ContentPart, ContentType, UserMessage
 from agiwo.scheduler.commands import DispatchReason
 from agiwo.scheduler.engine import Scheduler
 from agiwo.scheduler._tick import plan_tick
+from agiwo.scheduler.formatting import build_events_message
 from agiwo.scheduler.models import (
     AgentState,
     AgentStateStatus,
@@ -15,6 +17,7 @@ from agiwo.scheduler.models import (
     WakeCondition,
     WakeType,
 )
+from agiwo.scheduler.runtime_state import build_mailbox_input
 from agiwo.scheduler.store.memory import InMemoryAgentStateStorage
 
 
@@ -92,7 +95,7 @@ def test_plan_tick_debounces_pending_events_for_waiting_state() -> None:
             target_agent_id="parent",
             session_id="sess",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "first"},
+            payload={"user_input": UserMessage.to_storage_value("first")},
             created_at=now - timedelta(seconds=30),
         ),
         PendingEvent(
@@ -100,7 +103,7 @@ def test_plan_tick_debounces_pending_events_for_waiting_state() -> None:
             target_agent_id="parent",
             session_id="sess",
             event_type=SchedulerEventType.USER_HINT,
-            payload={"hint": "second"},
+            payload={"user_input": UserMessage.to_storage_value("second")},
             created_at=now - timedelta(seconds=20),
         ),
     ]
@@ -110,6 +113,51 @@ def test_plan_tick_debounces_pending_events_for_waiting_state() -> None:
     assert len(actions) == 1
     assert actions[0].reason == DispatchReason.WAKE_EVENTS
     assert [event.id for event in actions[0].events] == ["e1", "e2"]
+
+
+def test_plan_tick_non_urgent_single_event_waits_for_debounce() -> None:
+    """Baseline: a single non-urgent event inside the debounce window stays queued."""
+    now = datetime.now(timezone.utc)
+    engine = _engine(event_debounce_min_count=3)
+    waiting = _state("parent", status=AgentStateStatus.WAITING)
+    events = [
+        PendingEvent(
+            id="single",
+            target_agent_id="parent",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={"user_input": UserMessage.to_storage_value("hi")},
+            created_at=now,
+        ),
+    ]
+
+    actions = plan_tick(engine, [waiting], events, now=now)
+
+    assert actions == []
+
+
+def test_plan_tick_urgent_user_hint_bypasses_debounce_for_waiting_state() -> None:
+    """A single urgent USER_HINT must wake a WAITING root immediately."""
+    now = datetime.now(timezone.utc)
+    engine = _engine(event_debounce_min_count=3)
+    waiting = _state("parent", status=AgentStateStatus.WAITING)
+    events = [
+        PendingEvent(
+            id="urgent-1",
+            target_agent_id="parent",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={"user_input": UserMessage.to_storage_value("wake up")},
+            created_at=now,
+            urgent=True,
+        ),
+    ]
+
+    actions = plan_tick(engine, [waiting], events, now=now)
+
+    assert len(actions) == 1
+    assert actions[0].reason == DispatchReason.WAKE_EVENTS
+    assert [event.id for event in actions[0].events] == ["urgent-1"]
 
 
 def test_plan_tick_starts_pending_child_and_queued_root() -> None:
@@ -131,7 +179,7 @@ def test_plan_tick_starts_pending_child_and_queued_root() -> None:
         target_agent_id="root",
         session_id="sess",
         event_type=SchedulerEventType.USER_HINT,
-        payload={"hint": "second input"},
+        payload={"user_input": UserMessage.to_storage_value("second input")},
         created_at=now,
     )
 
@@ -143,5 +191,101 @@ def test_plan_tick_starts_pending_child_and_queued_root() -> None:
     ]
     queued_action = actions[1]
     assert queued_action.input_override is not None
-    assert "first input" in queued_action.input_override
-    assert "second input" in queued_action.input_override
+    merged_text = UserMessage.from_value(queued_action.input_override).extract_text()
+    assert "first input" in merged_text
+    assert "second input" in merged_text
+
+
+def _make_user_hint_event(
+    event_id: str,
+    user_input,
+    *,
+    created_at: datetime | None = None,
+) -> PendingEvent:
+    return PendingEvent(
+        id=event_id,
+        target_agent_id="root",
+        session_id="sess",
+        event_type=SchedulerEventType.USER_HINT,
+        payload={"user_input": UserMessage.to_storage_value(user_input)},
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+def test_build_mailbox_input_preserves_multimodal_parts_and_channel_context() -> None:
+    """USER_HINT attachments and ChannelContext must flow into the next run."""
+    hint_message = UserMessage(
+        content=[
+            ContentPart(type=ContentType.TEXT, text="please review the image"),
+            ContentPart(
+                type=ContentType.IMAGE,
+                url="/tmp/image.png",
+                mime_type="image/png",
+                metadata={"name": "image.png", "size": 123, "source": "feishu"},
+            ),
+        ],
+        context=ChannelContext(
+            source="feishu",
+            metadata={"chat_id": "oc-123", "trigger_user": "alice"},
+        ),
+    )
+    pending_input = "pending task"
+    events = (_make_user_hint_event("h-1", hint_message),)
+
+    merged = build_mailbox_input(pending_input, events)
+
+    assert isinstance(merged, UserMessage)
+    merged_text = merged.extract_text()
+    assert "pending task" in merged_text
+    assert "please review the image" in merged_text
+
+    # Image part must survive intact.
+    image_parts = [p for p in merged.content if p.type == ContentType.IMAGE]
+    assert len(image_parts) == 1
+    assert image_parts[0].url == "/tmp/image.png"
+    assert image_parts[0].metadata["source"] == "feishu"
+
+    # ChannelContext falls back to the hint when the pending input has none.
+    assert merged.context is not None
+    assert merged.context.source == "feishu"
+    assert merged.context.metadata["chat_id"] == "oc-123"
+
+
+def test_build_events_message_preserves_multimodal_and_channel_context() -> None:
+    hint_message = UserMessage(
+        content=[
+            ContentPart(type=ContentType.TEXT, text="see attachment"),
+            ContentPart(
+                type=ContentType.FILE,
+                url="/tmp/report.pdf",
+                mime_type="application/pdf",
+                metadata={"name": "report.pdf"},
+            ),
+        ],
+        context=ChannelContext(
+            source="feishu",
+            metadata={"chat_id": "oc-456"},
+        ),
+    )
+    events = (
+        _make_user_hint_event("hint-1", hint_message),
+        PendingEvent(
+            id="child-1",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.CHILD_COMPLETED,
+            payload={"result": "done", "child_agent_id": "worker-1"},
+            created_at=datetime.now(timezone.utc),
+            source_agent_id="worker-1",
+        ),
+    )
+
+    merged = build_events_message(events)
+
+    assert isinstance(merged, UserMessage)
+    text = merged.extract_text()
+    assert "User hint: see attachment" in text
+    assert "Child Completed" in text
+    assert any(p.type == ContentType.FILE for p in merged.content)
+    assert merged.context is not None
+    assert merged.context.source == "feishu"

--- a/tests/scheduler/test_selectors.py
+++ b/tests/scheduler/test_selectors.py
@@ -289,3 +289,31 @@ def test_build_events_message_preserves_multimodal_and_channel_context() -> None
     assert any(p.type == ContentType.FILE for p in merged.content)
     assert merged.context is not None
     assert merged.context.source == "feishu"
+
+
+def test_build_events_message_skips_empty_user_hint_header() -> None:
+    events = (
+        PendingEvent(
+            id="hint-empty",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.USER_HINT,
+            payload={},
+            created_at=datetime.now(timezone.utc),
+        ),
+        PendingEvent(
+            id="child-1",
+            target_agent_id="root",
+            session_id="sess",
+            event_type=SchedulerEventType.CHILD_COMPLETED,
+            payload={"result": "done", "child_agent_id": "worker-1"},
+            created_at=datetime.now(timezone.utc),
+            source_agent_id="worker-1",
+        ),
+    )
+
+    merged = build_events_message(events)
+
+    text = merged.extract_text()
+    assert "### User Hint - Agent: unknown" not in text
+    assert "### Child Completed - Agent: worker-1" in text


### PR DESCRIPTION
## Summary

修复 scheduler 的五个稳定性问题 + 两个次要质量问题，全部带回归测试。

## Problems addressed

### 1. `cancel()` 后 `wait_for()` 等到超时才返回（high）

`cancel_subtree()` 只写 `state.with_failed(reason)`，没写 `last_run_result`；`wait_for()` 要求 `last_run_result is not None` 才返回，所以取消完成后仍阻塞到 timeout。`shutdown_subtree()` 里的 `with_failed` 也有同样的缺口。

**Fix**: `cancel_subtree` / `shutdown_subtree` 在 `with_failed(...)` 时一并写 `last_run_result=SchedulerRunResult(termination_reason=CANCELLED, error=reason)`；runner 的 `_maybe_preserve_or_finalize_aborted_terminal` 兜底补写（替换原先的 `_should_preserve_terminal_abort` 盲 return）。

### 2. WAITING 下的 "urgent steer" 实际上并不 urgent（high）

`_steer_with_stream()` 把 WAITING 视为 urgent，但 `steer()` 写入普通 `USER_HINT` event 后 `plan_tick()` 仍然完全依赖通用 debounce 规则（`min_count=3` 或 `max_wait=10s`），没有任何 urgent bypass。

**Fix**: `PendingEvent` 新增 `urgent: bool = False` 字段；`Scheduler.steer(..., urgent=True)` 据此标记事件；`plan_tick` WAITING 分支见到 urgent 事件时无条件生成 `WAKE_EVENTS`，绕过 debounce。SQLite schema 同步加 `urgent INTEGER`。

### 3. Persistent root 默认配置下会静默丢失历史（mid-high）

`Scheduler.submit` / `enqueue_input` / `rebind_agent` 每次都调 `_prepare_root_agent`，构造一个全新 `Agent`；`Agent.__init__` 又每次 `create_run_step_storage(...)`。在默认 `RunStepStorageConfig.storage_type = "memory"` 下，每轮都是一个新的 in-memory 实例 → persistent session 第二轮看不到第一轮步骤。

**Fix**: 新增 `_ensure_root_runtime_agent` 以 canonical `Agent` 身份（Python 对象 identity）为键严格复用 scheduler-managed runtime agent。`submit` / `enqueue_input(agent=same)` 不再 clone；只有 `rebind_agent` 或传入不同 canonical agent 才 close 旧 runtime + 重建。`RuntimeState.canonical_agents` 记录映射。

### 4. 非 persistent root 生命周期没收口（mid）

`_cleanup_after_run()` 对 root 一律 `return`，只处理 child；非 persistent run 结束后 `_rt.agents` 仍持有 agent，`Scheduler.stop()` 也不会逐个 close。

**Fix**: `_cleanup_after_run` 对非 persistent 且 terminal 的 root 立即 `pop + await close`（与 child 对称，persistent root 仍保留）；`Scheduler.stop()` 关闭前批量 close 所有残留 runtime agent。同步清 `canonical_agents` 与 `execution_handles`。

### 5. `steer` / queued-input 路径把结构化 `UserInput` 压扁成纯文本（mid）

`Scheduler.steer()` 只取 `UserMessage.extract_text()`，`build_mailbox_input()` 和 `build_events_message()` 也只拼字符串；Feishu 构造的 `UserMessage(content=[text, image, ...], context=ChannelContext(source="feishu", ...))` 在走 steer 或 queued-input 聚合后，附件 / 非文本 parts / channel metadata 全部退化。

**Fix**: `Scheduler.steer()` 不再调用 `extract_text()`，改用 `UserMessage.has_content()` 判空；`PendingEvent.USER_HINT payload` 统一写 `{"user_input": UserMessage.to_storage_value(...)}`；`build_mailbox_input` / `build_events_message` 返回 `UserMessage`，保留 `ContentPart`（图片 / 文件等）与 `ChannelContext`。

### 6. `copy._deepcopy_dispatch[MappingProxyType] = ...` 全局副作用

`agiwo/scheduler/models.py` import 时就改全局 `copy._deepcopy_dispatch`，后续很难定位谁改变了 deepcopy 行为。

**Fix**: 删除全局 patch；`AgentState` / `PendingEvent` / `AgentStateStorageConfig` 各自实现 `__deepcopy__`，复用共享 helper `_deepcopy_frozen_field`（递归处理 `MappingProxyType` 和 frozen tuple）。

### 7. AGENTS.md 漂移

同步更新 scheduler 段，新增上述 5 条稳定性契约。

## Regression coverage

- `tests/scheduler/test_scheduler.py`: `TestSchedulerCancel.test_cancel_releases_wait_for_immediately`、`TestSchedulerSteer`（urgent / non-urgent default / multimodal round-trip）、`TestSchedulerRuntimeAgentReuse`（persistent reuse、non-persistent cleanup、rebind）。
- `tests/scheduler/test_selectors.py`: urgent bypass、非 urgent debounce baseline、`build_mailbox_input` / `build_events_message` 多模态 + `ChannelContext` 保留。
- `tests/scheduler/test_models.py`: `PendingEvent.urgent` 默认、deepcopy 保留 frozen mappings、全局 dispatch 表洁净断言。
- `console/tests/test_scheduler_api.py`: payload 迁移到 `user_input` key。

## Test results

- SDK: `531 passed, 9 skipped`
- Console: `188 passed`
- `scripts/lint.py ci`: ruff check + format + import-linter (8/8 contracts kept) + repo_guard 全部通过（仅 1 个非阻塞 warning：`runner.py` 801 行超过 720 预算，后续可拆分）。

## Breaking change

`PendingEvent.USER_HINT.payload` 从 `{"hint": str}` 切换到 `{"user_input": UserMessage.to_storage_value(...)}`，按用户要求不做向后兼容。历史持久化事件需要手动清理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Urgent user hints bypass debounce for immediate dispatch; steering now records structured user input.

* **Bug Fixes**
  * Cancellations persist CANCELLED termination results so wait_for() returns promptly.
  * Non-persistent agents are closed and removed after terminal completion.

* **Improvements**
  * Runtime-agent identity/reuse clarified; shutdown fully drains and closes agents.
  * Event/message handling now preserves multimodal content and channel context.

* **Tests**
  * Expanded coverage for urgency, steering, agent reuse, mailbox/message merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->