### PR TITLE
fix: isolate console docker smoke from loopback proxies

### DIFF
--- a/console/tests/test_docker_runtime.py
+++ b/console/tests/test_docker_runtime.py
@@ -13,6 +13,7 @@ from server.docker_runtime import (
     parse_mount_spec,
     parse_mounts,
     resolve_healthcheck_url,
+    resolve_container_user,
     wait_for_health,
 )
 
@@ -105,6 +106,15 @@ def test_build_docker_run_command_includes_defaults_and_mounts(tmp_path: Path) -
     assert command[-1] == "example:latest"
 
 
+def test_resolve_container_user_uses_host_uid_gid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("server.docker_runtime.os.getuid", lambda: 123)
+    monkeypatch.setattr("server.docker_runtime.os.getgid", lambda: 456)
+
+    assert resolve_container_user() == "123:456"
+
+
 def test_wait_for_health_retries_until_success() -> None:
     attempts = {"count": 0}
 
@@ -147,7 +157,8 @@ def test_ensure_supported_network_mode_rejects_unknown_value() -> None:
 
 
 def test_container_up_creates_data_dir_replaces_existing_container_and_waits_for_health(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_dir = tmp_path / "data"
     mount_source = tmp_path / "workspace"
@@ -209,7 +220,8 @@ def test_container_up_creates_data_dir_replaces_existing_container_and_waits_for
 
 
 def test_container_up_pulls_before_replacing_existing_container_when_requested(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_dir = tmp_path / "data"
     calls: list[list[str]] = []

--- a/scripts/smoke_console_docker.py
+++ b/scripts/smoke_console_docker.py
@@ -4,8 +4,11 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Mapping
+from os import environ as os_environ
 from os import getgid, getuid
 from pathlib import Path
+from urllib.parse import urlsplit
 from urllib.request import urlopen
 from uuid import uuid4
 
@@ -13,6 +16,42 @@ ROOT = Path(__file__).resolve().parent.parent
 TIMEOUT_SECONDS = 300
 HEALTH_TIMEOUT_SECONDS = 120
 CONTAINER_PORT = 8422
+LOOPBACK_PROXY_HOSTS = {"127.0.0.1", "::1", "localhost"}
+PROXY_ENV_KEYS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+
+
+def _proxy_hostname(value: str) -> str | None:
+    parsed = urlsplit(value if "://" in value else f"//{value}")
+    if parsed.hostname is not None:
+        return parsed.hostname.lower()
+    return None
+
+
+def build_docker_env(
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    env = dict(os_environ if base_env is None else base_env)
+    for key in PROXY_ENV_KEYS:
+        value = env.get(key)
+        if value is None:
+            continue
+        if _proxy_hostname(value) in LOOPBACK_PROXY_HOSTS:
+            env.pop(key, None)
+    return env
+
+
+def docker_proxy_clear_build_args() -> list[str]:
+    args: list[str] = []
+    for key in PROXY_ENV_KEYS:
+        args.extend(["--build-arg", f"{key}="])
+    return args
 
 
 def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -24,6 +63,7 @@ def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProce
             timeout=TIMEOUT_SECONDS,
             text=True,
             capture_output=True,
+            env=build_docker_env(),
         )
     except subprocess.CalledProcessError as exc:
         if exc.stdout:
@@ -63,34 +103,6 @@ def reserve_host_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def fix_volume_ownership(
-    docker: str,
-    image: str,
-    *,
-    data_dir: Path,
-    workspace_dir: Path,
-) -> None:
-    subprocess.run(
-        [
-            docker,
-            "run",
-            "--rm",
-            "-v",
-            f"{data_dir}:/data",
-            "-v",
-            f"{workspace_dir}:/mnt/host/workspace",
-            "--entrypoint",
-            "sh",
-            image,
-            "-c",
-            f"chown -R {getuid()}:{getgid()} /data /mnt/host/workspace",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-
 def main() -> int:
     docker = shutil.which("docker")
     if docker is None:
@@ -108,7 +120,16 @@ def main() -> int:
 
     try:
         run(
-            [docker, "build", "-f", "console/Dockerfile", "-t", image, "."],
+            [
+                docker,
+                "build",
+                *docker_proxy_clear_build_args(),
+                "-f",
+                "console/Dockerfile",
+                "-t",
+                image,
+                ".",
+            ],
             cwd=ROOT,
         )
         run(
@@ -151,19 +172,22 @@ def main() -> int:
             text=True,
             capture_output=True,
             check=False,
+            env=build_docker_env(),
         )
         if logs.stdout:
             print(logs.stdout, file=sys.stderr, end="")
         if logs.stderr:
             print(logs.stderr, file=sys.stderr, end="")
-        subprocess.run([docker, "rm", "-f", container], check=False)
-        fix_volume_ownership(
-            docker,
-            image,
-            data_dir=data_dir,
-            workspace_dir=workspace_dir,
+        subprocess.run(
+            [docker, "rm", "-f", container],
+            check=False,
+            env=build_docker_env(),
         )
-        subprocess.run([docker, "rmi", image], check=False)
+        subprocess.run(
+            [docker, "rmi", image],
+            check=False,
+            env=build_docker_env(),
+        )
         shutil.rmtree(tmp_path, ignore_errors=False)
 
     print("console docker smoke ok")

--- a/tests/scripts/test_smoke_console_docker.py
+++ b/tests/scripts/test_smoke_console_docker.py
@@ -1,0 +1,41 @@
+import scripts.smoke_console_docker as smoke_console_docker
+
+
+def test_build_docker_env_strips_loopback_proxy_values() -> None:
+    env = smoke_console_docker.build_docker_env(
+        {
+            "HTTP_PROXY": "http://127.0.0.1:7890",
+            "HTTPS_PROXY": "https://localhost:8443",
+            "ALL_PROXY": "socks5://[::1]:1080",
+            "KEEP_ME": "value",
+        }
+    )
+
+    assert "HTTP_PROXY" not in env
+    assert "HTTPS_PROXY" not in env
+    assert "ALL_PROXY" not in env
+    assert env["KEEP_ME"] == "value"
+
+
+def test_build_docker_env_keeps_non_loopback_proxy_values() -> None:
+    env = smoke_console_docker.build_docker_env(
+        {
+            "http_proxy": "http://proxy.internal:8080",
+            "https_proxy": "https://10.0.0.2:8443",
+            "all_proxy": "socks5://corp-proxy:1080",
+        }
+    )
+
+    assert env["http_proxy"] == "http://proxy.internal:8080"
+    assert env["https_proxy"] == "https://10.0.0.2:8443"
+    assert env["all_proxy"] == "socks5://corp-proxy:1080"
+
+
+def test_docker_proxy_clear_build_args_blank_all_supported_proxy_variables() -> None:
+    build_args = smoke_console_docker.docker_proxy_clear_build_args()
+
+    assert "--build-arg" in build_args
+    assert "HTTP_PROXY=" in build_args
+    assert "http_proxy=" in build_args
+    assert "HTTPS_PROXY=" in build_args
+    assert "https_proxy=" in build_args


### PR DESCRIPTION
## Summary
- strip loopback proxy settings from the smoke script environment before invoking docker
- pass empty proxy build args so docker build does not inherit localhost proxy endpoints
- remove the obsolete smoke ownership fixup and cover the new behavior with focused tests

## Testing
- uv run pytest console/tests/test_docker_runtime.py -q
- uv run pytest tests/scripts/test_smoke_console_docker.py -q
- uv run python scripts/lint.py ci
- uv run pytest tests/ -v --tb=short
- uv run python scripts/check.py pre-push