### PR TITLE
fix: retry llm stream creation

### DIFF
--- a/agiwo/llm/anthropic.py
+++ b/agiwo/llm/anthropic.py
@@ -95,6 +95,28 @@ class AnthropicModel(Model):
         )
 
     @retry_async(exceptions=ANTHROPIC_RETRYABLE)
+    async def _create_stream(
+        self,
+        *,
+        actual_model: str,
+        anthropic_messages: list[dict],
+        anthropic_tools: list[dict] | None,
+        params: dict[str, Any],
+    ) -> AsyncIterator[object]:
+        try:
+            return await self.client.messages.create(**params)
+        except Exception as e:
+            logger.error(
+                "llm_request_failed",
+                model=actual_model,
+                error=str(e),
+                error_type=type(e).__name__,
+                messages_count=len(anthropic_messages),
+                tools_count=len(anthropic_tools) if anthropic_tools else 0,
+                exc_info=True,
+            )
+            raise
+
     async def arun_stream(
         self,
         messages: list[dict],
@@ -141,19 +163,12 @@ class AnthropicModel(Model):
             detail=params,
         )
 
-        try:
-            stream = await self.client.messages.create(**params)
-        except Exception as e:
-            logger.error(
-                "llm_request_failed",
-                model=actual_model,
-                error=str(e),
-                error_type=type(e).__name__,
-                messages_count=len(anthropic_messages),
-                tools_count=len(anthropic_tools) if anthropic_tools else 0,
-                exc_info=True,
-            )
-            raise
+        stream = await self._create_stream(
+            actual_model=actual_model,
+            anthropic_messages=anthropic_messages,
+            anthropic_tools=anthropic_tools,
+            params=params,
+        )
 
         translator = AnthropicStreamTranslator(include_reasoning=True)
 

--- a/agiwo/llm/bedrock_anthropic.py
+++ b/agiwo/llm/bedrock_anthropic.py
@@ -95,6 +95,42 @@ class BedrockAnthropicModel(Model):
         return self._client
 
     @retry_async(exceptions=(BedrockRetryableError,))
+    async def _invoke_stream(
+        self,
+        *,
+        anthropic_messages: list[dict],
+        anthropic_tools: list[dict] | None,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            client = self._get_client()
+            return await asyncio.to_thread(
+                client.invoke_model_with_response_stream,
+                modelId=self.id,
+                body=json.dumps(body),
+            )
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"] if hasattr(e, "response") else None
+            logger.error(
+                "bedrock_request_failed",
+                model=self.id,
+                error=str(e),
+                error_code=error_code,
+                exc_info=True,
+            )
+            if error_code in BEDROCK_RETRYABLE_ERROR_CODES:
+                raise BedrockRetryableError(str(e)) from e
+            raise
+        except Exception as e:
+            logger.error(
+                "bedrock_request_failed",
+                model=self.id,
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
+            raise
+
     async def arun_stream(  # noqa: C901
         self,
         messages: list[dict],
@@ -134,61 +170,37 @@ class BedrockAnthropicModel(Model):
             tools_count=len(anthropic_tools) if anthropic_tools else 0,
         )
 
-        try:
-            client = self._get_client()
-            response = await asyncio.to_thread(
-                client.invoke_model_with_response_stream,
-                modelId=self.id,
-                body=json.dumps(body),
+        response = await self._invoke_stream(
+            anthropic_messages=anthropic_messages,
+            anthropic_tools=anthropic_tools,
+            body=body,
+        )
+
+        translator = AnthropicStreamTranslator(include_reasoning=False)
+
+        sync_queue: _queue.SimpleQueue[dict | None] = _queue.SimpleQueue()
+
+        def _read_stream() -> None:
+            try:
+                for event in response["body"]:
+                    sync_queue.put(json.loads(event["chunk"]["bytes"].decode()))
+            finally:
+                sync_queue.put(None)
+
+        loop = asyncio.get_running_loop()
+        reader_task = loop.run_in_executor(None, _read_stream)
+
+        while True:
+            chunk_data = await loop.run_in_executor(None, sync_queue.get)
+            if chunk_data is None:
+                break
+            stream_chunk = translator.process(
+                normalize_bedrock_anthropic_event(chunk_data)
             )
+            if stream_chunk is not None:
+                yield stream_chunk
 
-            translator = AnthropicStreamTranslator(include_reasoning=False)
-
-            sync_queue: _queue.SimpleQueue[dict | None] = _queue.SimpleQueue()
-
-            def _read_stream() -> None:
-                try:
-                    for event in response["body"]:
-                        sync_queue.put(json.loads(event["chunk"]["bytes"].decode()))
-                finally:
-                    sync_queue.put(None)
-
-            loop = asyncio.get_running_loop()
-            reader_task = loop.run_in_executor(None, _read_stream)
-
-            while True:
-                chunk_data = await loop.run_in_executor(None, sync_queue.get)
-                if chunk_data is None:
-                    break
-                stream_chunk = translator.process(
-                    normalize_bedrock_anthropic_event(chunk_data)
-                )
-                if stream_chunk is not None:
-                    yield stream_chunk
-
-            await reader_task
-
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"] if hasattr(e, "response") else None
-            logger.error(
-                "bedrock_request_failed",
-                model=self.id,
-                error=str(e),
-                error_code=error_code,
-                exc_info=True,
-            )
-            if error_code in BEDROCK_RETRYABLE_ERROR_CODES:
-                raise BedrockRetryableError(str(e)) from e
-            raise
-        except Exception as e:
-            logger.error(
-                "bedrock_request_failed",
-                model=self.id,
-                error=str(e),
-                error_type=type(e).__name__,
-                exc_info=True,
-            )
-            raise
+        await reader_task
 
 
 __all__ = ["BedrockAnthropicModel"]

--- a/agiwo/llm/openai.py
+++ b/agiwo/llm/openai.py
@@ -95,6 +95,37 @@ class OpenAIModel(Model):
         )
 
     @retry_async(exceptions=OPENAI_RETRYABLE)
+    async def _create_stream(
+        self,
+        *,
+        actual_model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+        params: dict[str, object],
+    ) -> AsyncIterator[object]:
+        try:
+            return await self.client.chat.completions.create(**params)
+        except Exception as e:
+            # Extract status code for better error classification (e.g., OpenRouter 429)
+            status_code = None
+            if hasattr(e, "status_code") and e.status_code is not None:
+                status_code = e.status_code
+            elif hasattr(e, "response") and hasattr(e.response, "status_code"):
+                status_code = e.response.status_code
+
+            error_msg = str(e)
+            logger.error(
+                "llm_request_failed",
+                model=actual_model,
+                error=error_msg,
+                error_type=type(e).__name__,
+                status_code=status_code,
+                messages_count=len(messages),
+                tools_count=len(tools) if tools else 0,
+                exc_info=True,
+            )
+            raise
+
     async def arun_stream(  # noqa: C901
         self,
         messages: list[dict],
@@ -138,28 +169,12 @@ class OpenAIModel(Model):
             detail=params,
         )
 
-        try:
-            stream = await self.client.chat.completions.create(**params)
-        except Exception as e:
-            # Extract status code for better error classification (e.g., OpenRouter 429)
-            status_code = None
-            if hasattr(e, "status_code") and e.status_code is not None:
-                status_code = e.status_code
-            elif hasattr(e, "response") and hasattr(e.response, "status_code"):
-                status_code = e.response.status_code
-
-            error_msg = str(e)
-            logger.error(
-                "llm_request_failed",
-                model=actual_model,
-                error=error_msg,
-                error_type=type(e).__name__,
-                status_code=status_code,
-                messages_count=len(messages),
-                tools_count=len(tools) if tools else 0,
-                exc_info=True,
-            )
-            raise
+        stream = await self._create_stream(
+            actual_model=actual_model,
+            messages=messages,
+            tools=tools,
+            params=params,
+        )
 
         chunk_count = 0
         logger.info("openai_stream_started", model=actual_model)

--- a/agiwo/llm/openai_response.py
+++ b/agiwo/llm/openai_response.py
@@ -1,3 +1,4 @@
+from contextlib import AsyncExitStack
 from typing import AsyncIterator
 import json
 import httpx
@@ -285,6 +286,36 @@ class OpenAIResponsesModel(Model):
                 current_data = line[len("data:") :].strip()
 
     @retry_async(exceptions=OPENAI_RETRYABLE)
+    async def _open_stream(
+        self,
+        *,
+        url: str,
+        params: dict[str, object],
+        headers: dict[str, str],
+    ) -> tuple[AsyncExitStack, httpx.Response]:
+        # Keep both client and streaming response contexts open for the caller.
+        stack = AsyncExitStack()
+        try:
+            limits = httpx.Limits(max_keepalive_connections=100, max_connections=100)
+            timeout = httpx.Timeout(120.0, connect=30.0)
+            client = await stack.enter_async_context(
+                httpx.AsyncClient(timeout=timeout, limits=limits)
+            )
+            response = await stack.enter_async_context(
+                client.stream("POST", url, json=params, headers=headers)
+            )
+            if response.status_code != 200:
+                error_text = await response.aread()
+                raise httpx.HTTPStatusError(
+                    f"Request failed with status {response.status_code}: {error_text.decode()}",
+                    request=response.request,
+                    response=response,
+                )
+            return stack, response
+        except Exception:
+            await stack.aclose()
+            raise
+
     async def arun_stream(
         self,
         messages: list[dict],
@@ -321,36 +352,28 @@ class OpenAIResponsesModel(Model):
         tool_calls_state: ToolCallState = {}
         logger.info("openai_responses_stream_started", model=actual_model)
 
-        # Configure httpx with larger limits and timeout for big requests
-        limits = httpx.Limits(max_keepalive_connections=100, max_connections=100)
-        timeout = httpx.Timeout(120.0, connect=30.0)
-
-        async with httpx.AsyncClient(timeout=timeout, limits=limits) as client:
-            async with client.stream(
-                "POST", url, json=params, headers=headers
-            ) as response:
-                if response.status_code != 200:
-                    error_text = await response.aread()
-                    raise httpx.HTTPStatusError(
-                        f"Request failed with status {response.status_code}: {error_text.decode()}",
-                        request=response.request,
-                        response=response,
-                    )
-
-                async for event in self._parse_sse_stream(response):
-                    stream_chunk = self._event_to_chunk(event, tool_calls_state)
-                    if stream_chunk is None:
-                        continue
-                    if (
-                        stream_chunk.content is None
-                        and stream_chunk.reasoning_content is None
-                        and stream_chunk.tool_calls is None
-                        and stream_chunk.usage is None
-                        and stream_chunk.finish_reason is None
-                    ):
-                        continue
-                    chunk_count += 1
-                    yield stream_chunk
+        stack, response = await self._open_stream(
+            url=url,
+            params=params,
+            headers=headers,
+        )
+        try:
+            async for event in self._parse_sse_stream(response):
+                stream_chunk = self._event_to_chunk(event, tool_calls_state)
+                if stream_chunk is None:
+                    continue
+                if (
+                    stream_chunk.content is None
+                    and stream_chunk.reasoning_content is None
+                    and stream_chunk.tool_calls is None
+                    and stream_chunk.usage is None
+                    and stream_chunk.finish_reason is None
+                ):
+                    continue
+                chunk_count += 1
+                yield stream_chunk
+        finally:
+            await stack.aclose()
 
         if chunk_count == 0:
             raise RuntimeError(

--- a/tests/llm/test_anthropic.py
+++ b/tests/llm/test_anthropic.py
@@ -1,6 +1,7 @@
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+from tenacity import wait_none
 from agiwo.llm.anthropic import AnthropicModel
 
 
@@ -51,6 +52,46 @@ async def test_anthropic_model_arun_stream_basic(
     assert len(chunks) == 1
     assert chunks[0].content == "Hello"
     mock_anthropic_client.messages.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.anthropic.get_settings")
+async def test_anthropic_model_arun_stream_retries_stream_creation(
+    mock_get_settings, mock_anthropic_client
+):
+    mock_settings = mock_get_settings.return_value
+    mock_settings.anthropic_api_key = None
+    model = AnthropicModel(
+        id="claude-3-5-sonnet",
+        name="claude-3-5-sonnet",
+        api_key="test-key",
+    )
+    model.client = mock_anthropic_client
+    model._create_stream.retry.wait = wait_none()
+
+    mock_event = MagicMock()
+    mock_event.type = "content_block_delta"
+    mock_event.delta = MagicMock(type="text_delta", text="Recovered")
+    mock_event.index = 0
+
+    class _MockStream:
+        def __aiter__(self):
+            return self._iterate()
+
+        async def _iterate(self):
+            yield mock_event
+
+    mock_anthropic_client.messages.create = AsyncMock(
+        side_effect=[ConnectionError("temporary"), _MockStream()]
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    chunks = []
+    async for chunk in model.arun_stream(messages):
+        chunks.append(chunk)
+
+    assert [chunk.content for chunk in chunks] == ["Recovered"]
+    assert mock_anthropic_client.messages.create.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from tenacity import wait_none
 from agiwo.llm.openai import OpenAIModel
 
 
@@ -70,6 +71,50 @@ async def test_openai_model_arun_stream_basic(mock_get_settings, mock_openai_cli
     assert len(chunks) == 1
     assert chunks[0].content == "Hello"
     mock_openai_client.chat.completions.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("agiwo.llm.openai.get_settings")
+async def test_openai_model_arun_stream_retries_stream_creation(
+    mock_get_settings, mock_openai_client
+):
+    mock_settings = mock_get_settings.return_value
+    mock_settings.openai_api_key = None
+    model = OpenAIModel(
+        id="gpt-4",
+        name="gpt-4",
+        api_key="test-key",
+    )
+    model.client = mock_openai_client
+    model._create_stream.retry.wait = wait_none()
+
+    mock_chunk = MagicMock()
+    mock_chunk.usage = None
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content="Recovered", tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+
+    class _MockStream:
+        def __aiter__(self):
+            return self._iterate()
+
+        async def _iterate(self):
+            yield mock_chunk
+
+    mock_openai_client.chat.completions.create = AsyncMock(
+        side_effect=[ConnectionError("temporary"), _MockStream()]
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    chunks = []
+    async for chunk in model.arun_stream(messages):
+        chunks.append(chunk)
+
+    assert [chunk.content for chunk in chunks] == ["Recovered"]
+    assert mock_openai_client.chat.completions.create.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_openai_response.py
+++ b/tests/llm/test_openai_response.py
@@ -1,7 +1,9 @@
 import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from tenacity import wait_none
 
 from agiwo.llm.openai_response import OpenAIResponsesModel
 from agiwo.llm.openai_response_converter import (
@@ -375,3 +377,73 @@ async def test_parse_sse_stream_handles_failed_event() -> None:
             chunk = model._event_to_chunk(event, tool_calls_state)
             if chunk is not None:
                 pass
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_model_retries_stream_opening(monkeypatch) -> None:
+    model = OpenAIResponsesModel(
+        id="gpt-4.1-mini",
+        name="gpt-4.1-mini",
+        api_key="test-key",
+        base_url="https://example.test/v1",
+    )
+    model._open_stream.retry.wait = wait_none()
+
+    attempts = {"stream_calls": 0}
+
+    class _StreamContext:
+        def __init__(self, enter_fn):
+            self._enter_fn = enter_fn
+
+        async def __aenter__(self):
+            return self._enter_fn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    class _MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def stream(self, method, url, json, headers):
+            del method, url, json, headers
+            attempts["stream_calls"] += 1
+            if attempts["stream_calls"] == 1:
+
+                def _raise_connect_error():
+                    raise httpx.ConnectError("temporary")
+
+                return _StreamContext(_raise_connect_error)
+
+            return _StreamContext(
+                lambda: _MockHTTPXResponse(
+                    [
+                        _event("response.output_text.delta", delta="Recovered"),
+                        _event(
+                            "response.completed",
+                            response={
+                                "usage": None,
+                                "output": [{"type": "message"}],
+                                "incomplete_details": None,
+                            },
+                        ),
+                    ]
+                )
+            )
+
+    monkeypatch.setattr("agiwo.llm.openai_response.httpx.AsyncClient", _MockAsyncClient)
+
+    messages = [{"role": "user", "content": "Hello"}]
+    chunks = []
+    async for chunk in model.arun_stream(messages):
+        chunks.append(chunk)
+
+    assert chunks[0].content == "Recovered"
+    assert chunks[-1].finish_reason == "stop"
+    assert attempts["stream_calls"] == 2


### PR DESCRIPTION
## Summary
- move retry handling from async generator `arun_stream()` methods to dedicated stream-creation coroutines
- fix OpenAI, Anthropic, OpenAI Responses, and Bedrock Anthropic providers so retry applies when the streaming request is first opened
- add regression tests covering retryable stream-opening failures before the first chunk is yielded

## Root Cause
`@retry_async` was applied directly to async generator functions. The call site gets an async generator object immediately, so provider exceptions raised later during `__anext__()` never went through tenacity. That meant the promised LLM-layer retry behavior was ineffective for streaming request setup failures.

## Verification
- `uv run python scripts/lint.py ci`
- `uv run pytest tests/llm/test_openai.py tests/llm/test_anthropic.py tests/llm/test_openai_response.py -q`
- pre-push hook:
  - `uv run pytest tests/ -v --tb=short`
  - `uv run python scripts/check.py console-tests`
