### PR TITLE
[codex] Tighten bash process ownership and stop semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,10 @@
 - `AgentTool` / `as_tool()` 属于 `agiwo.agent.nested.agent_tool`，并由 `Agent.as_tool()` 暴露；它是 agent runtime adapter，属于功能工具，受 `allowed_tools` 约束。
 - 生产代码统一通过 `ToolResult.success()/failed()/aborted()/denied()` 构造结果。
 - builtin tools 放在 `agiwo/tool/builtin/`，通过 `@builtin_tool(...)` 注册；`@default_enable` 控制默认自动启用。
-- `bash` 与 `bash_process` 是分离工具；后台任务的巡检/日志/停止/输入属于 `bash_process`。
+- `bash` 与 `bash_process` 是分离工具；后台任务的巡检/日志/停止/输入属于 `bash_process`，两者各自 `@default_enable`，`allowed_tools` 是唯一的开关，不会在 `ToolManager` 层做自动配对。
+- `bash_process` 的可见/可操作边界按 caller `context.agent_id` 隔离：跨 agent 访问统一返回 `job not found`，避免 id 枚举泄漏；sandbox registry 自身仍是 workspace 级共享资源。
+- Scheduler 需要 parent 视角看 child 的后台进程时走 `agiwo.tool.process.AgentProcessRegistry` protocol（由 `scheduler.tool_control.inspect_child_processes` 使用），不经过 `bash_process` action，因此不受 owner check 约束。
+- `ProcessRegistry.stop_process` 用 `os.killpg` 对整个进程组发信号并等待 leader 退出后再落盘 `state=exited`；所有 `start_process` 路径都带 `start_new_session=True` 以保证 `pgid == pid`。
 - 共享 MEMORY 检索统一通过 `agiwo.memory.WorkspaceMemoryService`，builtin retrieval tool 只是 adapter。
 - citation 等工具侧持久化在 `agiwo/tool/storage/citation/`。
 

--- a/agiwo/tool/builtin/bash_tool/__init__.py
+++ b/agiwo/tool/builtin/bash_tool/__init__.py
@@ -1,6 +1,12 @@
-"""Public exports and pairing helpers for bash tools."""
+"""Public exports for bash tools.
 
-from agiwo.tool.base import BaseTool
+``bash`` and ``bash_process`` are two independent default-enabled builtins.
+They share a workspace-scoped sandbox via ``get_shared_local_sandbox()`` when
+constructed with no config, so there is nothing to auto-pair: the
+``allowed_tools`` allowlist must be the only gate that decides whether each is
+exposed.
+"""
+
 from agiwo.tool.builtin.bash_tool.process_tool import (
     BashProcessTool,
     BashProcessToolConfig,
@@ -13,38 +19,6 @@ from agiwo.tool.builtin.bash_tool.security import (
 from agiwo.tool.builtin.bash_tool.tool import BashTool, BashToolConfig
 
 
-def ensure_bash_tool_pair(tools: list[BaseTool]) -> list[BaseTool]:
-    """Ensure bash execution and bash process management tools share one sandbox."""
-    resolved_tools = list(tools)
-    bash_tool = next((tool for tool in resolved_tools if tool.name == "bash"), None)
-    bash_process_tool = next(
-        (tool for tool in resolved_tools if tool.name == "bash_process"),
-        None,
-    )
-
-    if isinstance(bash_tool, BashTool) and bash_process_tool is None:
-        resolved_tools.append(
-            BashProcessTool(
-                BashProcessToolConfig(
-                    sandbox=bash_tool.config.sandbox,
-                    max_output_length=bash_tool.config.max_output_length,
-                )
-            )
-        )
-    elif isinstance(bash_process_tool, BashProcessTool) and bash_tool is None:
-        resolved_tools.append(
-            BashTool(
-                BashToolConfig(
-                    sandbox=bash_process_tool.config.sandbox,
-                    cwd=".",
-                    max_output_length=bash_process_tool.config.max_output_length,
-                )
-            )
-        )
-
-    return resolved_tools
-
-
 __all__ = [
     "BashProcessTool",
     "BashProcessToolConfig",
@@ -53,5 +27,4 @@ __all__ = [
     "BashToolConfig",
     "CommandSafetyDecision",
     "CommandSafetyValidator",
-    "ensure_bash_tool_pair",
 ]

--- a/agiwo/tool/builtin/bash_tool/process_tool.py
+++ b/agiwo/tool/builtin/bash_tool/process_tool.py
@@ -38,13 +38,22 @@ class BashLogsRequest:
 @default_enable
 @builtin_tool("bash_process")
 class BashProcessTool(BaseTool, AgentProcessRegistry):
-    """Manage background processes started by the bash tool."""
+    """Manage background processes started by the bash tool.
+
+    Owner boundary: every action is scoped to the caller's ``agent_id``
+    (``context.agent_id``). Cross-agent access returns ``job not found`` to
+    avoid leaking existence of other agents' jobs. The sandbox registry itself
+    is workspace-scoped; the scheduler uses :class:`AgentProcessRegistry` for
+    parent/child privileged inspection instead of this tool.
+    """
 
     name = "bash_process"
     description = (
-        "Manage background jobs started by the `bash` tool. "
-        "Choose an `action` to list jobs, inspect status, read logs, stop a job, "
-        "show log paths, or write stdin to a running PTY job."
+        "Manage background jobs started by this agent via the `bash` tool. "
+        "Jobs are scoped to the calling agent: you only see and control jobs "
+        "you started. Choose an `action` to list your jobs, inspect status, "
+        "read logs, stop a job, show log paths, or write stdin to a running "
+        "PTY job."
     )
     cacheable: bool = False
     timeout_seconds: int = 30
@@ -145,7 +154,7 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
             )
 
         try:
-            return await handler(parameters, tool_call_id)
+            return await handler(parameters, context)
         except TimeoutError:
             return self._error(
                 parameters, "log retrieval timed out", tool_call_id=tool_call_id
@@ -167,8 +176,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         return [self._serialize_process(process) for process in processes]
 
     async def _jobs(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         running_only = self._parse_bool(parameters.get("running_only"))
         if parameters.get("running_only") is not None and running_only is None:
             return self._error(
@@ -179,7 +189,14 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
             )
 
         state = "running" if running_only else "all"
-        jobs = await self.config.sandbox.list_processes(state=state)
+        # Agent-scoped listing: callers only see jobs they started. Admin/CLI
+        # contexts (agent_id is None) fall back to the workspace view.
+        if context.agent_id is None:
+            jobs = await self.config.sandbox.list_processes(state=state)
+        else:
+            jobs = await self.config.sandbox.list_processes_by_agent(
+                context.agent_id, state=state
+            )
         if not jobs:
             return self._ok(
                 parameters,
@@ -209,8 +226,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         )
 
     async def _status(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         job_id = self._require_job_id(parameters)
         if job_id is None:
             return self._error(
@@ -221,8 +239,12 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
             )
 
         try:
-            status = await self.config.sandbox.get_process_status(job_id)
-            info = await self.config.sandbox.attach_process(job_id)
+            status = await self.config.sandbox.get_process_status(
+                job_id, owner_agent_id=context.agent_id
+            )
+            info = await self.config.sandbox.attach_process(
+                job_id, owner_agent_id=context.agent_id
+            )
         except KeyError:
             return self._error(
                 parameters,
@@ -256,8 +278,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         )
 
     async def _paths(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         job_id = self._require_job_id(parameters)
         if job_id is None:
             return self._error(
@@ -268,7 +291,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
             )
 
         try:
-            logs = await self.config.sandbox.get_process_logs_info(job_id)
+            logs = await self.config.sandbox.get_process_logs_info(
+                job_id, owner_agent_id=context.agent_id
+            )
         except KeyError:
             return self._error(
                 parameters,
@@ -293,8 +318,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         )
 
     async def _stop(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         job_id = self._require_job_id(parameters)
         if job_id is None:
             return self._error(
@@ -315,7 +341,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
 
         signal_name = "KILL" if force else "TERM"
         try:
-            await self.config.sandbox.stop_process(job_id, signal=signal_name)
+            await self.config.sandbox.stop_process(
+                job_id, signal=signal_name, owner_agent_id=context.agent_id
+            )
         except KeyError:
             return self._error(
                 parameters,
@@ -333,8 +361,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         )
 
     async def _input(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         job_id = self._require_job_id(parameters)
         if job_id is None:
             return self._error(
@@ -367,7 +396,9 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
             data += "\n"
 
         try:
-            await self.config.sandbox.write_process_stdin(job_id, data)
+            await self.config.sandbox.write_process_stdin(
+                job_id, data, owner_agent_id=context.agent_id
+            )
         except KeyError:
             return self._error(
                 parameters,
@@ -389,14 +420,17 @@ class BashProcessTool(BaseTool, AgentProcessRegistry):
         )
 
     async def _logs(
-        self, parameters: dict[str, Any], tool_call_id: str = ""
+        self, parameters: dict[str, Any], context: ToolContext
     ) -> ToolResult:
+        tool_call_id = context.tool_call_id
         request = self._resolve_logs_request(parameters, tool_call_id=tool_call_id)
         if isinstance(request, ToolResult):
             return request
 
         try:
-            log_info = await self.config.sandbox.get_process_logs_info(request.job_id)
+            log_info = await self.config.sandbox.get_process_logs_info(
+                request.job_id, owner_agent_id=context.agent_id
+            )
         except KeyError:
             return self._error(
                 parameters,

--- a/agiwo/tool/builtin/bash_tool/registry.py
+++ b/agiwo/tool/builtin/bash_tool/registry.py
@@ -1,4 +1,11 @@
-"""Process registry for managing long-running processes."""
+"""Process registry for managing long-running processes.
+
+Ownership model:
+    Records carry ``agent_id`` from ``start_process``. All per-process
+    operations accept a keyword-only ``owner_agent_id`` and raise ``KeyError``
+    (indistinguishable from "not found") when the caller does not own the
+    record. ``owner_agent_id=None`` bypasses the check (admin/CLI path).
+"""
 
 import errno
 import json
@@ -7,6 +14,7 @@ import pty
 import signal
 import subprocess
 import threading
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -119,6 +127,9 @@ class ProcessRegistry:
         stderr_fp = open(stderr_path, "w")
 
         process_env = {**os.environ, **env} if env else None
+        # start_new_session=True makes the shell a session/process-group leader
+        # with pgid == pid, so stop_process can signal the whole group and avoid
+        # leaking reparented descendants (e.g. python -c 'subprocess.Popen(...)').
         process = subprocess.Popen(
             command,
             shell=True,
@@ -126,6 +137,7 @@ class ProcessRegistry:
             stderr=stderr_fp,
             cwd=cwd,
             env=process_env,
+            start_new_session=True,
         )
 
         record = ProcessRecord(
@@ -150,8 +162,8 @@ class ProcessRegistry:
 
     @staticmethod
     def _cleanup_pty_resources(
-        stdout_fp: Any,
-        stderr_fp: Any,
+        stdout_fp: IO[str],
+        stderr_fp: IO[str],
         master_fd: int | None,
         slave_fd: int | None,
     ) -> None:
@@ -241,22 +253,28 @@ class ProcessRegistry:
         self._save_registry()
         return process_id
 
-    def attach_process(self, process_id: str) -> ProcessInfo:
+    def attach_process(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessInfo:
         """Attach to an existing process.
 
         Args:
             process_id: Process ID to attach to.
+            owner_agent_id: Caller's agent id. ``None`` bypasses the owner
+                check (admin/CLI); otherwise the record's ``agent_id`` must
+                match.
 
         Returns:
             ProcessInfo with process metadata.
 
         Raises:
-            KeyError: If process not found.
+            KeyError: If the process does not exist or is not owned by the
+                caller (same exception to avoid id enumeration leakage).
         """
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-
-        record = self._processes[process_id]
+        record = self._require_record(process_id, owner_agent_id)
         self._update_process_status(record)
 
         return ProcessInfo(
@@ -268,22 +286,19 @@ class ProcessRegistry:
             exit_code=record.exit_code,
         )
 
-    def get_process_status(self, process_id: str) -> ProcessStatus:
+    def get_process_status(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessStatus:
         """Get status of a process.
 
-        Args:
-            process_id: Process ID to query.
-
-        Returns:
-            ProcessStatus with current state.
-
         Raises:
-            KeyError: If process not found.
+            KeyError: If the process does not exist or is not owned by the
+                caller.
         """
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-
-        record = self._processes[process_id]
+        record = self._require_record(process_id, owner_agent_id)
         self._update_process_status(record)
 
         return ProcessStatus(
@@ -294,60 +309,59 @@ class ProcessRegistry:
         )
 
     def stop_process(
-        self, process_id: str, signal_name: Literal["TERM", "KILL"]
+        self,
+        process_id: str,
+        signal_name: Literal["TERM", "KILL"],
+        *,
+        owner_agent_id: str | None = None,
     ) -> None:
-        """Stop a running process.
+        """Stop a running process (and its whole process group).
 
-        Args:
-            process_id: Process ID to stop.
-            signal_name: Signal to send ("TERM" or "KILL").
+        The pipe/pty launchers use ``start_new_session=True``, so the record's
+        ``pid`` is the process-group leader. This method signals the entire
+        group via :func:`os.killpg` and waits for the whole process group to
+        disappear before committing ``state = "exited"``. TERM escalates to
+        KILL after a grace period if any descendant refuses to die.
 
         Raises:
-            KeyError: If process not found.
+            KeyError: If the process does not exist or is not owned by the
+                caller.
         """
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-
-        record = self._processes[process_id]
+        record = self._require_record(process_id, owner_agent_id)
         self._update_process_status(record)
 
-        if record.state == "running":
-            sig = signal.SIGTERM if signal_name == "TERM" else signal.SIGKILL
-            process = self._process_refs.get(process_id)
+        if record.state != "running":
+            return
 
-            # Prefer stopping through in-memory Popen handle. Only fall back to raw PID
-            # if it is still the same OS process we originally started.
-            if process is None and not self._is_same_process(record):
-                record.state = "exited"
-                record.exit_code = -1
-                self._close_file_handles(process_id)
-                self._close_pty_handle(process_id)
-                self._save_registry()
-                return
+        sig = signal.SIGTERM if signal_name == "TERM" else signal.SIGKILL
+        process = self._process_refs.get(process_id)
 
-            try:
-                if process is not None:
-                    process.send_signal(sig)
-                else:
-                    os.kill(record.pid, sig)
-                record.state = "exited"
-                record.exit_code = -1
-                self._close_file_handles(process_id)
-                self._close_pty_handle(process_id)
-                self._save_registry()
-            except OSError:
-                record.state = "exited"
-                record.exit_code = -1
-                self._close_file_handles(process_id)
-                self._close_pty_handle(process_id)
-                self._save_registry()
+        # Without an in-memory handle, only trust the pid if start-time still
+        # matches. Otherwise another process may have reclaimed the pid.
+        if process is None and not self._is_same_process(record):
+            self._finalize_exited(record, process=None)
+            return
 
-    def write_process_stdin(self, process_id: str, data: str) -> None:
+        self._kill_process_group(record, sig)
+        group_exited = self._wait_for_process_group_exit(record, process)
+        if not group_exited and signal_name == "TERM":
+            self._kill_process_group(record, signal.SIGKILL)
+            group_exited = self._wait_for_process_group_exit(record, process)
+        if not group_exited:
+            raise RuntimeError(f"Process group did not exit: {process_id}")
+        if process is not None:
+            process.poll()
+        self._finalize_exited(record, process)
+
+    def write_process_stdin(
+        self,
+        process_id: str,
+        data: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> None:
         """Write stdin to a running PTY process."""
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-
-        record = self._processes[process_id]
+        record = self._require_record(process_id, owner_agent_id)
         self._update_process_status(record)
         if record.state != "running":
             raise RuntimeError(f"Process is not running: {process_id}")
@@ -415,27 +429,108 @@ class ProcessRegistry:
                 )
         return results
 
-    def get_process_logs_info(self, process_id: str) -> ProcessLogInfo:
+    def get_process_logs_info(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessLogInfo:
         """Get log file paths for a process.
 
-        Args:
-            process_id: Process ID to query.
-
-        Returns:
-            ProcessLogInfo with log file paths.
-
         Raises:
-            KeyError: If process not found.
+            KeyError: If the process does not exist or is not owned by the
+                caller.
         """
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-
-        record = self._processes[process_id]
+        record = self._require_record(process_id, owner_agent_id)
         return ProcessLogInfo(
             stdout_path=record.stdout_path,
             stderr_path=record.stderr_path,
             mode=record.mode,
         )
+
+    def _require_record(
+        self,
+        process_id: str,
+        owner_agent_id: str | None,
+    ) -> ProcessRecord:
+        """Look up a record and enforce the owner boundary.
+
+        ``owner_agent_id is None`` means the caller has no agent identity
+        (CLI, tests, admin); owner is not enforced in that case. Otherwise the
+        record's ``agent_id`` must match exactly; mismatch raises the same
+        ``KeyError`` as 'not found' to avoid leaking existence.
+        """
+        record = self._processes.get(process_id)
+        if record is None:
+            raise KeyError(f"Process not found: {process_id}")
+        if owner_agent_id is not None and record.agent_id != owner_agent_id:
+            raise KeyError(f"Process not found: {process_id}")
+        return record
+
+    def _kill_process_group(self, record: ProcessRecord, sig: int) -> None:
+        """Signal the record's process group; fall back to pid on OSError.
+
+        With ``start_new_session=True`` the leader's pgid equals its pid.
+        ``ProcessLookupError`` is treated as already-dead (idempotent).
+        """
+        try:
+            os.killpg(record.pid, sig)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+        try:
+            os.kill(record.pid, sig)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _process_group_alive(pgid: int) -> bool:
+        """Return whether a process group still has live members."""
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return True
+        return True
+
+    def _wait_for_process_group_exit(
+        self,
+        record: ProcessRecord,
+        process: subprocess.Popen[Any] | None,
+        *,
+        timeout: float = 3.0,
+    ) -> bool:
+        """Block until the whole process group exits or ``timeout`` elapses."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if process is not None:
+                process.poll()
+            if not self._process_group_alive(record.pid):
+                return True
+            time.sleep(0.05)
+        if process is not None:
+            process.poll()
+        return not self._process_group_alive(record.pid)
+
+    def _finalize_exited(
+        self,
+        record: ProcessRecord,
+        process: subprocess.Popen[Any] | None,
+    ) -> None:
+        """Commit the exited state with a best-effort real exit code."""
+        record.state = "exited"
+        if process is not None and process.returncode is not None:
+            record.exit_code = process.returncode
+        else:
+            record.exit_code = -1
+        self._close_file_handles(record.process_id)
+        self._close_pty_handle(record.process_id)
+        self._save_registry()
 
     def _update_process_status(self, record: ProcessRecord) -> None:
         """Update process status by checking if still running."""

--- a/agiwo/tool/builtin/bash_tool/sandbox/local.py
+++ b/agiwo/tool/builtin/bash_tool/sandbox/local.py
@@ -410,21 +410,43 @@ class LocalSandbox(Sandbox):
             pty_rows=pty_rows,
         )
 
-    async def attach_process(self, process_id: str) -> ProcessInfo:
-        return self._registry.attach_process(process_id)
+    async def attach_process(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessInfo:
+        return self._registry.attach_process(process_id, owner_agent_id=owner_agent_id)
 
-    async def get_process_status(self, process_id: str) -> ProcessStatus:
-        return self._registry.get_process_status(process_id)
+    async def get_process_status(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessStatus:
+        return self._registry.get_process_status(
+            process_id, owner_agent_id=owner_agent_id
+        )
 
-    async def stop_process(self, process_id: str, signal: str = "TERM") -> None:
-        self._registry.stop_process(process_id, signal)
+    async def stop_process(
+        self,
+        process_id: str,
+        signal: str = "TERM",
+        *,
+        owner_agent_id: str | None = None,
+    ) -> None:
+        self._registry.stop_process(process_id, signal, owner_agent_id=owner_agent_id)
 
     async def write_process_stdin(
         self,
         process_id: str,
         data: str,
+        *,
+        owner_agent_id: str | None = None,
     ) -> None:
-        self._registry.write_process_stdin(process_id, data)
+        self._registry.write_process_stdin(
+            process_id, data, owner_agent_id=owner_agent_id
+        )
 
     async def list_processes(
         self,
@@ -439,8 +461,15 @@ class LocalSandbox(Sandbox):
     ) -> list[ProcessInfo]:
         return self._registry.list_processes_by_agent(agent_id, state)
 
-    async def get_process_logs_info(self, process_id: str) -> ProcessLogInfo:
-        return self._registry.get_process_logs_info(process_id)
+    async def get_process_logs_info(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessLogInfo:
+        return self._registry.get_process_logs_info(
+            process_id, owner_agent_id=owner_agent_id
+        )
 
     def _build_env(self, extra_env: dict[str, str] | None) -> dict[str, str] | None:
         """Merge extra environment variables with current process environment."""

--- a/agiwo/tool/builtin/bash_tool/types.py
+++ b/agiwo/tool/builtin/bash_tool/types.py
@@ -119,31 +119,58 @@ class Sandbox(Protocol):
         """Start a long-running process."""
         ...
 
-    async def attach_process(self, process_id: str) -> ProcessInfo:
-        """Attach to an existing process."""
+    async def attach_process(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessInfo:
+        """Attach to an existing process.
+
+        ``owner_agent_id`` restricts visibility to records owned by that
+        agent; ``None`` bypasses the check (admin/CLI). A mismatch raises
+        ``KeyError`` (indistinguishable from 'not found').
+        """
         ...
 
-    async def get_process_status(self, process_id: str) -> ProcessStatus:
-        """Get the status of a process."""
+    async def get_process_status(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessStatus:
+        """Get the status of a process (owner-gated)."""
         ...
 
-    async def stop_process(self, process_id: str, signal: str = "TERM") -> None:
-        """Stop a running process."""
+    async def stop_process(
+        self,
+        process_id: str,
+        signal: str = "TERM",
+        *,
+        owner_agent_id: str | None = None,
+    ) -> None:
+        """Stop a running process (owner-gated)."""
         ...
 
     async def write_process_stdin(
         self,
         process_id: str,
         data: str,
+        *,
+        owner_agent_id: str | None = None,
     ) -> None:
-        """Write data to a process stdin (PTY mode)."""
+        """Write data to a process stdin (PTY mode, owner-gated)."""
         ...
 
     async def list_processes(
         self,
         state: Literal["running", "all"] = "all",
     ) -> list[ProcessInfo]:
-        """List processes managed by this sandbox."""
+        """List all processes managed by this sandbox (workspace view).
+
+        This view is intentionally unfiltered; the ``bash_process`` tool layer
+        is responsible for restricting callers to their own agent.
+        """
         ...
 
     async def list_processes_by_agent(
@@ -154,8 +181,13 @@ class Sandbox(Protocol):
         """List processes associated with a specific agent_id."""
         ...
 
-    async def get_process_logs_info(self, process_id: str) -> ProcessLogInfo:
-        """Get log file paths for a process."""
+    async def get_process_logs_info(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessLogInfo:
+        """Get log file paths for a process (owner-gated)."""
         ...
 
 

--- a/agiwo/tool/manager.py
+++ b/agiwo/tool/manager.py
@@ -12,7 +12,6 @@ from agiwo.tool.builtin.registry import (
     DEFAULT_TOOLS,
     ensure_builtin_tools_loaded,
 )
-from agiwo.tool.builtin.bash_tool import ensure_bash_tool_pair
 from agiwo.tool.reference import (
     AgentToolReference,
     BuiltinToolReference,
@@ -437,16 +436,14 @@ class ToolManager:
         return result
 
     def _finalize_tools(self, tools: list[BaseTool]) -> tuple[BaseTool, ...]:
-        """Apply final consistency checks and return immutable tuple.
+        """Return an immutable tuple of resolved tool instances.
 
-        Args:
-            tools: List of tool instances
-
-        Returns:
-            Finalized tuple of tool instances
+        ``bash`` and ``bash_process`` are independent default-enabled builtins
+        and must not be auto-paired here: an explicit ``allowed_tools=['bash']``
+        must really return only ``bash``, otherwise the ``allowed_tools``
+        capability boundary would be violated.
         """
-        resolved = ensure_bash_tool_pair(tools)
-        return tuple(resolved)
+        return tuple(tools)
 
     def render_tools_section(self, allowed_tools: list[str] | None = None) -> str:
         """Render a markdown section describing available tools.

--- a/docs/concepts/tool.md
+++ b/docs/concepts/tool.md
@@ -108,7 +108,7 @@ Agiwo includes these tools out of the box:
 | Tool | Description |
 |------|-------------|
 | `bash` | Execute shell commands with security sandboxing |
-| `bash_process` | Manage long-running background processes (inspect logs, stop, send input) |
+| `bash_process` | Manage background jobs started by the calling agent (inspect logs, stop, send input). Owner-scoped: each agent only sees and controls its own jobs; the scheduler uses a separate `AgentProcessRegistry` path for parent-level inspection. |
 | `web_search` | Search the web via multiple search engines |
 | `web_reader` | Fetch and extract readable content from URLs (supports lightweight fetch plus browser fallback) |
 | `memory_retrieval` | Hybrid BM25 + vector search over MEMORY/ files |

--- a/tests/tool/bash_tool_test_support.py
+++ b/tests/tool/bash_tool_test_support.py
@@ -103,10 +103,21 @@ class MockSandbox:
         }
         return process_id
 
-    async def attach_process(self, process_id: str) -> ProcessInfo:
-        if process_id not in self._processes:
+    def _require_owned(self, process_id: str, owner_agent_id: str | None) -> dict:
+        process = self._processes.get(process_id)
+        if process is None:
             raise KeyError(f"Process not found: {process_id}")
-        process = self._processes[process_id]
+        if owner_agent_id is not None and process.get("agent_id") != owner_agent_id:
+            raise KeyError(f"Process not found: {process_id}")
+        return process
+
+    async def attach_process(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessInfo:
+        process = self._require_owned(process_id, owner_agent_id)
         return ProcessInfo(
             process_id=process_id,
             command=process["command"],
@@ -116,10 +127,13 @@ class MockSandbox:
             exit_code=process["exit_code"],
         )
 
-    async def get_process_status(self, process_id: str) -> ProcessStatus:
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-        process = self._processes[process_id]
+    async def get_process_status(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessStatus:
+        process = self._require_owned(process_id, owner_agent_id)
         return ProcessStatus(
             state=process["state"],
             mode=process["mode"],
@@ -127,11 +141,16 @@ class MockSandbox:
             exit_code=process["exit_code"],
         )
 
-    async def stop_process(self, process_id: str, signal: str = "TERM") -> None:
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-        self._processes[process_id]["state"] = "exited"
-        self._processes[process_id]["exit_code"] = -9 if signal == "KILL" else -15
+    async def stop_process(
+        self,
+        process_id: str,
+        signal: str = "TERM",
+        *,
+        owner_agent_id: str | None = None,
+    ) -> None:
+        process = self._require_owned(process_id, owner_agent_id)
+        process["state"] = "exited"
+        process["exit_code"] = -9 if signal == "KILL" else -15
 
     async def list_processes(self, state: str = "all") -> list[ProcessInfo]:
         results = []
@@ -173,19 +192,28 @@ class MockSandbox:
             )
         return results
 
-    async def get_process_logs_info(self, process_id: str) -> ProcessLogInfo:
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
+    async def get_process_logs_info(
+        self,
+        process_id: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> ProcessLogInfo:
+        process = self._require_owned(process_id, owner_agent_id)
         return ProcessLogInfo(
             stdout_path=f"/tmp/{process_id}.stdout",
             stderr_path=f"/tmp/{process_id}.stderr",
-            mode=self._processes[process_id]["mode"],
+            mode=process["mode"],
         )
 
-    async def write_process_stdin(self, process_id: str, data: str) -> None:
-        if process_id not in self._processes:
-            raise KeyError(f"Process not found: {process_id}")
-        if self._processes[process_id]["mode"] != "pty":
+    async def write_process_stdin(
+        self,
+        process_id: str,
+        data: str,
+        *,
+        owner_agent_id: str | None = None,
+    ) -> None:
+        process = self._require_owned(process_id, owner_agent_id)
+        if process["mode"] != "pty":
             raise RuntimeError("Process does not support stdin writes (not PTY mode)")
         self.stdin_writes.append({"process_id": process_id, "data": data})
 

--- a/tests/tool/test_bash_process_tool.py
+++ b/tests/tool/test_bash_process_tool.py
@@ -4,6 +4,8 @@ import pytest
 
 from agiwo.tool.base import ToolResult
 from agiwo.tool.builtin.bash_tool.process_tool import BashProcessTool
+from agiwo.tool.context import ToolContext
+from tests.utils.agent_context import build_tool_context
 
 pytest_plugins = ("tests.tool.bash_tool_test_support",)
 
@@ -355,3 +357,183 @@ class TestBashProcessToolDefaultConstruction:
         tool = BashProcessTool()
         assert tool.name == "bash_process"
         assert "background jobs" in tool.description
+        assert "this agent" in tool.description
+
+
+class TestBashProcessToolOwnerIsolation:
+    """Regression for Issue 1: bash_process must be agent-scoped."""
+
+    @pytest.fixture
+    def agent_b_context(self):
+        return build_tool_context(agent_id="agent_b", agent_name="agent_b")
+
+    async def test_jobs_excludes_other_agents(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_1"},
+            mock_context,
+        )
+
+        result = await bash_process_tool.execute(
+            {"action": "jobs", "tool_call_id": "tc_iso_2"},
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is True
+        assert result.output["count"] == 0
+        assert "no jobs" in result.output["stdout"]
+
+    async def test_status_hides_other_agents_job(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        job_result = await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_3"},
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        result = await bash_process_tool.execute(
+            {"action": "status", "job_id": job_id, "tool_call_id": "tc_iso_4"},
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is False
+        assert result.output["exit_code"] == 1
+        assert "job not found" in result.output["stderr"]
+
+    async def test_stop_hides_other_agents_job(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        job_result = await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_5"},
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        result = await bash_process_tool.execute(
+            {"action": "stop", "job_id": job_id, "tool_call_id": "tc_iso_6"},
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is False
+        assert "job not found" in result.output["stderr"]
+        # Victim job still running (mock sandbox keeps state).
+        sandbox_record = bash_process_tool.config.sandbox._processes[job_id]
+        assert sandbox_record["state"] == "running"
+
+    async def test_paths_hides_other_agents_job(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        job_result = await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_7"},
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        result = await bash_process_tool.execute(
+            {"action": "paths", "job_id": job_id, "tool_call_id": "tc_iso_8"},
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is False
+        assert "job not found" in result.output["stderr"]
+
+    async def test_logs_hides_other_agents_job(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        job_result = await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_9"},
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        result = await bash_process_tool.execute(
+            {"action": "logs", "job_id": job_id, "tool_call_id": "tc_iso_10"},
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is False
+        assert "job not found" in result.output["stderr"]
+
+    async def test_input_hides_other_agents_job(
+        self, bash_tool, bash_process_tool, mock_context, agent_b_context
+    ):
+        job_result = await bash_tool.execute(
+            {
+                "command": "codex",
+                "pty": True,
+                "background": True,
+                "tool_call_id": "tc_iso_11",
+            },
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        result = await bash_process_tool.execute(
+            {
+                "action": "input",
+                "job_id": job_id,
+                "text": "hi",
+                "tool_call_id": "tc_iso_12",
+            },
+            agent_b_context,
+        )
+
+        assert result.output["ok"] is False
+        assert "job not found" in result.output["stderr"]
+        assert bash_process_tool.config.sandbox.stdin_writes == []
+
+    async def test_jobs_with_none_agent_id_lists_workspace_view(
+        self, bash_tool, bash_process_tool
+    ):
+        """Regression: ``context.agent_id is None`` is the admin/CLI path;
+        ``_jobs`` must fall back to ``list_processes()`` (workspace view)
+        instead of filtering by a literal ``None`` agent_id, otherwise admin
+        tools would never see any work.
+        """
+        ctx_a = build_tool_context(agent_id="agent_a", agent_name="agent_a")
+        ctx_b = build_tool_context(agent_id="agent_b", agent_name="agent_b")
+        await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_adm_1"},
+            ctx_a,
+        )
+        await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_adm_2"},
+            ctx_b,
+        )
+
+        admin_ctx = ToolContext(session_id="s", agent_id=None, agent_name=None)
+        result = await bash_process_tool.execute(
+            {"action": "jobs", "tool_call_id": "tc_adm_3"},
+            admin_ctx,
+        )
+
+        assert result.output["ok"] is True
+        assert result.output["count"] == 2
+        job_agents = {
+            bash_process_tool.config.sandbox._processes[j["process_id"]]["agent_id"]
+            for j in result.output["jobs"]
+        }
+        assert job_agents == {"agent_a", "agent_b"}
+
+    async def test_owner_can_still_operate(
+        self, bash_tool, bash_process_tool, mock_context
+    ):
+        job_result = await bash_tool.execute(
+            {"command": "sleep 10", "background": True, "tool_call_id": "tc_iso_13"},
+            mock_context,
+        )
+        job_id = job_result.output["job_id"]
+
+        status = await bash_process_tool.execute(
+            {"action": "status", "job_id": job_id, "tool_call_id": "tc_iso_14"},
+            mock_context,
+        )
+        stop = await bash_process_tool.execute(
+            {"action": "stop", "job_id": job_id, "tool_call_id": "tc_iso_15"},
+            mock_context,
+        )
+
+        assert status.output["ok"] is True
+        assert stop.output["ok"] is True

--- a/tests/tool/test_bash_tool_runtime_components.py
+++ b/tests/tool/test_bash_tool_runtime_components.py
@@ -1,5 +1,10 @@
 """Runtime component tests for BashTool internals."""
 
+import os
+import shlex
+import signal
+import sys
+import time
 from datetime import datetime
 
 import pytest
@@ -61,6 +66,62 @@ class TestProcessRegistrySafety:
         assert record.state == "exited"
         assert record.exit_code == -1
 
+    def test_owner_check_hides_record_as_not_found(self, tmp_path):
+        """Cross-agent lookups must raise KeyError (indistinguishable from
+        'not found') so callers cannot enumerate other agents' job ids.
+        """
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        record = ProcessRecord(
+            process_id="job_owned",
+            command="sleep 10",
+            cwd=str(tmp_path),
+            pid=0,
+            started_at=datetime.now().timestamp(),
+            state="exited",
+            exit_code=0,
+            agent_id="agent_a",
+            pid_start_time=None,
+        )
+        registry._processes[record.process_id] = record
+
+        with pytest.raises(KeyError):
+            registry.get_process_status("job_owned", owner_agent_id="agent_b")
+        with pytest.raises(KeyError):
+            registry.attach_process("job_owned", owner_agent_id="agent_b")
+        with pytest.raises(KeyError):
+            registry.get_process_logs_info("job_owned", owner_agent_id="agent_b")
+        with pytest.raises(KeyError):
+            registry.stop_process(
+                "job_owned", signal_name="TERM", owner_agent_id="agent_b"
+            )
+        with pytest.raises(KeyError):
+            registry.write_process_stdin("job_owned", "hi", owner_agent_id="agent_b")
+
+        # Owner still sees the record.
+        status = registry.get_process_status("job_owned", owner_agent_id="agent_a")
+        assert status.state == "exited"
+
+    def test_owner_check_bypassed_for_none_caller(self, tmp_path):
+        """Admin/CLI path (owner_agent_id=None) must keep working."""
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        record = ProcessRecord(
+            process_id="job_legacy",
+            command="echo",
+            cwd=str(tmp_path),
+            pid=0,
+            started_at=datetime.now().timestamp(),
+            state="exited",
+            exit_code=0,
+            agent_id="agent_a",
+            pid_start_time=None,
+        )
+        registry._processes[record.process_id] = record
+
+        status = registry.get_process_status("job_legacy", owner_agent_id=None)
+        assert status.state == "exited"
+
     def test_list_processes_by_agent_filters_records(self, tmp_path):
         logs_dir = tmp_path / "logs"
         registry = ProcessRegistry(logs_dir)
@@ -91,6 +152,241 @@ class TestProcessRegistrySafety:
 
         assert len(jobs) == 1
         assert jobs[0].process_id == "job_a"
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+class TestProcessRegistryStopProcessGroup:
+    """Regression for Issue 2: stop_process must kill the whole process group.
+
+    Without ``start_new_session=True`` + ``os.killpg``, signalling just the
+    shell leader would leave descendants reparented to init, so ``status``
+    would claim the job exited while the real workload keeps running.
+    """
+
+    def test_stop_process_kills_reparented_child(self, tmp_path):
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+
+        # Run a bash command that launches a bash child (the worker). The
+        # child will inherit the shell's new session/process-group, so
+        # killpg must reach it.
+        # Single-quoted so the outer sh does not expand ``$!``; bash expands
+        # it after backgrounding ``sleep``.
+        command = "bash -c 'sleep 30 & echo $! ; wait'"
+        job_id = registry.start_process(command=command, cwd=str(tmp_path))
+        record = registry._processes[job_id]
+
+        # Wait until the child PID has been printed to stdout log.
+        worker_pid: int | None = None
+        deadline = time.monotonic() + 5.0
+        stdout_path = logs_dir / f"{job_id}.stdout"
+        while time.monotonic() < deadline:
+            if stdout_path.exists():
+                text = stdout_path.read_text().strip()
+                if text.isdigit():
+                    worker_pid = int(text)
+                    break
+            time.sleep(0.05)
+        assert worker_pid is not None, "worker pid was not captured in time"
+        assert _pid_alive(worker_pid), "worker should still be running before stop"
+
+        registry.stop_process(job_id, signal_name="TERM")
+
+        # After stop_process returns: state must be exited AND worker dead.
+        assert record.state == "exited"
+        for _ in range(40):  # up to 2s for reaping
+            if not _pid_alive(worker_pid):
+                break
+            time.sleep(0.05)
+        assert not _pid_alive(worker_pid), (
+            "worker process survived stop_process; process-group kill missing"
+        )
+
+    def test_stop_waits_for_process_group_not_just_leader(self, tmp_path):
+        """If the leader exits on TERM but a child ignores TERM, stop_process
+        must keep waiting for the process group and escalate to SIGKILL.
+        """
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+
+        child_script = tmp_path / "child.py"
+        child_script.write_text(
+            "\n".join(
+                [
+                    "import os",
+                    "import signal",
+                    "import time",
+                    "",
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN)",
+                    "print(os.getpid(), flush=True)",
+                    "time.sleep(60)",
+                ]
+            )
+            + "\n"
+        )
+        parent_script = tmp_path / "parent.py"
+        parent_script.write_text(
+            "\n".join(
+                [
+                    "import signal",
+                    "import subprocess",
+                    "import sys",
+                    "import time",
+                    "",
+                    "signal.signal(signal.SIGTERM, lambda *_args: sys.exit(0))",
+                    f"subprocess.Popen([{sys.executable!r}, {str(child_script)!r}])",
+                    "time.sleep(60)",
+                ]
+            )
+            + "\n"
+        )
+
+        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(parent_script))}"
+        job_id = registry.start_process(command=command, cwd=str(tmp_path))
+        record = registry._processes[job_id]
+
+        child_pid: int | None = None
+        deadline = time.monotonic() + 5.0
+        stdout_path = logs_dir / f"{job_id}.stdout"
+        while time.monotonic() < deadline:
+            if stdout_path.exists():
+                text = stdout_path.read_text().strip()
+                if text.isdigit():
+                    child_pid = int(text)
+                    break
+            time.sleep(0.05)
+        assert child_pid is not None, "child pid was not captured in time"
+        assert _pid_alive(child_pid), "child should still be running before stop"
+
+        start = time.monotonic()
+        registry.stop_process(job_id, signal_name="TERM")
+        elapsed = time.monotonic() - start
+
+        assert record.state == "exited"
+        assert not _pid_alive(child_pid), (
+            "child process survived stop_process; process-group wait is incomplete"
+        )
+        assert elapsed >= 2.5, (
+            f"stop_process returned in {elapsed:.2f}s; "
+            "leader exit was treated as group exit"
+        )
+
+    def test_pipe_launcher_uses_new_session(self, tmp_path):
+        """``_start_pipe_process`` must create a new session so pgid == pid."""
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        job_id = registry.start_process(command="sleep 30", cwd=str(tmp_path))
+        record = registry._processes[job_id]
+        try:
+            assert os.getpgid(record.pid) == record.pid
+        finally:
+            try:
+                os.killpg(record.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+
+    def test_pty_launcher_uses_new_session(self, tmp_path):
+        """``_start_pty_process`` is an independent code path and must also
+        produce a session leader (pgid == pid)."""
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        job_id = registry.start_process(
+            command="sleep 30", cwd=str(tmp_path), use_pty=True
+        )
+        record = registry._processes[job_id]
+        assert record.mode == "pty"
+        try:
+            assert os.getpgid(record.pid) == record.pid
+        finally:
+            try:
+                os.killpg(record.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+
+    def test_stop_escalates_to_sigkill_when_term_ignored(self, tmp_path):
+        """Regression: when the shell leader itself ignores SIGTERM,
+        ``stop_process`` must escalate to SIGKILL after the grace period and
+        still commit ``state == 'exited'`` with a real exit_code.
+
+        The command is ``trap '' TERM; while true; do sleep 1; done`` so the
+        top-level ``sh`` (which is what ``subprocess.Popen`` actually waits
+        on with ``shell=True``) installs ``SIG_IGN`` for SIGTERM in its own
+        process. Without escalation, ``stop_process`` would hang / never
+        complete.
+        """
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        command = "trap '' TERM; while true; do sleep 1; done"
+        job_id = registry.start_process(command=command, cwd=str(tmp_path))
+        record = registry._processes[job_id]
+
+        time.sleep(0.3)  # let sh install the trap and enter the loop
+        assert _pid_alive(record.pid)
+
+        start = time.monotonic()
+        registry.stop_process(job_id, signal_name="TERM")
+        elapsed = time.monotonic() - start
+
+        assert record.state == "exited"
+        assert not _pid_alive(record.pid)
+        # Escalation path waits ~3s for TERM before sending SIGKILL; returning
+        # in <2.5s means we never actually paid the grace period.
+        assert elapsed >= 2.5, (
+            f"stop_process returned in {elapsed:.2f}s; "
+            "SIGKILL escalation branch was not exercised"
+        )
+        assert elapsed < 10.0
+        assert record.exit_code == -signal.SIGKILL
+
+    def test_stop_records_real_exit_code(self, tmp_path):
+        """Regression: after stop_process, ``exit_code`` must reflect the
+        real ``process.returncode`` (Python returns ``-signum`` for signals),
+        not a hard-coded -1.
+        """
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        job_id = registry.start_process(command="sleep 60", cwd=str(tmp_path))
+        record = registry._processes[job_id]
+        assert _pid_alive(record.pid)
+
+        registry.stop_process(job_id, signal_name="KILL")
+
+        assert record.state == "exited"
+        assert record.exit_code == -signal.SIGKILL
+
+    def test_stop_is_idempotent_on_exited_record(self, tmp_path):
+        """Regression: stopping an already-exited record must be a no-op,
+        must not raise, and must preserve the recorded exit_code.
+        """
+        logs_dir = tmp_path / "logs"
+        registry = ProcessRegistry(logs_dir)
+        record = ProcessRecord(
+            process_id="job_done",
+            command="echo",
+            cwd=str(tmp_path),
+            pid=0,
+            started_at=datetime.now().timestamp(),
+            state="exited",
+            exit_code=0,
+            agent_id=None,
+            pid_start_time=None,
+        )
+        registry._processes[record.process_id] = record
+
+        registry.stop_process("job_done", signal_name="TERM")
+        registry.stop_process("job_done", signal_name="KILL")
+
+        assert record.state == "exited"
+        assert record.exit_code == 0
 
 
 class TestLocalSandboxProcessLimit:
@@ -161,12 +457,15 @@ class TestLocalSandboxProcessLimit:
     async def test_write_process_stdin_delegates_to_registry(self, tmp_path):
         sandbox = LocalSandbox(workspace_dir=str(tmp_path))
         called: dict[str, object] = {}
-        sandbox._registry.write_process_stdin = (  # type: ignore[method-assign]
-            lambda process_id, data: called.update(
-                {"process_id": process_id, "data": data}
-            )
-        )
 
-        await sandbox.write_process_stdin("job_1", "input\n")
+        def fake_write(process_id, data, *, owner_agent_id=None):
+            called["process_id"] = process_id
+            called["data"] = data
+            called["owner_agent_id"] = owner_agent_id
+
+        sandbox._registry.write_process_stdin = fake_write  # type: ignore[method-assign]
+
+        await sandbox.write_process_stdin("job_1", "input\n", owner_agent_id="agent_1")
         assert called["process_id"] == "job_1"
         assert called["data"] == "input\n"
+        assert called["owner_agent_id"] == "agent_1"

--- a/tests/tool/test_tool_manager.py
+++ b/tests/tool/test_tool_manager.py
@@ -288,16 +288,15 @@ class TestMergeTools:
 class TestFinalizeTools:
     """Test _finalize_tools method."""
 
-    @patch("agiwo.tool.manager.ensure_bash_tool_pair")
-    def test_finalize_calls_bash_pair(self, mock_ensure, tool_manager):
-        """Should call ensure_bash_tool_pair for consistency."""
-        tools = [Mock(name="tool1")]
-        mock_ensure.return_value = tools
+    def test_finalize_returns_tuple_without_mutation(self, tool_manager):
+        """``_finalize_tools`` must not silently inject tools; allowlist is
+        the sole gate (no more ensure_bash_tool_pair auto-pairing)."""
+        a = Mock(spec=BaseTool)
+        a.name = "bash"
+        result = tool_manager._finalize_tools([a])
 
-        result = tool_manager._finalize_tools(tools)
-
-        mock_ensure.assert_called_once_with(tools)
-        assert result == tuple(tools)
+        assert isinstance(result, tuple)
+        assert result == (a,)
 
 
 class TestNormalizeAllowedTools:
@@ -336,9 +335,33 @@ class TestGetToolsIntegration:
     def test_get_tools_explicit_allowlist(self, tool_manager):
         """Get tools with explicit allowlist."""
         tools = tool_manager.get_tools(allowed_tools=["bash"])
-        assert len(tools) >= 1  # At least bash (bash_process may be auto-added)
         tool_names = {t.name for t in tools}
         assert "bash" in tool_names
+
+    def test_get_tools_allowlist_excludes_bash_process(self, tool_manager):
+        """Regression for Issue 3: allowed_tools=['bash'] must NOT auto-add
+        bash_process, otherwise the allowlist boundary is bypassed."""
+        tools = tool_manager.get_tools(allowed_tools=["bash"])
+        tool_names = {t.name for t in tools}
+        assert "bash_process" not in tool_names
+
+    def test_get_tools_allowlist_excludes_bash_when_only_bash_process(
+        self, tool_manager
+    ):
+        """Symmetric case: allowed_tools=['bash_process'] must NOT drag bash
+        along. Previously ``ensure_bash_tool_pair`` auto-added the sibling in
+        both directions."""
+        tools = tool_manager.get_tools(allowed_tools=["bash_process"])
+        tool_names = {t.name for t in tools}
+        assert "bash_process" in tool_names
+        assert "bash" not in tool_names
+
+    def test_get_tools_defaults_include_both_bash_tools(self, tool_manager):
+        """When allowed_tools=None, both builtins are default-enabled."""
+        tools = tool_manager.get_tools(allowed_tools=None)
+        tool_names = {t.name for t in tools}
+        assert "bash" in tool_names
+        assert "bash_process" in tool_names
 
     def test_get_tools_empty_allowlist(self, tool_manager):
         """Empty allowlist should return no builtin tools."""


### PR DESCRIPTION
## What changed

This PR tightens the runtime contract around `bash` / `bash_process` in three places:

- make `bash` and `bash_process` independent builtins, with `allowed_tools` as the only capability gate
- scope `bash_process` visibility and mutating actions to the calling agent, while keeping the scheduler's privileged child-process inspection path separate
- make `ProcessRegistry.stop_process()` wait for the full process group to exit before recording `state="exited"`, with SIGKILL escalation if descendants survive SIGTERM

It also updates the related docs and adds regression coverage for owner isolation, allowlist behavior, and process-group shutdown edge cases.

## Why

The previous behavior had two correctness gaps:

- `ToolManager` could silently auto-pair `bash` and `bash_process`, which weakened the explicit `allowed_tools` boundary
- `stop_process()` treated leader exit as equivalent to job exit, so a parent could terminate while descendants in the same process group kept running

This PR aligns the implementation with the intended tool boundary and process lifecycle semantics.

## User and developer impact

- agents only see and control their own `bash_process` jobs
- `allowed_tools=['bash']` no longer implicitly grants `bash_process`, and vice versa
- stopping a background bash job is now stricter and more accurate for process trees, reducing false "exited" states
- scheduler-side child inspection still works through `AgentProcessRegistry`

## Root cause

The registry already launched processes in a shared sandbox and, after the recent `start_new_session=True` work, could signal the whole process group. But the completion check still waited on the tracked leader process instead of the pgid as a whole. Separately, the final tool assembly step still contained legacy auto-pairing logic for `bash` and `bash_process`.

## Validation

- `uv run pytest tests/tool/test_bash_tool_runtime_components.py tests/tool/test_bash_process_tool.py tests/tool/test_tool_manager.py -q`
- `uv run python scripts/lint.py ci`
- pre-push hook passed full local gate, including repo lint/contracts, SDK tests, and console backend tests
