### PR TITLE
Add agiwo-console Docker deployment path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,23 @@ jobs:
       - name: Run web production build
         run: npm --prefix console/web run build
 
+  smoke-console-docker:
+    name: Smoke Console Docker
+    runs-on: ubuntu-latest
+    needs: [lint, test-console, test-web]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Smoke test Console Docker deployment
+        run: uv run python scripts/smoke_console_docker.py
+
   package-sdk:
     name: Package SDK
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The Console is a separately published control-plane package and is intentionally
 - Built-in channel integrations today: Feishu only
 - Readiness: useful for operators, not yet production-ready
 
-### Start The API Server
+### Start The API Server (Host Mode)
 
 The Console environment template lives at [console/.env.example.full](console/.env.example.full).
 
@@ -229,6 +229,33 @@ Useful routes:
 - `POST /api/chat/{agent_id}`
 - `GET /api/scheduler/states`
 - `GET /api/traces`
+
+### Start The Complete Console In Docker
+
+The Docker path starts the backend, Web UI, Agent runtime, and Bash execution inside one managed container.
+
+```bash
+pip install agiwo-console
+cat > .env <<'EOF'
+OPENAI_API_KEY=...
+EOF
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env
+```
+
+Optional agent-visible host directories must be declared explicitly:
+
+```bash
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env \
+  --mount "$HOME/projects:projects" \
+  --mount "$HOME/media:media"
+```
+
+The managed container exposes one default public entrypoint at `http://localhost:8422`.
+All default persistence is rooted under the mounted data directory. Host directories are not visible to the Agent runtime unless they are passed with `--mount`.
 
 ### Start The Web UI
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ agiwo-console container up \
 
 The managed container exposes one default public entrypoint at `http://localhost:8422`.
 All default persistence is rooted under the mounted data directory. Host directories are not visible to the Agent runtime unless they are passed with `--mount`.
+Each `--mount <host-path>:<alias>` appears inside the container as `/mnt/host/<alias>`, so the examples above are available to agents as `/mnt/host/projects` and `/mnt/host/media`.
 
 ### Start The Web UI
 

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,0 +1,59 @@
+FROM node:20-bookworm-slim AS web-builder
+
+WORKDIR /build/console/web
+COPY console/web/package.json console/web/package-lock.json ./
+RUN npm ci
+COPY console/web/ ./
+RUN npm run build
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /opt/agiwo
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        ffmpeg \
+        git \
+        jq \
+        nginx \
+        nodejs \
+        npm \
+        ripgrep \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir yt-dlp
+
+COPY pyproject.toml README.md ./
+COPY agiwo ./agiwo
+RUN pip install --no-cache-dir .
+
+COPY console/pyproject.toml ./console/pyproject.toml
+COPY console/server ./console/server
+RUN pip install --no-cache-dir ./console
+
+RUN mkdir -p /opt/agiwo-console/web /data /var/log/nginx
+
+COPY --from=web-builder /build/console/web/.next /opt/agiwo-console/web/.next
+COPY --from=web-builder /build/console/web/node_modules /opt/agiwo-console/web/node_modules
+COPY --from=web-builder /build/console/web/package.json /opt/agiwo-console/web/package.json
+COPY --from=web-builder /build/console/web/package-lock.json /opt/agiwo-console/web/package-lock.json
+COPY --from=web-builder /build/console/web/public /opt/agiwo-console/web/public
+COPY --from=web-builder /build/console/web/next.config.ts /opt/agiwo-console/web/next.config.ts
+
+COPY console/docker/entrypoint.sh /usr/local/bin/agiwo-console-entrypoint.sh
+COPY console/docker/healthcheck.sh /usr/local/bin/agiwo-console-healthcheck.sh
+COPY console/docker/nginx.conf /etc/nginx/nginx.conf
+RUN chmod +x /usr/local/bin/agiwo-console-entrypoint.sh /usr/local/bin/agiwo-console-healthcheck.sh
+
+EXPOSE 8422
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=6 CMD ["/usr/local/bin/agiwo-console-healthcheck.sh"]
+
+ENTRYPOINT ["/usr/local/bin/agiwo-console-entrypoint.sh"]

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update \
 
 RUN pip install --no-cache-dir yt-dlp
 
+RUN groupadd --system agiwo \
+    && useradd --system --gid agiwo --create-home --home-dir /home/agiwo agiwo
+
 COPY pyproject.toml README.md ./
 COPY agiwo ./agiwo
 RUN pip install --no-cache-dir .
@@ -39,7 +42,8 @@ COPY console/pyproject.toml ./console/pyproject.toml
 COPY console/server ./console/server
 RUN pip install --no-cache-dir ./console
 
-RUN mkdir -p /opt/agiwo-console/web /data /var/log/nginx
+RUN mkdir -p /opt/agiwo-console/web /data /var/log/nginx /tmp/nginx \
+    && chown -R agiwo:agiwo /opt/agiwo-console/web /data /var/log/nginx /tmp/nginx /home/agiwo
 
 COPY --from=web-builder /build/console/web/.next /opt/agiwo-console/web/.next
 COPY --from=web-builder /build/console/web/node_modules /opt/agiwo-console/web/node_modules
@@ -51,9 +55,12 @@ COPY --from=web-builder /build/console/web/next.config.ts /opt/agiwo-console/web
 COPY console/docker/entrypoint.sh /usr/local/bin/agiwo-console-entrypoint.sh
 COPY console/docker/healthcheck.sh /usr/local/bin/agiwo-console-healthcheck.sh
 COPY console/docker/nginx.conf /etc/nginx/nginx.conf
-RUN chmod +x /usr/local/bin/agiwo-console-entrypoint.sh /usr/local/bin/agiwo-console-healthcheck.sh
+RUN chmod +x /usr/local/bin/agiwo-console-entrypoint.sh /usr/local/bin/agiwo-console-healthcheck.sh \
+    && chown -R agiwo:agiwo /opt/agiwo-console/web /usr/local/bin/agiwo-console-entrypoint.sh /usr/local/bin/agiwo-console-healthcheck.sh
 
 EXPOSE 8422
 HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=6 CMD ["/usr/local/bin/agiwo-console-healthcheck.sh"]
+
+USER agiwo
 
 ENTRYPOINT ["/usr/local/bin/agiwo-console-entrypoint.sh"]

--- a/console/docker/entrypoint.sh
+++ b/console/docker/entrypoint.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 export AGIWO_ROOT_PATH="${AGIWO_ROOT_PATH:-/data/root}"
 export AGIWO_CONSOLE_HOST="${AGIWO_CONSOLE_HOST:-127.0.0.1}"
 export AGIWO_CONSOLE_PORT="${AGIWO_CONSOLE_PORT:-18080}"
-export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-}"
 
 if [[ ! -d /data ]]; then
   echo "/data mount is required" >&2

--- a/console/docker/entrypoint.sh
+++ b/console/docker/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export AGIWO_ROOT_PATH="${AGIWO_ROOT_PATH:-/data/root}"
+export AGIWO_CONSOLE_HOST="${AGIWO_CONSOLE_HOST:-127.0.0.1}"
+export AGIWO_CONSOLE_PORT="${AGIWO_CONSOLE_PORT:-18080}"
+export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-}"
+
+if [[ ! -d /data ]]; then
+  echo "/data mount is required" >&2
+  exit 1
+fi
+
+if [[ ! -w /data ]]; then
+  echo "/data must be writable" >&2
+  exit 1
+fi
+
+mkdir -p "${AGIWO_ROOT_PATH}" "${AGIWO_ROOT_PATH}/skills" /data/runtime
+
+backend_pid=""
+web_pid=""
+nginx_pid=""
+
+shutdown() {
+  for pid in "$backend_pid" "$web_pid" "$nginx_pid"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+  wait || true
+}
+
+trap shutdown EXIT INT TERM
+
+agiwo-console serve --host "${AGIWO_CONSOLE_HOST}" --port "${AGIWO_CONSOLE_PORT}" &
+backend_pid=$!
+
+(
+  cd /opt/agiwo-console/web
+  npm run start -- --hostname 127.0.0.1 --port 13000
+) &
+web_pid=$!
+
+nginx -g 'daemon off;' &
+nginx_pid=$!
+
+wait -n "$backend_pid" "$web_pid" "$nginx_pid"
+exit $?

--- a/console/docker/healthcheck.sh
+++ b/console/docker/healthcheck.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl --fail --silent --show-error http://127.0.0.1:8422/api/health >/dev/null

--- a/console/docker/nginx.conf
+++ b/console/docker/nginx.conf
@@ -1,0 +1,42 @@
+events {}
+
+http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    upstream agiwo_console_api {
+        server 127.0.0.1:18080;
+    }
+
+    upstream agiwo_console_web {
+        server 127.0.0.1:13000;
+    }
+
+    server {
+        listen 8422;
+        server_name _;
+
+        location /api/ {
+            proxy_pass http://agiwo_console_api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+        }
+
+        location / {
+            proxy_pass http://agiwo_console_web;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+    }
+}

--- a/console/docker/nginx.conf
+++ b/console/docker/nginx.conf
@@ -1,6 +1,17 @@
+pid /tmp/nginx.pid;
+
 events {}
 
 http {
+    access_log /dev/stdout;
+    error_log /dev/stderr info;
+
+    client_body_temp_path /tmp/nginx/client_temp;
+    proxy_temp_path /tmp/nginx/proxy_temp;
+    fastcgi_temp_path /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path /tmp/nginx/uwsgi_temp;
+    scgi_temp_path /tmp/nginx/scgi_temp;
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
@@ -21,6 +32,9 @@ http {
         location /api/ {
             proxy_pass http://agiwo_console_api;
             proxy_http_version 1.1;
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/console/server/cli.py
+++ b/console/server/cli.py
@@ -1,7 +1,21 @@
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 import uvicorn
+
+from server.docker_runtime import (
+    DEFAULT_CONTAINER_NAME,
+    DEFAULT_IMAGE,
+    DEFAULT_PUBLISH,
+    DockerRuntimeError,
+    container_down,
+    container_logs,
+    container_restart,
+    container_status,
+    container_up,
+    ContainerUpOptions,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -14,25 +28,101 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--env-file", default=None)
     serve.add_argument("--reload", action="store_true")
 
+    container = subparsers.add_parser(
+        "container",
+        help="Manage the Agiwo Console Docker container",
+    )
+    container_subparsers = container.add_subparsers(dest="container_command")
+
+    up = container_subparsers.add_parser("up", help="Start the managed container")
+    up.add_argument("--name", default=DEFAULT_CONTAINER_NAME)
+    up.add_argument("--image", default=DEFAULT_IMAGE)
+    up.add_argument("--data-dir", required=True)
+    up.add_argument("--mount", action="append", default=[])
+    up.add_argument("--env-file", default=None)
+    up.add_argument("--env", action="append", default=[])
+    up.add_argument("--publish", default=DEFAULT_PUBLISH)
+    up.add_argument("--network-mode", choices=["bridge", "host"], default="bridge")
+    up.add_argument("--pull", action="store_true")
+    up.add_argument("--replace", action="store_true")
+
+    down = container_subparsers.add_parser("down", help="Stop and remove the container")
+    down.add_argument("--name", default=DEFAULT_CONTAINER_NAME)
+
+    status = container_subparsers.add_parser("status", help="Show container status")
+    status.add_argument("--name", default=DEFAULT_CONTAINER_NAME)
+
+    logs = container_subparsers.add_parser("logs", help="Show container logs")
+    logs.add_argument("--name", default=DEFAULT_CONTAINER_NAME)
+
+    restart = container_subparsers.add_parser("restart", help="Restart the container")
+    restart.add_argument("--name", default=DEFAULT_CONTAINER_NAME)
+    restart.add_argument("--publish", default=DEFAULT_PUBLISH)
+    restart.add_argument("--network-mode", choices=["bridge", "host"], default="bridge")
+
     return parser
+
+
+def _run_container_command(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> int:
+    try:
+        if args.container_command == "up":
+            result = container_up(
+                ContainerUpOptions(
+                    name=args.name,
+                    image=args.image,
+                    data_dir=Path(args.data_dir),
+                    mount_specs=tuple(args.mount),
+                    env_file=args.env_file,
+                    env=tuple(args.env),
+                    publish=args.publish,
+                    network_mode=args.network_mode,
+                    pull=args.pull,
+                    replace=args.replace,
+                )
+            )
+        else:
+            handlers = {
+                "down": lambda: container_down(args.name),
+                "status": lambda: container_status(args.name),
+                "logs": lambda: container_logs(args.name),
+                "restart": lambda: container_restart(
+                    args.name,
+                    publish=args.publish,
+                    network_mode=args.network_mode,
+                ),
+            }
+            handler = handlers.get(args.container_command)
+            if handler is None:
+                parser.print_help()
+                return 0
+            result = handler()
+    except DockerRuntimeError as exc:
+        print(str(exc), flush=True)
+        return 1
+    return result
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    if args.command != "serve":
-        parser.print_help()
+    if args.command == "serve":
+        uvicorn.run(
+            "server.app:app",
+            host=args.host,
+            port=args.port,
+            reload=args.reload,
+            env_file=args.env_file,
+            factory=False,
+        )
         return 0
 
-    uvicorn.run(
-        "server.app:app",
-        host=args.host,
-        port=args.port,
-        reload=args.reload,
-        env_file=args.env_file,
-        factory=False,
-    )
+    if args.command == "container":
+        return _run_container_command(args, parser)
+
+    parser.print_help()
     return 0
 
 

--- a/console/server/cli.py
+++ b/console/server/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -99,7 +100,7 @@ def _run_container_command(
                 return 0
             result = handler()
     except DockerRuntimeError as exc:
-        print(str(exc), flush=True)
+        print(str(exc), file=sys.stderr, flush=True)
         return 1
     return result
 

--- a/console/server/docker_runtime.py
+++ b/console/server/docker_runtime.py
@@ -1,0 +1,379 @@
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import urlopen
+
+
+DEFAULT_CONTAINER_NAME = "agiwo-console"
+DEFAULT_IMAGE = "agiwo-console:latest"
+DEFAULT_PUBLISH = "8422:8422"
+DEFAULT_HEALTH_TIMEOUT_SECONDS = 30.0
+_ALIAS_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class DockerRuntimeError(RuntimeError):
+    """Raised when the managed Docker lifecycle cannot proceed."""
+
+
+@dataclass(frozen=True)
+class DockerMount:
+    source: Path
+    alias: str
+
+    @property
+    def target(self) -> str:
+        return f"/mnt/host/{self.alias}"
+
+
+@dataclass(frozen=True)
+class ContainerUpOptions:
+    name: str = DEFAULT_CONTAINER_NAME
+    image: str = DEFAULT_IMAGE
+    data_dir: Path = Path(".agiwo-console-docker")
+    mount_specs: tuple[str, ...] = ()
+    env_file: str | None = None
+    env: tuple[str, ...] = ()
+    publish: str = DEFAULT_PUBLISH
+    network_mode: str = "bridge"
+    pull: bool = False
+    replace: bool = False
+    health_timeout_seconds: float = DEFAULT_HEALTH_TIMEOUT_SECONDS
+
+
+RunCommand = Callable[..., subprocess.CompletedProcess[str]]
+SleepFn = Callable[[float], None]
+MonotonicFn = Callable[[], float]
+UrlOpenFn = Callable[..., object]
+
+
+def _run_capture(
+    cmd: Sequence[str],
+    *,
+    runner: RunCommand = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    return runner(cmd, capture_output=True, text=True, check=False)
+
+
+def resolve_docker_binary(
+    *,
+    docker_which: Callable[[str], str | None] = shutil.which,
+) -> str:
+    docker_bin = docker_which("docker")
+    if not docker_bin:
+        raise DockerRuntimeError("docker executable not found in PATH")
+    return docker_bin
+
+
+def ensure_docker_access(
+    *,
+    docker_bin: str,
+    runner: RunCommand = subprocess.run,
+) -> None:
+    info = _run_capture([docker_bin, "info"], runner=runner)
+    if info.returncode != 0:
+        detail = (info.stderr or info.stdout or "").strip() or "unknown docker error"
+        raise DockerRuntimeError(f"docker daemon is unavailable: {detail}")
+
+
+def ensure_supported_network_mode(network_mode: str) -> None:
+    if network_mode != "host":
+        return
+    if sys.platform != "linux":
+        raise DockerRuntimeError(
+            "--network-mode=host is only supported as a first-class option on Linux"
+        )
+
+
+def ensure_data_dir(data_dir: Path) -> Path:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    if not data_dir.is_dir():
+        raise DockerRuntimeError(f"data directory is not a directory: {data_dir}")
+    if not os.access(data_dir, os.W_OK):
+        raise DockerRuntimeError(f"data directory is not writable: {data_dir}")
+    return data_dir.resolve()
+
+
+def parse_mount_spec(spec: str) -> DockerMount:
+    source_text, sep, alias = spec.rpartition(":")
+    if not sep or not source_text or not alias:
+        raise DockerRuntimeError(f"invalid mount {spec!r}; expected <source>:<alias>")
+    if not _ALIAS_PATTERN.fullmatch(alias):
+        raise DockerRuntimeError(
+            f"invalid mount alias {alias!r}; expected pattern {_ALIAS_PATTERN.pattern}"
+        )
+    source = Path(source_text).expanduser()
+    if not source.exists():
+        raise DockerRuntimeError(f"mount source does not exist: {source}")
+    return DockerMount(source=source.resolve(), alias=alias)
+
+
+def parse_mounts(specs: Sequence[str]) -> tuple[DockerMount, ...]:
+    mounts = [parse_mount_spec(spec) for spec in specs]
+    aliases = [mount.alias for mount in mounts]
+    if len(aliases) != len(set(aliases)):
+        raise DockerRuntimeError("mount aliases must be unique")
+    return tuple(mounts)
+
+
+def _container_exists(
+    *,
+    docker_bin: str,
+    name: str,
+    runner: RunCommand = subprocess.run,
+) -> bool:
+    inspect = _run_capture(
+        [docker_bin, "container", "inspect", name],
+        runner=runner,
+    )
+    return inspect.returncode == 0
+
+
+def _tail_logs(
+    *,
+    docker_bin: str,
+    name: str,
+    runner: RunCommand = subprocess.run,
+    tail: int = 50,
+) -> str:
+    logs = _run_capture(
+        [docker_bin, "logs", "--tail", str(tail), name],
+        runner=runner,
+    )
+    return (logs.stderr or logs.stdout or "").strip()
+
+
+def resolve_healthcheck_url(publish: str, network_mode: str) -> str:
+    if network_mode == "host":
+        return "http://127.0.0.1:8422/api/health"
+    host_port = publish.split(":", maxsplit=1)[0]
+    if not host_port.isdigit():
+        raise DockerRuntimeError(
+            f"invalid publish value {publish!r}; expected HOST:CONTAINER"
+        )
+    return f"http://127.0.0.1:{host_port}/api/health"
+
+
+def wait_for_health(
+    url: str,
+    *,
+    timeout_seconds: float,
+    sleep: SleepFn = time.sleep,
+    monotonic: MonotonicFn = time.monotonic,
+    opener: UrlOpenFn = urlopen,
+) -> None:
+    deadline = monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while monotonic() < deadline:
+        try:
+            with opener(url, timeout=2.0) as response:  # type: ignore[misc]
+                status = getattr(response, "status", None)
+                if status == 200:
+                    return
+                last_error = DockerRuntimeError(
+                    f"unexpected health status {status} from {url}"
+                )
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        sleep(1.0)
+    if last_error is None:
+        raise DockerRuntimeError(f"health check timed out for {url}")
+    raise DockerRuntimeError(f"health check failed for {url}: {last_error}")
+
+
+def build_docker_run_command(
+    options: ContainerUpOptions,
+    *,
+    mounts: Sequence[DockerMount],
+) -> list[str]:
+    command = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        options.name,
+        "--restart",
+        "unless-stopped",
+    ]
+    if options.network_mode == "host":
+        command.extend(["--network", "host"])
+    else:
+        command.extend(["-p", options.publish])
+    command.extend(["-v", f"{options.data_dir}:/data"])
+    for mount in mounts:
+        command.extend(["-v", f"{mount.source}:{mount.target}"])
+    if options.env_file:
+        command.extend(["--env-file", options.env_file])
+    command.extend(["-e", "AGIWO_ROOT_PATH=/data/root"])
+    for item in options.env:
+        command.extend(["-e", item])
+    command.append(options.image)
+    return command
+
+
+def container_up(
+    options: ContainerUpOptions,
+    *,
+    docker_which: Callable[[str], str | None] = shutil.which,
+    runner: RunCommand = subprocess.run,
+    sleep: SleepFn = time.sleep,
+    monotonic: MonotonicFn = time.monotonic,
+    opener: UrlOpenFn = urlopen,
+) -> int:
+    docker_bin = resolve_docker_binary(docker_which=docker_which)
+    ensure_docker_access(docker_bin=docker_bin, runner=runner)
+    ensure_supported_network_mode(options.network_mode)
+
+    resolved_data_dir = ensure_data_dir(options.data_dir)
+    mounts = parse_mounts(options.mount_specs)
+    normalized = ContainerUpOptions(
+        name=options.name,
+        image=options.image,
+        data_dir=resolved_data_dir,
+        mount_specs=options.mount_specs,
+        env_file=options.env_file,
+        env=options.env,
+        publish=options.publish,
+        network_mode=options.network_mode,
+        pull=options.pull,
+        replace=options.replace,
+        health_timeout_seconds=options.health_timeout_seconds,
+    )
+
+    if _container_exists(docker_bin=docker_bin, name=normalized.name, runner=runner):
+        if not normalized.replace:
+            raise DockerRuntimeError(
+                f"container {normalized.name!r} already exists; use --replace to recreate it"
+            )
+        replace = _run_capture(
+            [docker_bin, "rm", "-f", normalized.name],
+            runner=runner,
+        )
+        if replace.returncode != 0:
+            detail = (
+                replace.stderr or replace.stdout or ""
+            ).strip() or "docker rm failed"
+            raise DockerRuntimeError(detail)
+
+    if normalized.pull:
+        pull = _run_capture([docker_bin, "pull", normalized.image], runner=runner)
+        if pull.returncode != 0:
+            detail = (pull.stderr or pull.stdout or "").strip() or "docker pull failed"
+            raise DockerRuntimeError(detail)
+
+    command = build_docker_run_command(normalized, mounts=mounts)
+    command[0] = docker_bin
+    run = _run_capture(command, runner=runner)
+    if run.returncode != 0:
+        detail = (run.stderr or run.stdout or "").strip() or "docker run failed"
+        raise DockerRuntimeError(detail)
+
+    health_url = resolve_healthcheck_url(normalized.publish, normalized.network_mode)
+    try:
+        wait_for_health(
+            health_url,
+            timeout_seconds=normalized.health_timeout_seconds,
+            sleep=sleep,
+            monotonic=monotonic,
+            opener=opener,
+        )
+    except DockerRuntimeError as exc:
+        logs = _tail_logs(docker_bin=docker_bin, name=normalized.name, runner=runner)
+        if logs:
+            raise DockerRuntimeError(f"{exc}\nRecent container logs:\n{logs}") from exc
+        raise
+    return 0
+
+
+def container_down(
+    name: str,
+    *,
+    docker_which: Callable[[str], str | None] = shutil.which,
+    runner: RunCommand = subprocess.run,
+) -> int:
+    docker_bin = resolve_docker_binary(docker_which=docker_which)
+    ensure_docker_access(docker_bin=docker_bin, runner=runner)
+    command = _run_capture([docker_bin, "rm", "-f", name], runner=runner)
+    if command.returncode != 0:
+        detail = (command.stderr or command.stdout or "").strip()
+        raise DockerRuntimeError(detail or f"failed to remove container {name!r}")
+    return 0
+
+
+def container_logs(
+    name: str,
+    *,
+    docker_which: Callable[[str], str | None] = shutil.which,
+    runner: RunCommand = subprocess.run,
+) -> int:
+    docker_bin = resolve_docker_binary(docker_which=docker_which)
+    ensure_docker_access(docker_bin=docker_bin, runner=runner)
+    command = runner([docker_bin, "logs", name], text=True, check=False)
+    if command.returncode != 0:
+        raise DockerRuntimeError(f"failed to read logs for container {name!r}")
+    return 0
+
+
+def container_status(
+    name: str,
+    *,
+    docker_which: Callable[[str], str | None] = shutil.which,
+    runner: RunCommand = subprocess.run,
+) -> int:
+    docker_bin = resolve_docker_binary(docker_which=docker_which)
+    ensure_docker_access(docker_bin=docker_bin, runner=runner)
+    command = _run_capture(
+        [
+            docker_bin,
+            "ps",
+            "-a",
+            "--filter",
+            f"name=^{name}$",
+            "--format",
+            "{{.Names}}\t{{.State}}\t{{.Status}}",
+        ],
+        runner=runner,
+    )
+    if command.returncode != 0:
+        detail = (command.stderr or command.stdout or "").strip()
+        raise DockerRuntimeError(detail or f"failed to inspect container {name!r}")
+    output = command.stdout.strip()
+    if not output:
+        print(f"container {name!r} not found")
+        return 1
+    print(output)
+    return 0
+
+
+def container_restart(
+    name: str,
+    *,
+    publish: str = DEFAULT_PUBLISH,
+    network_mode: str = "bridge",
+    health_timeout_seconds: float = DEFAULT_HEALTH_TIMEOUT_SECONDS,
+    docker_which: Callable[[str], str | None] = shutil.which,
+    runner: RunCommand = subprocess.run,
+    sleep: SleepFn = time.sleep,
+    monotonic: MonotonicFn = time.monotonic,
+    opener: UrlOpenFn = urlopen,
+) -> int:
+    docker_bin = resolve_docker_binary(docker_which=docker_which)
+    ensure_docker_access(docker_bin=docker_bin, runner=runner)
+    ensure_supported_network_mode(network_mode)
+    command = _run_capture([docker_bin, "restart", name], runner=runner)
+    if command.returncode != 0:
+        detail = (command.stderr or command.stdout or "").strip()
+        raise DockerRuntimeError(detail or f"failed to restart container {name!r}")
+    wait_for_health(
+        resolve_healthcheck_url(publish, network_mode),
+        timeout_seconds=health_timeout_seconds,
+        sleep=sleep,
+        monotonic=monotonic,
+        opener=opener,
+    )
+    return 0

--- a/console/server/docker_runtime.py
+++ b/console/server/docker_runtime.py
@@ -65,7 +65,7 @@ def resolve_docker_binary(
     docker_which: Callable[[str], str | None] = shutil.which,
 ) -> str:
     docker_bin = docker_which("docker")
-    if not docker_bin:
+    if docker_bin is None:
         raise DockerRuntimeError("docker executable not found in PATH")
     return docker_bin
 
@@ -82,6 +82,11 @@ def ensure_docker_access(
 
 
 def ensure_supported_network_mode(network_mode: str) -> None:
+    allowed_modes = {"bridge", "host", "none"}
+    if network_mode not in allowed_modes:
+        raise DockerRuntimeError(
+            f"unsupported network mode {network_mode!r}; expected one of {sorted(allowed_modes)}"
+        )
     if network_mode != "host":
         return
     if sys.platform != "linux":
@@ -103,6 +108,10 @@ def parse_mount_spec(spec: str) -> DockerMount:
     source_text, sep, alias = spec.rpartition(":")
     if not sep or not source_text or not alias:
         raise DockerRuntimeError(f"invalid mount {spec!r}; expected <source>:<alias>")
+    if alias in {".", ".."}:
+        raise DockerRuntimeError(
+            f"invalid mount alias {alias!r}; relative path aliases are not allowed"
+        )
     if not _ALIAS_PATTERN.fullmatch(alias):
         raise DockerRuntimeError(
             f"invalid mount alias {alias!r}; expected pattern {_ALIAS_PATTERN.pattern}"
@@ -151,12 +160,28 @@ def _tail_logs(
 def resolve_healthcheck_url(publish: str, network_mode: str) -> str:
     if network_mode == "host":
         return "http://127.0.0.1:8422/api/health"
+    if ":" not in publish:
+        raise DockerRuntimeError(
+            f"invalid publish value {publish!r}; expected HOST:CONTAINER"
+        )
     host_port = publish.split(":", maxsplit=1)[0]
     if not host_port.isdigit():
         raise DockerRuntimeError(
             f"invalid publish value {publish!r}; expected HOST:CONTAINER"
         )
     return f"http://127.0.0.1:{host_port}/api/health"
+
+
+def _pull_image(
+    *,
+    docker_bin: str,
+    image: str,
+    runner: RunCommand = subprocess.run,
+) -> None:
+    pull = _run_capture([docker_bin, "pull", image], runner=runner)
+    if pull.returncode != 0:
+        detail = (pull.stderr or pull.stdout or "").strip() or "docker pull failed"
+        raise DockerRuntimeError(detail)
 
 
 def wait_for_health(
@@ -250,6 +275,12 @@ def container_up(
             raise DockerRuntimeError(
                 f"container {normalized.name!r} already exists; use --replace to recreate it"
             )
+        if normalized.pull:
+            _pull_image(
+                docker_bin=docker_bin,
+                image=normalized.image,
+                runner=runner,
+            )
         replace = _run_capture(
             [docker_bin, "rm", "-f", normalized.name],
             runner=runner,
@@ -260,11 +291,12 @@ def container_up(
             ).strip() or "docker rm failed"
             raise DockerRuntimeError(detail)
 
-    if normalized.pull:
-        pull = _run_capture([docker_bin, "pull", normalized.image], runner=runner)
-        if pull.returncode != 0:
-            detail = (pull.stderr or pull.stdout or "").strip() or "docker pull failed"
-            raise DockerRuntimeError(detail)
+    if normalized.pull and not normalized.replace:
+        _pull_image(
+            docker_bin=docker_bin,
+            image=normalized.image,
+            runner=runner,
+        )
 
     command = build_docker_run_command(normalized, mounts=mounts)
     command[0] = docker_bin

--- a/console/tests/test_cli.py
+++ b/console/tests/test_cli.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from unittest.mock import patch
 
 from server.cli import build_parser, main
+from server.docker_runtime import ContainerUpOptions, DockerRuntimeError
 
 
 def test_build_parser_supports_serve_subcommand() -> None:
@@ -50,3 +52,64 @@ def test_cli_serve_forwards_reload_and_env_file() -> None:
         env_file="/tmp/console.env",
         factory=False,
     )
+
+
+def test_build_parser_supports_container_up_defaults() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["container", "up", "--data-dir", "/tmp/data"])
+
+    assert args.command == "container"
+    assert args.container_command == "up"
+    assert args.name == "agiwo-console"
+    assert args.image == "agiwo-console:latest"
+    assert args.data_dir == "/tmp/data"
+    assert args.mount == []
+    assert args.env == []
+    assert args.env_file is None
+    assert args.publish == "8422:8422"
+    assert args.network_mode == "bridge"
+    assert args.pull is False
+    assert args.replace is False
+
+
+def test_cli_container_up_dispatches_to_runtime() -> None:
+    with patch("server.cli.container_up", return_value=0) as run:
+        exit_code = main(
+            [
+                "container",
+                "up",
+                "--data-dir",
+                "/tmp/data",
+                "--mount",
+                "/tmp/work:workspace",
+                "--env",
+                "OPENAI_API_KEY=test",
+                "--replace",
+            ]
+        )
+
+    assert exit_code == 0
+    run.assert_called_once_with(
+        ContainerUpOptions(
+            name="agiwo-console",
+            image="agiwo-console:latest",
+            data_dir=Path("/tmp/data"),
+            mount_specs=("/tmp/work:workspace",),
+            env_file=None,
+            env=("OPENAI_API_KEY=test",),
+            publish="8422:8422",
+            network_mode="bridge",
+            pull=False,
+            replace=True,
+        )
+    )
+
+
+def test_cli_container_runtime_error_returns_failure(capsys) -> None:
+    with patch("server.cli.container_status", side_effect=DockerRuntimeError("boom")):
+        exit_code = main(["container", "status"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "boom" in captured.out

--- a/console/tests/test_cli.py
+++ b/console/tests/test_cli.py
@@ -112,4 +112,4 @@ def test_cli_container_runtime_error_returns_failure(capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "boom" in captured.out
+    assert "boom" in captured.err

--- a/console/tests/test_docker_runtime.py
+++ b/console/tests/test_docker_runtime.py
@@ -1,0 +1,196 @@
+import subprocess
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+from server.docker_runtime import (
+    ContainerUpOptions,
+    DockerRuntimeError,
+    build_docker_run_command,
+    container_up,
+    parse_mount_spec,
+    parse_mounts,
+    resolve_healthcheck_url,
+    wait_for_health,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status: int):
+        self.status = status
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def test_parse_mount_spec_resolves_existing_source(tmp_path: Path) -> None:
+    source = tmp_path / "workspace"
+    source.mkdir()
+
+    mount = parse_mount_spec(f"{source}:workspace")
+
+    assert mount.source == source.resolve()
+    assert mount.alias == "workspace"
+    assert mount.target == "/mnt/host/workspace"
+
+
+def test_parse_mounts_rejects_duplicate_aliases(tmp_path: Path) -> None:
+    source = tmp_path / "workspace"
+    source.mkdir()
+
+    with pytest.raises(DockerRuntimeError, match="aliases must be unique"):
+        parse_mounts(
+            [
+                f"{source}:shared",
+                f"{source}:shared",
+            ]
+        )
+
+
+def test_build_docker_run_command_includes_defaults_and_mounts(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    mount_source = tmp_path / "project"
+    mount_source.mkdir()
+    mounts = parse_mounts([f"{mount_source}:project"])
+
+    command = build_docker_run_command(
+        ContainerUpOptions(
+            name="console",
+            image="example:latest",
+            data_dir=data_dir,
+            mount_specs=(f"{mount_source}:project",),
+            env_file="/tmp/console.env",
+            env=("OPENAI_API_KEY=test",),
+            publish="9000:8422",
+        ),
+        mounts=mounts,
+    )
+
+    assert command[:8] == [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        "console",
+        "--restart",
+        "unless-stopped",
+        "-p",
+    ]
+    assert "9000:8422" in command
+    assert f"{data_dir}:/data" in command
+    assert f"{mount_source.resolve()}:/mnt/host/project" in command
+    assert "AGIWO_ROOT_PATH=/data/root" in command
+    assert "OPENAI_API_KEY=test" in command
+    assert command[-1] == "example:latest"
+
+
+def test_wait_for_health_retries_until_success() -> None:
+    attempts = {"count": 0}
+
+    def opener(url: str, timeout: float) -> _FakeResponse:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise URLError("not ready")
+        return _FakeResponse(200)
+
+    wait_for_health(
+        "http://127.0.0.1:8422/api/health",
+        timeout_seconds=2.0,
+        sleep=lambda _seconds: None,
+        monotonic=iter([0.0, 0.1, 0.2]).__next__,
+        opener=opener,
+    )
+
+    assert attempts["count"] == 2
+
+
+def test_resolve_healthcheck_url_uses_host_port() -> None:
+    assert (
+        resolve_healthcheck_url("9000:8422", "bridge")
+        == "http://127.0.0.1:9000/api/health"
+    )
+    assert (
+        resolve_healthcheck_url("8422:8422", "host")
+        == "http://127.0.0.1:8422/api/health"
+    )
+
+
+def test_container_up_creates_data_dir_replaces_existing_container_and_waits_for_health(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "data"
+    mount_source = tmp_path / "workspace"
+    mount_source.mkdir()
+    calls: list[list[str]] = []
+
+    def runner(cmd, capture_output=False, text=False, check=False):
+        calls.append(list(cmd))
+        if cmd[1:] == ["info"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+        if cmd[1:4] == ["container", "inspect", "console"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[1:4] == ["rm", "-f", "console"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[1] == "run":
+            return subprocess.CompletedProcess(cmd, 0, stdout="cid", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    options = ContainerUpOptions(
+        name="console",
+        image="example:latest",
+        data_dir=data_dir,
+        mount_specs=(f"{mount_source}:workspace",),
+        replace=True,
+        health_timeout_seconds=1.0,
+    )
+
+    exit_code = container_up(
+        options,
+        docker_which=lambda _name: "/usr/bin/docker",
+        runner=runner,
+        sleep=lambda _seconds: None,
+        monotonic=iter([0.0, 0.1]).__next__,
+        opener=lambda _url, timeout: _FakeResponse(200),
+    )
+
+    assert exit_code == 0
+    assert data_dir.is_dir()
+    assert calls[0] == ["/usr/bin/docker", "info"]
+    assert calls[1] == ["/usr/bin/docker", "container", "inspect", "console"]
+    assert calls[2] == ["/usr/bin/docker", "rm", "-f", "console"]
+    assert calls[3][:8] == [
+        "/usr/bin/docker",
+        "run",
+        "-d",
+        "--name",
+        "console",
+        "--restart",
+        "unless-stopped",
+        "-p",
+    ]
+
+
+def test_container_up_rejects_host_network_on_non_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr("server.docker_runtime.sys.platform", "darwin")
+
+    with pytest.raises(DockerRuntimeError, match="only supported"):
+        container_up(
+            ContainerUpOptions(
+                data_dir=data_dir,
+                network_mode="host",
+            ),
+            docker_which=lambda _name: "/usr/bin/docker",
+            runner=lambda *args, **kwargs: subprocess.CompletedProcess(
+                args[0], 0, "", ""
+            ),
+            sleep=lambda _seconds: None,
+            monotonic=iter([0.0]).__next__,
+            opener=lambda _url, timeout: _FakeResponse(200),
+        )

--- a/console/tests/test_docker_runtime.py
+++ b/console/tests/test_docker_runtime.py
@@ -9,6 +9,7 @@ from server.docker_runtime import (
     DockerRuntimeError,
     build_docker_run_command,
     container_up,
+    ensure_supported_network_mode,
     parse_mount_spec,
     parse_mounts,
     resolve_healthcheck_url,
@@ -49,6 +50,17 @@ def test_parse_mounts_rejects_duplicate_aliases(tmp_path: Path) -> None:
                 f"{source}:shared",
             ]
         )
+
+
+def test_parse_mount_spec_rejects_relative_aliases(tmp_path: Path) -> None:
+    source = tmp_path / "workspace"
+    source.mkdir()
+
+    with pytest.raises(DockerRuntimeError, match="relative path aliases"):
+        parse_mount_spec(f"{source}:.")
+
+    with pytest.raises(DockerRuntimeError, match="relative path aliases"):
+        parse_mount_spec(f"{source}:..")
 
 
 def test_build_docker_run_command_includes_defaults_and_mounts(tmp_path: Path) -> None:
@@ -119,6 +131,16 @@ def test_resolve_healthcheck_url_uses_host_port() -> None:
     )
 
 
+def test_resolve_healthcheck_url_rejects_publish_without_host_port() -> None:
+    with pytest.raises(DockerRuntimeError, match="expected HOST:CONTAINER"):
+        resolve_healthcheck_url("8422", "bridge")
+
+
+def test_ensure_supported_network_mode_rejects_unknown_value() -> None:
+    with pytest.raises(DockerRuntimeError, match="unsupported network mode"):
+        ensure_supported_network_mode("weird")
+
+
 def test_container_up_creates_data_dir_replaces_existing_container_and_waits_for_health(
     tmp_path: Path,
 ) -> None:
@@ -172,6 +194,47 @@ def test_container_up_creates_data_dir_replaces_existing_container_and_waits_for
         "unless-stopped",
         "-p",
     ]
+
+
+def test_container_up_pulls_before_replacing_existing_container_when_requested(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "data"
+    calls: list[list[str]] = []
+
+    def runner(cmd, capture_output=False, text=False, check=False):
+        calls.append(list(cmd))
+        if cmd[1:] == ["info"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+        if cmd[1:4] == ["container", "inspect", "console"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        if cmd[1:3] == ["pull", "example:latest"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[1:4] == ["rm", "-f", "console"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[1] == "run":
+            return subprocess.CompletedProcess(cmd, 0, stdout="cid", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    exit_code = container_up(
+        ContainerUpOptions(
+            name="console",
+            image="example:latest",
+            data_dir=data_dir,
+            replace=True,
+            pull=True,
+            health_timeout_seconds=1.0,
+        ),
+        docker_which=lambda _name: "/usr/bin/docker",
+        runner=runner,
+        sleep=lambda _seconds: None,
+        monotonic=iter([0.0, 0.1]).__next__,
+        opener=lambda _url, timeout: _FakeResponse(200),
+    )
+
+    assert exit_code == 0
+    assert calls[2] == ["/usr/bin/docker", "pull", "example:latest"]
+    assert calls[3] == ["/usr/bin/docker", "rm", "-f", "console"]
 
 
 def test_container_up_rejects_host_network_on_non_linux(

--- a/console/web/src/lib/api.test.ts
+++ b/console/web/src/lib/api.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_API_URL;
+  vi.resetModules();
+});
+
+describe("api url base", () => {
+  test("defaults to same-origin relative paths", async () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    const api = await import("./api");
+
+    expect(api.sessionInputStreamUrl("sess-1")).toBe("/api/sessions/sess-1/input");
+  });
+
+  test("uses NEXT_PUBLIC_API_URL when configured", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:8422/";
+
+    const api = await import("./api");
+
+    expect(api.sessionInputStreamUrl("sess-1")).toBe(
+      "http://localhost:8422/api/sessions/sess-1/input",
+    );
+  });
+});

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -1,4 +1,8 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8422";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ?? "";
+
+function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}
 
 export class ApiError extends Error {
   status: number;
@@ -13,7 +17,7 @@ export class ApiError extends Error {
 }
 
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(apiUrl(path), {
     ...init,
     headers: {
       "Content-Type": "application/json",
@@ -601,7 +605,7 @@ export function updateAgent(agentId: string, data: AgentConfigCreate) {
 }
 
 export async function deleteAgent(agentId: string) {
-  const res = await fetch(`${API_BASE}/api/agents/${agentId}`, { method: "DELETE" });
+  const res = await fetch(apiUrl(`/api/agents/${agentId}`), { method: "DELETE" });
   if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
 }
 
@@ -767,14 +771,14 @@ export function forkSession(sessionId: string, contextSummary: string) {
 }
 
 export async function deleteSession(sessionId: string) {
-  const res = await fetch(`${API_BASE}/api/sessions/${sessionId}`, { method: "DELETE" });
+  const res = await fetch(apiUrl(`/api/sessions/${sessionId}`), { method: "DELETE" });
   if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
 }
 
 // ── Session Input Stream ───────────────────────────────────────────────
 
 export function sessionInputStreamUrl(sessionId: string) {
-  return `${API_BASE}/api/sessions/${sessionId}/input`;
+  return apiUrl(`/api/sessions/${sessionId}/input`);
 }
 
 export function parseStreamEventPayload(data: string): StreamEventPayload | null {

--- a/docs/console/docker.md
+++ b/docs/console/docker.md
@@ -1,0 +1,71 @@
+# Console Docker Deployment
+
+`agiwo-console container up` starts a complete Console deployment in one managed Docker container.
+
+That container includes:
+
+- the FastAPI backend
+- the Web UI
+- the Agent runtime
+- Bash execution and related runtime tools
+
+The default public entrypoint is `http://localhost:8422`.
+
+## Quick Start
+
+```bash
+pip install agiwo-console
+cat > .env <<'EOF'
+OPENAI_API_KEY=...
+EOF
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env
+```
+
+## Data Root
+
+`--data-dir` is the single persistent host directory for the managed container.
+
+The container maps it to `/data` and roots default runtime state under `/data/root`.
+
+That includes:
+
+- SQLite-backed Console state
+- default agent workspace state
+- logs and runtime-owned files
+- the default custom skills location under `/data/root/skills`
+
+## Host Directory Mounts
+
+Host directories are not visible to the Agent runtime by default.
+
+To make a host directory available inside the container, pass `--mount <source>:<alias>`:
+
+```bash
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env \
+  --mount "$HOME/projects:projects" \
+  --mount "$HOME/media:media"
+```
+
+Inside the container, those paths appear as:
+
+- `/mnt/host/projects`
+- `/mnt/host/media`
+
+## Lifecycle Commands
+
+```bash
+agiwo-console container status
+agiwo-console container logs
+agiwo-console container restart
+agiwo-console container down
+```
+
+## Notes
+
+- `--network-mode host` is treated as an advanced option and is only supported as a first-class path on Linux.
+- `NEXT_PUBLIC_API_URL` is optional in Docker mode because the Web UI uses same-origin API access by default.
+- If `container up` fails its health check, inspect `agiwo-console container logs` before removing the container.

--- a/docs/console/overview.md
+++ b/docs/console/overview.md
@@ -20,7 +20,7 @@ Console
 
 ## Quick Start
 
-### Start the API Server
+### Start the API Server (Host Mode)
 
 ```bash
 pip install agiwo-console
@@ -33,6 +33,31 @@ agiwo-console serve --env-file .env
 If you are running from the source repository instead, you can still start from `console/.env.example.full`.
 
 The server starts at `http://localhost:8422`.
+
+### Start the Complete Console in Docker
+
+```bash
+pip install agiwo-console
+cat > .env <<'EOF'
+OPENAI_API_KEY=...
+EOF
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env
+```
+
+The Docker path starts the FastAPI backend, Web UI, Agent runtime, and Bash execution in one managed container. The public entrypoint is still `http://localhost:8422`, but the runtime now lives inside the container instead of on the host.
+
+If the Agent should see host directories, declare them explicitly:
+
+```bash
+agiwo-console container up \
+  --data-dir "$HOME/agiwo-data" \
+  --env-file .env \
+  --mount "$HOME/projects:projects"
+```
+
+Mounted host directories appear inside the container as `/mnt/host/<alias>`. Undeclared host paths are not visible to the Agent runtime.
 
 ### Start the Web UI
 

--- a/docs/superpowers/plans/2026-04-18-agiwo-console-docker-deployment.md
+++ b/docs/superpowers/plans/2026-04-18-agiwo-console-docker-deployment.md
@@ -1,0 +1,391 @@
+# Agiwo Console Docker Deployment Implementation Plan
+
+> **For agentic workers:** `writing-plans` is unavailable in this session. Follow this repo-native plan directly and implement one task at a time. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a first-class Docker deployment path for `agiwo-console` that starts a complete Console instance, including the FastAPI backend, Web UI, Agent runtime, Bash execution, and persistence, through a single CLI-managed container workflow.
+
+**Architecture:** Keep `agiwo-console serve` intact as the host-mode path. Add a parallel `agiwo-console container ...` command group that manages one official Docker image and one managed container. Inside that container, run the backend, Web UI, and a reverse proxy behind one public port. Root all default persistence under `/data`, expose host work directories only through explicit mounts under `/mnt/host/<alias>`, and keep the existing `AGIWO_*` / `AGIWO_CONSOLE_*` configuration model canonical.
+
+**Tech Stack:** Python 3.10+, FastAPI, Next.js, Docker, uvicorn, uv, Hatchling, pytest, Vitest, shell entrypoint tooling, lightweight reverse proxy
+
+---
+
+## File Structure
+
+- Modify: `console/server/cli.py`
+  - Add the `container` command group and keep `serve` behavior unchanged.
+- Create: `console/server/docker_runtime.py`
+  - Centralize Docker CLI argument normalization, preflight checks, command construction, and lifecycle helpers.
+- Create: `console/server/tests/test_cli.py`
+  - Add unit coverage for CLI parsing and Docker command dispatch.
+- Create: `console/server/tests/test_docker_runtime.py`
+  - Add focused tests for mount validation, alias validation, network-mode handling, and health-check behavior.
+- Create: `console/Dockerfile`
+  - Build the official single-image Console runtime with backend, frontend, and runtime tools.
+- Create: `console/docker/entrypoint.sh`
+  - Start the backend, Web UI, and reverse proxy inside the container.
+- Create: `console/docker/nginx.conf`
+  - Route `/api/*` and SSE traffic to FastAPI and route all other requests to the Web UI.
+- Create: `console/docker/healthcheck.sh`
+  - Provide a stable in-container health probe.
+- Modify: `console/web/src/lib/api.ts`
+  - Switch the frontend API base strategy from an absolute localhost default to same-origin-first behavior.
+- Modify: `console/web/next.config.ts`
+  - Add any runtime-facing configuration needed to keep the production container path stable.
+- Modify: `console/pyproject.toml`
+  - Ensure the package includes Docker runtime assets in the built artifact if needed by the CLI-managed flow.
+- Modify: `README.md`
+  - Document the Docker deployment path.
+- Modify: `docs/console/overview.md`
+  - Describe host mode versus container mode and the one-port deployment shape.
+- Create: `docs/console/docker.md`
+  - Add the dedicated Docker deployment guide.
+- Modify: `AGENTS.md`
+  - Update repository-level startup or deployment guidance if the stable Console startup surface changes materially.
+- Modify: `.github/workflows/ci.yml`
+  - Add Docker build and smoke coverage for the supported container path.
+
+### Task 1: Add The Docker Container Lifecycle Surface To `agiwo-console`
+
+**Files:**
+- Modify: `console/server/cli.py`
+- Create: `console/server/docker_runtime.py`
+- Create: `console/server/tests/test_cli.py`
+- Create: `console/server/tests/test_docker_runtime.py`
+- Test: `console/server/tests/test_cli.py`
+- Test: `console/server/tests/test_docker_runtime.py`
+
+- [ ] **Step 1: Capture the current CLI behavior with thin regression coverage before expanding the command surface**
+
+Add tests that prove:
+
+- `agiwo-console serve` still dispatches to `uvicorn.run`
+- `--host`, `--port`, `--env-file`, and `--reload` still pass through unchanged
+
+- [ ] **Step 2: Introduce a dedicated Docker runtime module instead of embedding container logic directly in `cli.py`**
+
+Create a small module, for example `console/server/docker_runtime.py`, that owns:
+
+- Docker executable discovery
+- daemon reachability checks
+- `--data-dir` creation and writability checks
+- mount alias validation
+- Docker command construction
+- post-start health polling
+- `up`, `down`, `status`, `logs`, and `restart` execution helpers
+
+This keeps `cli.py` as a command parser and dispatch layer rather than a process-orchestration file.
+
+- [ ] **Step 3: Add the `container` command group in `console/server/cli.py`**
+
+Recommended subcommands:
+
+- `container up`
+- `container down`
+- `container status`
+- `container logs`
+- `container restart`
+
+Recommended `container up` flags:
+
+- `--name`
+- `--image`
+- `--data-dir`
+- repeated `--mount <source>:<alias>`
+- `--env-file`
+- repeated `--env KEY=VALUE`
+- `--publish`
+- `--network-mode`
+- `--pull`
+- `--replace`
+
+- [ ] **Step 4: Define and test strict preflight validation rules**
+
+Enforce these behaviors:
+
+- missing `docker` binary fails early
+- unreachable daemon fails early
+- missing `--data-dir` is created automatically, then verified writable
+- missing `--mount` source path fails
+- duplicate or invalid aliases fail
+- `--network-mode=host` fails on unsupported platforms
+- existing container name fails unless `--replace` is set
+
+- [ ] **Step 5: Define the managed `docker run` contract**
+
+The runtime helper should translate the supported flags into a controlled `docker run` invocation with defaults equivalent to:
+
+```bash
+docker run -d \
+  --name agiwo-console \
+  --restart unless-stopped \
+  -p 8422:8422 \
+  -v <data-dir>:/data \
+  -e AGIWO_ROOT_PATH=/data/root \
+  <image>
+```
+
+Each explicit mount should map to:
+
+```bash
+-v <source>:/mnt/host/<alias>
+```
+
+- [ ] **Step 6: Require health-based startup completion**
+
+`container up` should not return success just because `docker run` returned zero. It should poll `GET /api/health` on the public endpoint and only succeed once the container is actually serving traffic.
+
+On failure:
+
+- return a non-zero exit code
+- print a short diagnostic summary
+- include recent container logs or a targeted log tail
+- leave the failed container intact for debugging
+
+- [ ] **Step 7: Add CLI unit tests for success and failure paths**
+
+Cover at least:
+
+- command parsing
+- Docker argument construction
+- `--replace` behavior
+- `status` output for missing/running/stopped containers
+- health-check timeout handling
+- unsupported host-network selection
+
+- [ ] **Step 8: Run the focused backend test slice and commit**
+
+Run:
+
+```bash
+cd console
+uv run pytest server/tests/test_cli.py server/tests/test_docker_runtime.py -v
+```
+
+Then commit:
+
+```bash
+git add console/server/cli.py console/server/docker_runtime.py console/server/tests/test_cli.py console/server/tests/test_docker_runtime.py
+git commit -m "feat: add console docker lifecycle cli"
+```
+
+### Task 2: Build The Official Complete Console Runtime Image
+
+**Files:**
+- Create: `console/Dockerfile`
+- Create: `console/docker/entrypoint.sh`
+- Create: `console/docker/nginx.conf`
+- Create: `console/docker/healthcheck.sh`
+- Modify: `console/pyproject.toml`
+- Test: Docker image build and runtime smoke
+
+- [ ] **Step 1: Add a multi-stage Dockerfile for the full Console deployment unit**
+
+The Dockerfile should:
+
+- build the Web UI in a dedicated Node stage
+- install the Console backend package and runtime dependencies in the final stage
+- copy the built frontend assets or production app bundle into the final image
+- install the required runtime tools:
+  - Python
+  - Node.js / npm
+  - git
+  - bash / coreutils
+  - `curl` / `wget`
+  - `ripgrep`
+  - `jq`
+  - `ffmpeg`
+  - `yt-dlp`
+
+- [ ] **Step 2: Add a fixed container entrypoint**
+
+`console/docker/entrypoint.sh` should:
+
+- verify `/data` is writable
+- create `/data/root`, `/data/root/skills`, and `/data/runtime`
+- apply required default environment values such as `AGIWO_ROOT_PATH=/data/root`
+- start the backend, Web UI, and reverse proxy
+- terminate the container if any required subprocess exits unexpectedly
+
+- [ ] **Step 3: Add the reverse-proxy contract**
+
+Use a lightweight reverse proxy configuration so that:
+
+- `/api/*` goes to FastAPI
+- `/api/health` goes to FastAPI
+- SSE routes continue to work through the proxy
+- all other requests go to the Web UI
+
+The container should expose one public port, `8422`, and no separate documented frontend port.
+
+- [ ] **Step 4: Add a stable healthcheck**
+
+The image should include a healthcheck script that probes the same in-container public entrypoint the CLI depends on. Keep the health semantics aligned with `container up`.
+
+- [ ] **Step 5: Ensure packaging includes any runtime assets the CLI depends on**
+
+If the Console wheel needs to ship Docker templates or runtime assets for the CLI-managed path, update `console/pyproject.toml` build configuration so those files are included in the package.
+
+- [ ] **Step 6: Add a reproducible local smoke command**
+
+Verify the image can be built and run locally with a temporary data directory and that:
+
+- `GET /api/health` succeeds
+- the root browser route responds on the same port
+- `/data/root` is created
+
+- [ ] **Step 7: Commit the Docker runtime artifact**
+
+```bash
+git add console/Dockerfile console/docker/entrypoint.sh console/docker/nginx.conf console/docker/healthcheck.sh console/pyproject.toml
+git commit -m "feat: add official console docker image"
+```
+
+### Task 3: Make The Web UI Work Behind The Same-Origin Container Entry Point
+
+**Files:**
+- Modify: `console/web/src/lib/api.ts`
+- Modify: `console/web/next.config.ts`
+- Test: `console/web` lint, test, and build
+
+- [ ] **Step 1: Remove the hard-coded absolute localhost default from the frontend API layer**
+
+The current API helper defaults to `http://localhost:8422`. Replace that with same-origin-first behavior so the production container path works correctly behind the reverse proxy.
+
+Preferred behavior:
+
+- when `NEXT_PUBLIC_API_URL` is provided, use it
+- otherwise, use a relative API base such as `""` and fetch `/api/...` from the current origin
+
+- [ ] **Step 2: Review streaming and browser-only usage to ensure the new API base is safe**
+
+Confirm that:
+
+- ordinary JSON API calls still work in development
+- SSE/chat streaming calls still resolve correctly from the browser
+- the change does not break local frontend development with `NEXT_PUBLIC_API_URL=http://localhost:8422`
+
+- [ ] **Step 3: Add or update frontend tests if needed**
+
+Add targeted coverage if the API helper behavior is currently untested and the same-origin switch could regress client behavior.
+
+- [ ] **Step 4: Run the frontend verification path**
+
+Run:
+
+```bash
+cd console/web
+npm run lint
+npm test
+npm run build
+```
+
+- [ ] **Step 5: Commit the frontend deployment adjustment**
+
+```bash
+git add console/web/src/lib/api.ts console/web/next.config.ts
+git commit -m "fix: support same-origin console api in docker mode"
+```
+
+### Task 4: Document The Docker Deployment Model And Operator Rules
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/console/overview.md`
+- Create: `docs/console/docker.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update the root README to introduce the supported Docker path**
+
+Document:
+
+- `agiwo-console serve` as host mode
+- `agiwo-console container up` as container mode
+- the one-port access story
+- the unified data-root model
+- explicit host mounts for agent-visible directories
+
+- [ ] **Step 2: Expand `docs/console/overview.md` with the two startup modes**
+
+Clarify:
+
+- host mode versus container mode
+- what runs inside the container
+- why host directories are not visible by default
+- why `host` networking is advanced-only
+
+- [ ] **Step 3: Add a dedicated Docker guide**
+
+Create `docs/console/docker.md` with:
+
+- prerequisites
+- example `container up` command
+- data-root explanation
+- mount examples
+- environment variable guidance
+- troubleshooting for image pull failures, health-check failures, and mount mistakes
+
+- [ ] **Step 4: Update AGENTS.md only if stable startup or deployment guidance materially changes**
+
+Keep AGENTS at the directory/API boundary level. Only add Docker-related notes if they are truly stable repository rules rather than implementation details.
+
+- [ ] **Step 5: Commit the documentation pass**
+
+```bash
+git add README.md docs/console/overview.md docs/console/docker.md AGENTS.md
+git commit -m "docs: add console docker deployment guide"
+```
+
+### Task 5: Add Continuous Validation For The Official Docker Path
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Test: CI-equivalent local checks where feasible
+
+- [ ] **Step 1: Add Docker image build validation to CI**
+
+At minimum, CI should prove the official image builds successfully.
+
+- [ ] **Step 2: Add a lightweight runtime smoke path**
+
+The smoke path should:
+
+1. build the image
+2. start the container with a temporary data directory
+3. wait for the health endpoint
+4. verify the root route is reachable on the same port
+5. verify the container exits cleanly on teardown
+
+- [ ] **Step 3: Keep the coverage bounded**
+
+Do not make CI responsible for validating every optional runtime tool in an expensive end-to-end job. Keep the smoke path focused on the public deployment contract, and reserve deeper tool-presence checks for a smaller dedicated build-validation step if needed.
+
+- [ ] **Step 4: Run the repository checks that match the touched surface**
+
+Run:
+
+```bash
+uv run python scripts/lint.py ci
+cd console && uv run pytest server/tests/test_cli.py server/tests/test_docker_runtime.py -v
+cd console/web && npm run lint && npm test && npm run build
+```
+
+If the Docker smoke path is scriptable locally, run that too before finalizing.
+
+- [ ] **Step 5: Commit the CI coverage**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: validate console docker deployment path"
+```
+
+## Final Verification Checklist
+
+- [ ] `agiwo-console serve` still works as before
+- [ ] `agiwo-console container up` starts the managed container and waits for health
+- [ ] backend and frontend are reachable through the same public origin
+- [ ] Agent persistence defaults under `/data/root`
+- [ ] explicit mounts appear under `/mnt/host/<alias>`
+- [ ] undeclared host directories remain inaccessible
+- [ ] frontend API calls work with same-origin deployment
+- [ ] docs match the supported command surface

--- a/docs/superpowers/plans/2026-04-18-agiwo-console-docker-deployment.md
+++ b/docs/superpowers/plans/2026-04-18-agiwo-console-docker-deployment.md
@@ -16,9 +16,9 @@
   - Add the `container` command group and keep `serve` behavior unchanged.
 - Create: `console/server/docker_runtime.py`
   - Centralize Docker CLI argument normalization, preflight checks, command construction, and lifecycle helpers.
-- Create: `console/server/tests/test_cli.py`
+- Create: `console/tests/test_cli.py`
   - Add unit coverage for CLI parsing and Docker command dispatch.
-- Create: `console/server/tests/test_docker_runtime.py`
+- Create: `console/tests/test_docker_runtime.py`
   - Add focused tests for mount validation, alias validation, network-mode handling, and health-check behavior.
 - Create: `console/Dockerfile`
   - Build the official single-image Console runtime with backend, frontend, and runtime tools.
@@ -50,10 +50,10 @@
 **Files:**
 - Modify: `console/server/cli.py`
 - Create: `console/server/docker_runtime.py`
-- Create: `console/server/tests/test_cli.py`
-- Create: `console/server/tests/test_docker_runtime.py`
-- Test: `console/server/tests/test_cli.py`
-- Test: `console/server/tests/test_docker_runtime.py`
+- Create: `console/tests/test_cli.py`
+- Create: `console/tests/test_docker_runtime.py`
+- Test: `console/tests/test_cli.py`
+- Test: `console/tests/test_docker_runtime.py`
 
 - [ ] **Step 1: Capture the current CLI behavior with thin regression coverage before expanding the command surface**
 
@@ -159,13 +159,13 @@ Run:
 
 ```bash
 cd console
-uv run pytest server/tests/test_cli.py server/tests/test_docker_runtime.py -v
+uv run pytest tests/test_cli.py tests/test_docker_runtime.py -v
 ```
 
 Then commit:
 
 ```bash
-git add console/server/cli.py console/server/docker_runtime.py console/server/tests/test_cli.py console/server/tests/test_docker_runtime.py
+git add console/server/cli.py console/server/docker_runtime.py console/tests/test_cli.py console/tests/test_docker_runtime.py
 git commit -m "feat: add console docker lifecycle cli"
 ```
 
@@ -366,7 +366,7 @@ Run:
 
 ```bash
 uv run python scripts/lint.py ci
-cd console && uv run pytest server/tests/test_cli.py server/tests/test_docker_runtime.py -v
+cd console && uv run pytest tests/test_cli.py tests/test_docker_runtime.py -v
 cd console/web && npm run lint && npm test && npm run build
 ```
 

--- a/docs/superpowers/specs/2026-04-17-agiwo-console-docker-design.md
+++ b/docs/superpowers/specs/2026-04-17-agiwo-console-docker-design.md
@@ -1,0 +1,426 @@
+# Agiwo Console Docker Deployment Design
+
+**Goal:** Add a first-class Docker deployment path for `agiwo-console` so users can start a complete Console instance, with the API server, Web UI, Agent runtime, Bash execution, and persistence all running inside a managed container through a single CLI workflow.
+
+## Scope
+
+This design covers the first supported Docker deployment experience for `agiwo-console`.
+
+It includes:
+
+1. a full Console container image that serves both the FastAPI backend and the Web UI
+2. a new `agiwo-console container ...` CLI surface that manages the Docker container lifecycle
+3. a fixed container filesystem contract with one persistent data root and explicit host-directory mounts
+4. an official runtime image that includes the tools needed for common Agent execution paths
+5. Docker-focused documentation, validation, and operational guardrails
+
+It does not include:
+
+- replacing the existing host-mode `agiwo-console serve` flow
+- adding Docker lifecycle controls to the Web UI
+- introducing `docker compose` as the primary launch path
+- allowing implicit access to arbitrary host directories from inside the container
+- building multiple runtime image flavors in the first release
+
+## Context
+
+The current Console startup model is intentionally thin:
+
+- `agiwo-console serve` starts the FastAPI app through `uvicorn.run(...)`
+- the Web UI is started separately from `console/web`
+- runtime configuration is still driven by the existing `AGIWO_*`, `AGIWO_CONSOLE_*`, and provider credential environment variables
+- Agent execution, Bash tool execution, workspace state, and SQLite-backed persistence all currently run in the local process environment
+
+That is workable for source-based development, but it is not a one-command deployment story. It leaves users to assemble their own runtime environment, install system tools, decide where state lives, and manually keep the backend and frontend aligned.
+
+The requested Docker support is not just "put the server in a container". The intended behavior is:
+
+- users launch Console through a single deployment entrypoint
+- the Agent runtime lives inside the container
+- Bash and related tool execution stay inside the container boundary
+- persistence lives under a user-owned mounted data directory
+- host filesystem access is opt-in through explicit mounts only
+- Web UI access is included in the same Dockerized deployment unit
+
+That makes this a deployment-shape feature, not just a packaging tweak.
+
+## Decision
+
+Ship a first-party Docker deployment mode for `agiwo-console` with these product-level rules:
+
+1. `agiwo-console serve` remains the host-mode startup path
+2. `agiwo-console container ...` becomes the supported Docker lifecycle interface
+3. the official Docker deployment unit is one image and one container that serves both backend and Web UI
+4. all default persistent state lives under one mounted data root inside the container
+5. host directory access is denied by default and only enabled through explicit user-provided mounts
+6. the first official image is a single full-feature runtime image rather than a minimal base image
+
+## Alternatives Considered
+
+### 1. Backend-Only Containerization
+
+Containerize only `console/server` and keep the Web UI outside the first release.
+
+Why not chosen:
+
+- it falls short of the stated one-command deployment goal
+- it still exposes frontend startup and API wiring details to the user
+- it creates a hybrid deployment story instead of a complete supported shape
+
+### 2. CLI Wrapper Around External Docker Files Only
+
+Ship Dockerfile and docs, but keep the CLI as a thin helper around user-managed Docker invocations.
+
+Why not chosen:
+
+- it creates two competing "official" startup paths
+- container naming, path mapping, health checks, and diagnostics become inconsistent
+- it weakens the product-level ergonomics of the new deployment mode
+
+### 3. `docker compose` As The First-Class Launch Path
+
+Generate or manage Compose files and use them as the default deployment interface.
+
+Why not chosen for the first release:
+
+- it adds another artifact format and lifecycle to maintain
+- the requested feature can be satisfied cleanly with direct `docker run`
+- the current Console CLI already has a command-oriented startup model, so extending that surface is simpler
+
+## Deployment Unit
+
+The first Docker deployment should be a complete Console unit, not a backend-only runtime.
+
+The official image should include:
+
+- the Python Console server
+- the production-built Next.js Web UI
+- the Agent runtime dependencies and common CLI tools
+- a container entrypoint that starts the required internal processes
+
+The official container should expose one external port and one browser entrypoint. Users should not have to think in terms of separate frontend and backend ports during the supported Docker flow.
+
+Internally, the container should run three logical pieces:
+
+- the FastAPI backend
+- the Web UI server
+- a lightweight reverse proxy that exposes one public port and routes traffic to the correct internal service
+
+Routing contract:
+
+- `/api/*`, health checks, and SSE traffic go to the FastAPI backend
+- all non-API browser routes go to the Web UI
+
+This keeps the public surface simple while preserving the existing application boundaries.
+
+## CLI Command Surface
+
+The Docker path should extend the existing `agiwo-console` CLI rather than creating a new executable.
+
+Recommended commands:
+
+- `agiwo-console serve`
+- `agiwo-console container up`
+- `agiwo-console container down`
+- `agiwo-console container status`
+- `agiwo-console container logs`
+- `agiwo-console container restart`
+
+`serve` remains the host-mode path.
+
+`container up` is the primary deployment command. It should accept a tightly scoped set of arguments that describe deployment intent rather than exposing arbitrary Docker pass-through behavior.
+
+Recommended `up` arguments:
+
+- `--name` for the managed container name, defaulting to something stable such as `agiwo-console`
+- `--image` to override the image tag
+- `--data-dir` for the required persistent host data root
+- repeated `--mount <source>:<alias>` options for explicit host directory mounts
+- `--env-file` for provider credentials and runtime configuration
+- repeated `--env KEY=VALUE` overrides
+- `--publish` for port mapping, defaulting to `8422:8422`
+- `--network-mode` with `bridge` as the default and `host` as an advanced option
+- `--pull` to optionally refresh the image before startup
+- `--replace` to remove and recreate an existing managed container of the same name
+
+The CLI should translate those arguments into a controlled `docker run` invocation.
+
+Default behavior for the first release:
+
+- detached startup
+- `--restart unless-stopped`
+- port mapping `8422:8422`
+- host data directory mounted to `/data`
+- each declared host mount mapped to `/mnt/host/<alias>`
+
+The CLI should remain opinionated. It should not become a generic Docker argument tunnel in the first release.
+
+## Filesystem And Path Model
+
+The Docker design should split filesystem visibility into two explicit classes.
+
+### 1. Persistent Console-Owned Data Root
+
+The user provides one host data directory. The CLI mounts it to `/data` inside the container.
+
+All default persistent state should derive from that mounted root, including:
+
+- SDK root path
+- SQLite-backed persistence
+- trace and metadata state
+- agent workspace state
+- runtime logs
+- a default location for user-managed custom skills
+
+Recommended internal layout:
+
+- `/data/root` as the effective `AGIWO_ROOT_PATH`
+- `/data/root/skills` as the default custom skills location
+- `/data/runtime` for deployment-owned runtime outputs such as logs or auxiliary state
+
+This keeps all first-party persistent state under one obvious host-owned directory.
+
+### 2. Explicit Host Workspace Mounts
+
+Host filesystem access for Agent work must be opt-in.
+
+Rules:
+
+- the container does not automatically see the current working directory
+- the container does not automatically see the user home directory
+- every host directory that should be visible to Agent tools must be declared explicitly through `--mount`
+
+Each explicit mount should appear inside the container as:
+
+- `/mnt/host/<alias>`
+
+This gives the runtime a stable and documented container-path convention while keeping the host boundary explicit.
+
+### Path Semantics
+
+In Docker mode, Console users are working with container paths, not raw host absolute paths.
+
+That must be reflected consistently in:
+
+- docs
+- CLI help text
+- error messages
+- any Console UI surfaces that display configured skill or workspace paths
+
+The design should avoid ambiguous mixed semantics such as showing a host path in one place and requiring a container path elsewhere.
+
+## Runtime Image
+
+The first official image should prioritize deployability over minimal size.
+
+The image should include at least:
+
+- Python
+- Node.js and npm
+- git
+- bash and common shell utilities
+- `curl` and `wget`
+- `ripgrep`
+- `jq`
+- `ffmpeg`
+- `yt-dlp`
+
+This set matches the stated requirement that Agent execution inside the container should feel like a usable runtime rather than a stripped API appliance.
+
+The first release should ship one full-feature official image. It should not split into `base`, `media`, or similar variants yet.
+
+## Container Process Model
+
+The container should use a multi-stage build and a fixed startup entrypoint.
+
+Recommended internal service shape:
+
+- FastAPI backend listens on an internal loopback port, for example `127.0.0.1:18080`
+- Web UI listens on an internal loopback port, for example `127.0.0.1:13000`
+- a lightweight reverse proxy listens on the public container port `8422`
+
+The entrypoint should:
+
+1. verify that `/data` exists and is writable
+2. create required subdirectories such as `/data/root` and `/data/runtime`
+3. apply the container-mode default environment contract
+4. start backend, frontend, and reverse proxy
+5. exit the container if any required subprocess dies unexpectedly
+
+The reverse proxy should be the only externally visible listener. That keeps the public contract simple and decouples browser access from the internal service topology.
+
+## Configuration Model
+
+Docker mode should not invent a second business configuration system.
+
+### Existing Config Remains Canonical
+
+The application inside the container should continue to read:
+
+- `AGIWO_*` for SDK settings
+- `AGIWO_CONSOLE_*` for Console settings
+- provider credentials such as `OPENAI_API_KEY`
+
+The backend and runtime should not care whether they were started through host mode or Docker mode.
+
+### CLI Deployment Parameters Stay Separate
+
+Deployment parameters such as:
+
+- `--data-dir`
+- `--mount`
+- `--publish`
+- `--network-mode`
+- `--name`
+- `--replace`
+
+belong to the host-side CLI orchestration layer. They should influence Docker startup, not become new application configuration objects.
+
+### Minimal Bridge Defaults
+
+The CLI may inject a small number of container-specific defaults when starting the official container.
+
+The main required default is:
+
+- `AGIWO_ROOT_PATH=/data/root`
+
+Beyond that, the design should minimize new bridge variables. Docker mode is a deployment carrier for the existing config system, not a new settings hierarchy.
+
+### Frontend API Base Handling
+
+The Web UI should prefer same-origin API access in Docker mode instead of relying on a hard-coded absolute default such as `http://localhost:8422`.
+
+This change is important even outside Docker packaging, because the supported container deployment exposes frontend and backend behind one external origin. The browser-facing API strategy should align with that deployment contract.
+
+## Error Handling
+
+The CLI should validate deployment preconditions before attempting `docker run`.
+
+Required preflight checks:
+
+- `docker` binary exists
+- the Docker daemon is reachable
+- the declared data directory is created automatically when missing, then verified writable
+- the data directory is writable
+- each `--mount` source path exists
+- each mount alias is unique and matches a restricted safe pattern such as `[A-Za-z0-9._-]+`
+- `--network-mode=host` is rejected when unsupported on the current platform
+- container name conflicts fail clearly unless `--replace` is set
+
+Startup success for `container up` should mean more than "Docker returned exit code 0". The CLI should wait for the managed container to become healthy through the public health endpoint.
+
+Recommended success condition:
+
+- container is running
+- `GET /api/health` succeeds within a bounded timeout
+
+On health failure, the CLI should:
+
+- return a non-zero exit code
+- print a short diagnostic summary
+- include recent container logs or a targeted tail
+- leave the failed container in place for inspection rather than silently removing it
+
+## Platform Behavior
+
+The default network mode should be bridge plus explicit port publishing.
+
+That means the first supported path is effectively:
+
+- `-p 8422:8422`
+
+`host` networking should remain available as an advanced option, but not the default. This avoids making the primary Docker path depend on Linux-specific network behavior and keeps the one-command deployment more portable.
+
+## Testing And Validation
+
+Validation should be split across unit, integration, and smoke layers.
+
+### CLI Tests
+
+Add Python tests that cover:
+
+- parser behavior for `container` subcommands
+- `docker run` argument construction
+- validation of `--data-dir`, `--mount`, `--replace`, and `--network-mode`
+- health-check success and failure behavior
+- stable error handling when Docker or the target container is unavailable
+
+### Image Build Validation
+
+The repository should validate that the Docker image builds and contains the required runtime tools, including:
+
+- Python
+- Node.js
+- `ffmpeg`
+- `yt-dlp`
+- git
+- `ripgrep`
+- `jq`
+
+### Runtime Integration Validation
+
+At least one automated integration path should verify:
+
+1. `agiwo-console container up` starts the official image
+2. `GET /api/health` succeeds through the public port
+3. the browser-facing root route is reachable from the same public port
+4. default persistence resolves under `/data/root`
+5. explicit host mounts appear under `/mnt/host/<alias>`
+6. undeclared host paths are not visible inside the container
+
+### Documentation Smoke
+
+At least one documented Docker startup command should be exercised in CI or a release smoke workflow so the public docs do not drift from the supported path.
+
+## Documentation Changes
+
+The Docker deployment mode should update the live documentation set, at minimum:
+
+- `README.md`
+- `docs/console/overview.md`
+- a dedicated Docker deployment guide for Console
+
+The docs should describe:
+
+- the difference between host mode and container mode
+- the single data-root model
+- the explicit host-mount model
+- the one-port browser access contract
+- the official CLI commands for container lifecycle management
+- platform caveats for `--network-mode=host`
+
+## Acceptance Criteria
+
+The design is complete when the implementation delivers all of the following:
+
+1. users can start a complete Console deployment through one `agiwo-console container up ...` command
+2. the deployment exposes one browser-facing origin and one default public port
+3. Agent and Bash execution run inside the container rather than on the host
+4. all default persistent state is rooted under the user-provided data directory
+5. host filesystem access requires explicit user-provided mounts
+6. the existing `agiwo-console serve` host-mode startup path still works
+
+## Implementation Outline
+
+The implementation should proceed in three stages.
+
+### Stage 1: Docker Runtime Artifact
+
+- add the official Dockerfile and container entrypoint
+- build and serve the Web UI inside the image
+- add the reverse proxy and internal process wiring
+- establish the `/data` and `/mnt/host/*` path conventions
+
+### Stage 2: CLI Container Lifecycle
+
+- extend `console/server/cli.py` with the `container` command group
+- implement `up`, `down`, `status`, `logs`, and `restart`
+- add deployment preflight validation and post-start health checks
+- keep `serve` unchanged as the host-mode path
+
+### Stage 3: Documentation And Validation
+
+- add Docker deployment documentation
+- update existing Console startup docs to explain both modes clearly
+- add CLI tests, image validation, and runtime smoke coverage
+- ensure the repository can continuously validate the public Docker path

--- a/scripts/smoke_console_docker.py
+++ b/scripts/smoke_console_docker.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from os import getgid, getuid
 from pathlib import Path
 from urllib.request import urlopen
 from uuid import uuid4
@@ -55,6 +56,34 @@ def wait_for_http(url: str, *, timeout_seconds: float) -> None:
     raise SystemExit(f"Timed out waiting for {url}: {last_error}")
 
 
+def fix_volume_ownership(
+    docker: str,
+    image: str,
+    *,
+    data_dir: Path,
+    workspace_dir: Path,
+) -> None:
+    subprocess.run(
+        [
+            docker,
+            "run",
+            "--rm",
+            "-v",
+            f"{data_dir}:/data",
+            "-v",
+            f"{workspace_dir}:/mnt/host/workspace",
+            "--entrypoint",
+            "sh",
+            image,
+            "-c",
+            f"chown -R {getuid()}:{getgid()} /data /mnt/host/workspace",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def main() -> int:
     docker = shutil.which("docker")
     if docker is None:
@@ -63,59 +92,65 @@ def main() -> int:
     image = f"agiwo-console-smoke:{uuid4().hex[:8]}"
     container = f"agiwo-console-smoke-{uuid4().hex[:8]}"
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        data_dir = tmp_path / "data"
-        workspace_dir = tmp_path / "workspace"
-        data_dir.mkdir()
-        workspace_dir.mkdir()
+    tmp_path = Path(tempfile.mkdtemp(prefix="agiwo-console-smoke-"))
+    data_dir = tmp_path / "data"
+    workspace_dir = tmp_path / "workspace"
+    data_dir.mkdir()
+    workspace_dir.mkdir()
 
-        try:
-            run(
-                [docker, "build", "-f", "console/Dockerfile", "-t", image, "."],
-                cwd=ROOT,
-            )
-            run(
-                [
-                    docker,
-                    "run",
-                    "-d",
-                    "--name",
-                    container,
-                    "-p",
-                    f"{HOST_PORT}:8422",
-                    "-v",
-                    f"{data_dir}:/data",
-                    "-v",
-                    f"{workspace_dir}:/mnt/host/workspace",
-                    image,
-                ],
-                cwd=ROOT,
-            )
+    try:
+        run(
+            [docker, "build", "-f", "console/Dockerfile", "-t", image, "."],
+            cwd=ROOT,
+        )
+        run(
+            [
+                docker,
+                "run",
+                "-d",
+                "--name",
+                container,
+                "-p",
+                f"{HOST_PORT}:8422",
+                "-v",
+                f"{data_dir}:/data",
+                "-v",
+                f"{workspace_dir}:/mnt/host/workspace",
+                image,
+            ],
+            cwd=ROOT,
+        )
 
-            wait_for_http(
-                f"http://127.0.0.1:{HOST_PORT}/api/health",
-                timeout_seconds=HEALTH_TIMEOUT_SECONDS,
-            )
-            wait_for_http(
-                f"http://127.0.0.1:{HOST_PORT}/",
-                timeout_seconds=HEALTH_TIMEOUT_SECONDS,
-            )
+        wait_for_http(
+            f"http://127.0.0.1:{HOST_PORT}/api/health",
+            timeout_seconds=HEALTH_TIMEOUT_SECONDS,
+        )
+        wait_for_http(
+            f"http://127.0.0.1:{HOST_PORT}/",
+            timeout_seconds=HEALTH_TIMEOUT_SECONDS,
+        )
 
-            if not (data_dir / "root").is_dir():
-                raise SystemExit("Expected data root to be created under mounted /data")
+        if not (data_dir / "root").is_dir():
+            raise SystemExit("Expected data root to be created under mounted /data")
 
-            run([docker, "exec", container, "test", "-d", "/mnt/host/workspace"])
-        finally:
-            subprocess.run(
-                [docker, "logs", container],
-                cwd=ROOT,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-            subprocess.run([docker, "rm", "-f", container], check=False)
-            subprocess.run([docker, "rmi", image], check=False)
+        run([docker, "exec", container, "test", "-d", "/mnt/host/workspace"])
+    finally:
+        subprocess.run(
+            [docker, "logs", container],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        subprocess.run([docker, "rm", "-f", container], check=False)
+        fix_volume_ownership(
+            docker,
+            image,
+            data_dir=data_dir,
+            workspace_dir=workspace_dir,
+        )
+        subprocess.run([docker, "rmi", image], check=False)
+        shutil.rmtree(tmp_path, ignore_errors=False)
 
     print("console docker smoke ok")
     return 0

--- a/scripts/smoke_console_docker.py
+++ b/scripts/smoke_console_docker.py
@@ -1,4 +1,5 @@
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -11,7 +12,7 @@ from uuid import uuid4
 ROOT = Path(__file__).resolve().parent.parent
 TIMEOUT_SECONDS = 300
 HEALTH_TIMEOUT_SECONDS = 120
-HOST_PORT = 18422
+CONTAINER_PORT = 8422
 
 
 def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -56,6 +57,12 @@ def wait_for_http(url: str, *, timeout_seconds: float) -> None:
     raise SystemExit(f"Timed out waiting for {url}: {last_error}")
 
 
+def reserve_host_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
 def fix_volume_ownership(
     docker: str,
     image: str,
@@ -91,6 +98,7 @@ def main() -> int:
 
     image = f"agiwo-console-smoke:{uuid4().hex[:8]}"
     container = f"agiwo-console-smoke-{uuid4().hex[:8]}"
+    host_port = reserve_host_port()
 
     tmp_path = Path(tempfile.mkdtemp(prefix="agiwo-console-smoke-"))
     data_dir = tmp_path / "data"
@@ -111,7 +119,7 @@ def main() -> int:
                 "--name",
                 container,
                 "-p",
-                f"{HOST_PORT}:8422",
+                f"{host_port}:{CONTAINER_PORT}",
                 "-v",
                 f"{data_dir}:/data",
                 "-v",
@@ -122,11 +130,11 @@ def main() -> int:
         )
 
         wait_for_http(
-            f"http://127.0.0.1:{HOST_PORT}/api/health",
+            f"http://127.0.0.1:{host_port}/api/health",
             timeout_seconds=HEALTH_TIMEOUT_SECONDS,
         )
         wait_for_http(
-            f"http://127.0.0.1:{HOST_PORT}/",
+            f"http://127.0.0.1:{host_port}/",
             timeout_seconds=HEALTH_TIMEOUT_SECONDS,
         )
 
@@ -135,13 +143,17 @@ def main() -> int:
 
         run([docker, "exec", container, "test", "-d", "/mnt/host/workspace"])
     finally:
-        subprocess.run(
+        logs = subprocess.run(
             [docker, "logs", container],
             cwd=ROOT,
             text=True,
             capture_output=True,
             check=False,
         )
+        if logs.stdout:
+            print(logs.stdout, file=sys.stderr, end="")
+        if logs.stderr:
+            print(logs.stderr, file=sys.stderr, end="")
         subprocess.run([docker, "rm", "-f", container], check=False)
         fix_volume_ownership(
             docker,

--- a/scripts/smoke_console_docker.py
+++ b/scripts/smoke_console_docker.py
@@ -1,0 +1,125 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.request import urlopen
+from uuid import uuid4
+
+ROOT = Path(__file__).resolve().parent.parent
+TIMEOUT_SECONDS = 300
+HEALTH_TIMEOUT_SECONDS = 120
+HOST_PORT = 18422
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            check=True,
+            timeout=TIMEOUT_SECONDS,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            print(exc.stdout, file=sys.stderr)
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        raise SystemExit(exc.returncode) from exc
+    except subprocess.TimeoutExpired as exc:
+        print(
+            "Command timed out after "
+            f"{TIMEOUT_SECONDS}s: {' '.join(str(part) for part in cmd)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+
+
+def wait_for_http(url: str, *, timeout_seconds: float) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url, timeout=3.0) as response:
+                if getattr(response, "status", None) == 200:
+                    return
+                last_error = RuntimeError(
+                    f"unexpected status {response.status} for {url}"
+                )
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        time.sleep(1)
+    raise SystemExit(f"Timed out waiting for {url}: {last_error}")
+
+
+def main() -> int:
+    docker = shutil.which("docker")
+    if docker is None:
+        raise SystemExit("docker executable not found in PATH")
+
+    image = f"agiwo-console-smoke:{uuid4().hex[:8]}"
+    container = f"agiwo-console-smoke-{uuid4().hex[:8]}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        data_dir = tmp_path / "data"
+        workspace_dir = tmp_path / "workspace"
+        data_dir.mkdir()
+        workspace_dir.mkdir()
+
+        try:
+            run(
+                [docker, "build", "-f", "console/Dockerfile", "-t", image, "."],
+                cwd=ROOT,
+            )
+            run(
+                [
+                    docker,
+                    "run",
+                    "-d",
+                    "--name",
+                    container,
+                    "-p",
+                    f"{HOST_PORT}:8422",
+                    "-v",
+                    f"{data_dir}:/data",
+                    "-v",
+                    f"{workspace_dir}:/mnt/host/workspace",
+                    image,
+                ],
+                cwd=ROOT,
+            )
+
+            wait_for_http(
+                f"http://127.0.0.1:{HOST_PORT}/api/health",
+                timeout_seconds=HEALTH_TIMEOUT_SECONDS,
+            )
+            wait_for_http(
+                f"http://127.0.0.1:{HOST_PORT}/",
+                timeout_seconds=HEALTH_TIMEOUT_SECONDS,
+            )
+
+            if not (data_dir / "root").is_dir():
+                raise SystemExit("Expected data root to be created under mounted /data")
+
+            run([docker, "exec", container, "test", "-d", "/mnt/host/workspace"])
+        finally:
+            subprocess.run(
+                [docker, "logs", container],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            subprocess.run([docker, "rm", "-f", container], check=False)
+            subprocess.run([docker, "rmi", image], check=False)
+
+    print("console docker smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `agiwo-console container` lifecycle commands with Docker preflight checks, mount validation, and health-based startup
- add the first complete Console Docker runtime artifact, including the Dockerfile, entrypoint, reverse proxy, and Docker smoke script
- switch the web client to same-origin API access by default and document the new host-mode versus container-mode startup paths
- add CI coverage for the Console Docker deployment smoke path

## Testing
- `uv run python scripts/lint.py changed`
- `cd console && uv run pytest tests/test_cli.py tests/test_docker_runtime.py -v`
- `cd console/web && npm run lint`
- `cd console/web && npm test`
- `cd console/web && npm run build`
- `git push -u origin refactor/console-docker-deployment` (ran pre-push gate: `scripts/lint.py ci`, SDK tests, Console tests)

## Notes
- I attempted to run the new local Docker smoke script, but the local build was blocked while Docker tried to fetch `python:3.11-slim` and `node:20-bookworm-slim` from Docker Hub due network timeouts. The failure happened before the container runtime logic started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `agiwo-console container` command with up/down/status/logs/restart subcommands for Docker-based deployment.
  * Enables starting Console backend, Web UI, and agent runtime in a managed container with persistent data storage and optional host directory mounting.
  * Supports environment configuration via `--env-file` and individual `--env` flags.

* **Documentation**
  * Updated README with Docker deployment instructions and Quick Start guide.
  * Added comprehensive Docker deployment documentation and design specifications.

* **Tests**
  * Added Docker smoke tests in CI pipeline.
  * Added test coverage for container CLI commands and Docker runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->