### PR TITLE
Improve console Docker deployment flow

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,9 +20,9 @@ while read local_ref local_sha remote_ref remote_sha; do
     fi
 
     # Check prefix
-    if ! [[ "$branch_name" =~ ^(feature/|refactor/|bugfix/|release/|docs/).+ ]]; then
+    if ! [[ "$branch_name" =~ ^(feature/|feat/|refactor/|bugfix/|fix/|release/|docs/).+ ]]; then
         echo "❌ Error: Branch name '$branch_name' doesn't follow naming convention!"
-        echo "💡 Branch name must start with one of: feature/, refactor/, bugfix/, release/, docs/."
+        echo "💡 Branch name must start with one of: feature/, feat/, refactor/, bugfix/, fix/, release/, docs/."
         exit 1
     fi
 

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -74,6 +74,7 @@ EOF
 
 COPY README.md ./
 COPY agiwo ./agiwo
+COPY templates ./templates
 RUN --mount=type=cache,target=/root/.cache/pip PIP_CACHE_DIR=/root/.cache/pip pip install --no-deps --no-build-isolation .
 
 COPY console/pyproject.toml ./console/pyproject.toml

--- a/console/server/docker_runtime.py
+++ b/console/server/docker_runtime.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 from urllib.request import urlopen
 
 
@@ -15,6 +16,15 @@ DEFAULT_IMAGE = "agiwo-console:latest"
 DEFAULT_PUBLISH = "8422:8422"
 DEFAULT_HEALTH_TIMEOUT_SECONDS = 30.0
 _ALIAS_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_LOOPBACK_PROXY_HOSTS = {"127.0.0.1", "::1", "localhost"}
+_PROXY_ENV_KEYS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
 
 
 class DockerRuntimeError(RuntimeError):
@@ -101,6 +111,27 @@ def resolve_container_user() -> str | None:
     if getuid is None or getgid is None:
         return None
     return f"{getuid()}:{getgid()}"
+
+
+def _proxy_hostname(value: str) -> str | None:
+    parsed = urlsplit(value if "://" in value else f"//{value}")
+    if parsed.hostname is not None:
+        return parsed.hostname.lower()
+    return None
+
+
+def build_loopback_proxy_env_overrides(
+    base_env: dict[str, str] | None = None,
+) -> tuple[str, ...]:
+    env = os.environ if base_env is None else base_env
+    overrides: list[str] = []
+    for key in _PROXY_ENV_KEYS:
+        value = env.get(key)
+        if value is None:
+            continue
+        if _proxy_hostname(value) in _LOOPBACK_PROXY_HOSTS:
+            overrides.append(f"{key}=")
+    return tuple(overrides)
 
 
 def ensure_data_dir(data_dir: Path) -> Path:
@@ -246,6 +277,8 @@ def build_docker_run_command(
     if options.env_file:
         command.extend(["--env-file", options.env_file])
     command.extend(["-e", "AGIWO_ROOT_PATH=/data/root"])
+    for item in build_loopback_proxy_env_overrides():
+        command.extend(["-e", item])
     for item in options.env:
         command.extend(["-e", item])
     command.append(options.image)

--- a/console/tests/test_docker_runtime.py
+++ b/console/tests/test_docker_runtime.py
@@ -7,6 +7,7 @@ import pytest
 from server.docker_runtime import (
     ContainerUpOptions,
     DockerRuntimeError,
+    build_loopback_proxy_env_overrides,
     build_docker_run_command,
     container_up,
     ensure_supported_network_mode,
@@ -104,6 +105,44 @@ def test_build_docker_run_command_includes_defaults_and_mounts(tmp_path: Path) -
     assert "AGIWO_ROOT_PATH=/data/root" in command
     assert "OPENAI_API_KEY=test" in command
     assert command[-1] == "example:latest"
+
+
+def test_build_loopback_proxy_env_overrides_blanks_local_proxy_values() -> None:
+    overrides = build_loopback_proxy_env_overrides(
+        {
+            "HTTP_PROXY": "http://127.0.0.1:7890",
+            "HTTPS_PROXY": "https://localhost:8443",
+            "ALL_PROXY": "socks5://[::1]:1080",
+            "NO_PROXY": "example.com",
+        }
+    )
+
+    assert overrides == (
+        "HTTP_PROXY=",
+        "HTTPS_PROXY=",
+        "ALL_PROXY=",
+    )
+
+
+def test_build_docker_run_command_blanks_loopback_proxy_env_before_explicit_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:7890")
+    monkeypatch.setenv("HTTPS_PROXY", "https://proxy.internal:8443")
+
+    command = build_docker_run_command(
+        ContainerUpOptions(
+            data_dir=data_dir,
+            env=("OPENAI_API_KEY=test",),
+        ),
+        mounts=(),
+    )
+
+    assert "HTTP_PROXY=" in command
+    assert "HTTPS_PROXY=" not in command
+    assert command.index("HTTP_PROXY=") < command.index("OPENAI_API_KEY=test")
 
 
 def test_resolve_container_user_uses_host_uid_gid(

--- a/docs/console/docker.md
+++ b/docs/console/docker.md
@@ -23,6 +23,23 @@ agiwo-console container up \
   --env-file .env
 ```
 
+## From a Cloned Repository
+
+If you are deploying from this source repository instead of an installed
+`agiwo-console` package, use the repo shortcut script:
+
+```bash
+scripts/deploy_console.sh \
+  --env-file .env \
+  --data-dir "$HOME/agiwo-data"
+```
+
+The script builds the current `console/Dockerfile` image and then starts the managed
+container through `uv run --project console agiwo-console container up`.
+
+It forwards common container options such as `--mount`, `--env`, `--env-name`,
+`--publish`, and `--network-mode`.
+
 ## Data Root
 
 `--data-dir` is the single persistent host directory for the managed container.
@@ -63,6 +80,15 @@ agiwo-console container status
 agiwo-console container logs
 agiwo-console container restart
 agiwo-console container down
+```
+
+For a source-repo deployment, use the existing CLI for follow-up operations:
+
+```bash
+uv run --project console agiwo-console container status
+uv run --project console agiwo-console container logs
+uv run --project console agiwo-console container restart
+uv run --project console agiwo-console container down
 ```
 
 ## Notes

--- a/docs/superpowers/specs/2026-04-20-console-source-deploy-script-design.md
+++ b/docs/superpowers/specs/2026-04-20-console-source-deploy-script-design.md
@@ -1,0 +1,210 @@
+# Console Source Deploy Script Design
+
+**Goal:** Add a repo-local deployment shortcut for `agiwo-console` that builds the Console Docker image from the current source tree and starts the managed container with an explicit `--env-file <path>` input.
+
+**Architecture:** Keep image build ownership in a new repo script and reuse the existing `agiwo-console container up` lifecycle surface for container creation, replacement, health checks, and follow-up operations. The new script is a thin operator shortcut, not a replacement for the Console CLI or Docker runtime layer.
+
+**Tech Stack:** Bash, Docker, `uv`, existing `agiwo-console` CLI, existing Console Docker image at `console/Dockerfile`
+
+## Scope
+
+This design covers a source-repo deployment shortcut for Docker mode only.
+
+It includes:
+
+1. a new `scripts/deploy_console.sh` helper
+2. local image build from `console/Dockerfile`
+3. deployment through `uv run --project console agiwo-console container up`
+4. explicit `--env-file <path>` support on the script surface
+5. minimal documentation for the source-repo deployment path
+
+It does not include:
+
+1. changing the stable `agiwo-console serve` host-mode path
+2. replacing `agiwo-console container status|logs|restart|down`
+3. adding a second deployment implementation that shells out to raw `docker run`
+4. supporting ad hoc inline env overrides beyond the existing `--env-file` path
+
+## Current State
+
+The repository already has:
+
+1. a stable Console Docker image definition at `console/Dockerfile`
+2. a stable managed container lifecycle through `agiwo-console container ...`
+3. Docker runtime health-check logic in `console/server/docker_runtime.py`
+4. documentation for package-installed Docker deployment in `docs/console/docker.md`
+
+What is still missing is a repo-local shortcut that an operator can run directly from the checked-out source tree without manually remembering the build command and the follow-up `container up` invocation.
+
+## Product Decision
+
+Add a single repo script at `scripts/deploy_console.sh`.
+
+That script should:
+
+1. validate required local prerequisites
+2. build a local image from the current repository state unless told not to
+3. invoke `uv run --project console agiwo-console container up`
+4. pass through deployment intent such as `--env-file`, `--data-dir`, `--name`, `--publish`, and repeated `--mount`
+5. print the follow-up lifecycle commands the operator should use after deployment
+
+The script is intentionally narrow. It should act as a convenient deployment entrypoint for the source tree, not a new generic deployment framework.
+
+## Interface
+
+The script should expose this shape:
+
+```bash
+scripts/deploy_console.sh \
+  --env-file /path/to/.env \
+  --data-dir /path/to/data \
+  [--name agiwo-console] \
+  [--image agiwo-console:local] \
+  [--publish 8422:8422] \
+  [--mount /host/path:alias] \
+  [--mount /another/path:alias] \
+  [--no-build] \
+  [--pull]
+```
+
+### Required arguments
+
+- `--env-file <path>`: path to the environment file consumed by the managed container
+- `--data-dir <path>`: persistent host directory mounted to `/data`
+
+### Optional arguments
+
+- `--name <container-name>`: defaults to `agiwo-console`
+- `--image <tag>`: defaults to a local build tag such as `agiwo-console:local`
+- `--publish <host:container>`: defaults to `8422:8422`
+- `--mount <source:alias>`: may be repeated and is forwarded unchanged
+- `--no-build`: skip image build and use the existing local tag
+- `--pull`: forward to `container up` for image refresh behavior
+
+### Behavioral default
+
+The script should always pass `--replace` to `container up`.
+
+Reasoning:
+
+1. this script represents "deploy the current source tree"
+2. redeploying the same container name should update the running instance by default
+3. avoiding `--replace` would make repeat deployments fail on a pre-existing container, which is the wrong operator experience for a shortcut deploy command
+
+## Flow
+
+The script should execute this sequence:
+
+1. resolve the repository root relative to the script path
+2. verify `console/Dockerfile` exists
+3. verify `docker` is available in `PATH`
+4. verify `uv` is available in `PATH`
+5. verify `--env-file` was provided and the file exists
+6. verify `--data-dir` was provided
+7. create `--data-dir` with `mkdir -p`
+8. build the image with `docker build -f console/Dockerfile -t <image> .` unless `--no-build` is set
+9. run `uv run --project console agiwo-console container up ... --replace`
+10. print the public URL and follow-up lifecycle commands
+
+## Ownership Boundaries
+
+### `scripts/deploy_console.sh`
+
+Owns:
+
+1. operator-facing convenience defaults
+2. local prerequisite checks
+3. local image build from source
+4. forwarding validated arguments to the existing CLI
+
+Does not own:
+
+1. Docker container lifecycle semantics
+2. managed health-check polling
+3. mount validation rules
+4. container restart, logs, status, or teardown behavior
+
+### Existing `agiwo-console container up`
+
+Continues to own:
+
+1. container creation and replacement
+2. Docker availability checks
+3. mount parsing and validation
+4. publish/network handling
+5. startup health verification
+
+This split preserves the current architecture boundary: the new script is a repo convenience layer above the existing stable container interface.
+
+## Error Handling
+
+The script should fail fast in these cases:
+
+1. `docker` is missing
+2. `uv` is missing
+3. `console/Dockerfile` is missing
+4. `--env-file` is omitted
+5. `--env-file` points to a non-existent path
+6. `--data-dir` is omitted
+7. `docker build` fails
+8. `agiwo-console container up` fails
+
+The script should not:
+
+1. guess fallback env file paths
+2. silently continue after a failed build
+3. swallow `container up` errors
+
+When `container up` fails, the script should preserve the non-zero exit code and let the existing CLI error text surface directly.
+
+## Output
+
+The script output should stay terse and operator-focused.
+
+Expected high-signal messages:
+
+1. build start
+2. build success
+3. deployment start
+4. deployment success
+5. public URL such as `http://localhost:8422`
+6. follow-up commands for:
+   - `container status`
+   - `container logs`
+   - `container down`
+
+The script should not print a verbose derived config dump unless there is a failure.
+
+## Documentation
+
+Update `docs/console/docker.md` with a new source-repo deployment example that uses:
+
+```bash
+scripts/deploy_console.sh \
+  --env-file .env \
+  --data-dir "$HOME/agiwo-data"
+```
+
+The documentation should make two points explicit:
+
+1. this path is for operators deploying from a cloned repository
+2. post-deploy lifecycle commands still use `uv run --project console agiwo-console container ...`
+
+## Testing
+
+Minimum verification for this change:
+
+1. `uv run python scripts/lint.py ci`
+2. a script-level smoke run against a temporary env file and temporary data directory
+3. verify the managed container serves `GET /api/health`
+
+The smoke run may reuse the existing local Docker runtime and does not require introducing a new long-lived test fixture.
+
+## Acceptance Criteria
+
+1. Running `scripts/deploy_console.sh --env-file <path> --data-dir <path>` from the repo root builds the Console image and starts a healthy managed container.
+2. Re-running the same command replaces the existing container instead of failing on name collision.
+3. The script does not implement its own `docker run` deployment path.
+4. The script works with repeated `--mount <source:alias>` options.
+5. The script prints the URL and the follow-up lifecycle commands after a successful deployment.
+6. `docs/console/docker.md` documents the source-repo shortcut.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["agiwo"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"templates" = "templates"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/scripts/deploy_console.sh
+++ b/scripts/deploy_console.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/deploy_console.sh --env-file PATH --data-dir PATH [options]
+
+Options:
+  --env-file PATH       Path to the env file passed to agiwo-console container up
+  --env KEY=VALUE       Extra env passed to agiwo-console container up; may be repeated
+  --env-name NAME       Forward host env NAME into the container; may be repeated
+  --data-dir PATH       Host data directory mounted to /data
+  --name NAME           Container name (default: agiwo-console)
+  --image TAG           Local image tag (default: agiwo-console:local)
+  --publish HOST:PORT   Port mapping passed to container up (default: 8422:8422)
+  --network-mode MODE   Docker network mode passed to container up (bridge|host; default: bridge)
+  --mount SRC:ALIAS     Additional host mount; may be repeated
+  --pull                Forward --pull to container up
+  --no-build            Skip docker build and use the existing image tag
+  --help                Show this help text
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found in PATH: $1" >&2
+    exit 1
+  fi
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE=""
+DATA_DIR=""
+NAME="agiwo-console"
+IMAGE="agiwo-console:local"
+PUBLISH="8422:8422"
+NETWORK_MODE="bridge"
+DO_BUILD=1
+PULL=0
+MOUNTS=()
+EXTRA_ENVS=()
+FORWARD_ENV_NAMES=()
+BUILD_PROXY_ARGS=(
+  --build-arg HTTP_PROXY=
+  --build-arg HTTPS_PROXY=
+  --build-arg ALL_PROXY=
+  --build-arg http_proxy=
+  --build-arg https_proxy=
+  --build-arg all_proxy=
+)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    --data-dir)
+      DATA_DIR="${2:-}"
+      shift 2
+      ;;
+    --env-name)
+      FORWARD_ENV_NAMES+=("${2:-}")
+      shift 2
+      ;;
+    --env)
+      EXTRA_ENVS+=("${2:-}")
+      shift 2
+      ;;
+    --name)
+      NAME="${2:-}"
+      shift 2
+      ;;
+    --image)
+      IMAGE="${2:-}"
+      shift 2
+      ;;
+    --publish)
+      PUBLISH="${2:-}"
+      shift 2
+      ;;
+    --network-mode)
+      NETWORK_MODE="${2:-}"
+      shift 2
+      ;;
+    --mount)
+      MOUNTS+=("${2:-}")
+      shift 2
+      ;;
+    --pull)
+      PULL=1
+      shift
+      ;;
+    --no-build)
+      DO_BUILD=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ENV_FILE" ]]; then
+  echo "--env-file is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file does not exist: $ENV_FILE" >&2
+  exit 1
+fi
+
+if [[ -z "$DATA_DIR" ]]; then
+  echo "--data-dir is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -f "$ROOT/console/Dockerfile" ]]; then
+  echo "Missing Dockerfile: $ROOT/console/Dockerfile" >&2
+  exit 1
+fi
+
+require_cmd docker
+require_cmd uv
+
+mkdir -p "$DATA_DIR"
+ENV_FILE="$(cd "$(dirname "$ENV_FILE")" && pwd)/$(basename "$ENV_FILE")"
+DATA_DIR="$(cd "$DATA_DIR" && pwd)"
+
+if [[ "$DO_BUILD" -eq 1 ]]; then
+  echo "[deploy_console] building image: $IMAGE"
+  (
+    cd "$ROOT"
+    DOCKER_BUILDKIT=1 docker build "${BUILD_PROXY_ARGS[@]}" -f console/Dockerfile -t "$IMAGE" .
+  )
+  echo "[deploy_console] build complete"
+fi
+
+CMD=(
+  uv
+  run
+  --project
+  console
+  agiwo-console
+  container
+  up
+  --name "$NAME"
+  --image "$IMAGE"
+  --data-dir "$DATA_DIR"
+  --env-file "$ENV_FILE"
+  --publish "$PUBLISH"
+  --network-mode "$NETWORK_MODE"
+  --replace
+)
+
+if [[ "$PULL" -eq 1 ]]; then
+  CMD+=(--pull)
+fi
+
+for mount_spec in "${MOUNTS[@]}"; do
+  CMD+=(--mount "$mount_spec")
+done
+
+for env_spec in "${EXTRA_ENVS[@]}"; do
+  CMD+=(--env "$env_spec")
+done
+
+for env_name in "${FORWARD_ENV_NAMES[@]}"; do
+  if [[ -z "$env_name" ]]; then
+    echo "--env-name requires a non-empty variable name" >&2
+    exit 1
+  fi
+  if [[ -z "${!env_name+x}" ]]; then
+    echo "Host environment variable is not set: $env_name" >&2
+    exit 1
+  fi
+  CMD+=(--env "$env_name=${!env_name}")
+done
+
+echo "[deploy_console] deploying container: $NAME"
+(
+  cd "$ROOT"
+  "${CMD[@]}"
+)
+echo "[deploy_console] deployment complete"
+
+if [[ "$NETWORK_MODE" == "host" ]]; then
+  HOST_PORT="8422"
+else
+  HOST_PORT="${PUBLISH%%:*}"
+fi
+echo "Console is available at: http://localhost:${HOST_PORT}"
+echo "Status: uv run --project console agiwo-console container status --name \"$NAME\""
+echo "Logs:   uv run --project console agiwo-console container logs --name \"$NAME\""
+echo "Down:   uv run --project console agiwo-console container down --name \"$NAME\""

--- a/scripts/smoke_console_docker.py
+++ b/scripts/smoke_console_docker.py
@@ -26,6 +26,7 @@ PROXY_ENV_KEYS = (
     "https_proxy",
     "all_proxy",
 )
+REQUIRED_TEMPLATE_FILES = ("IDENTITY.md", "SOUL.md", "USER.md")
 
 
 def _proxy_hostname(value: str) -> str | None:
@@ -84,6 +85,19 @@ def run(
             file=sys.stderr,
         )
         raise SystemExit(1) from exc
+
+
+def build_installed_templates_check_code() -> str:
+    required_templates = ", ".join(repr(name) for name in REQUIRED_TEMPLATE_FILES)
+    return (
+        "from pathlib import Path; "
+        "import agiwo; "
+        "templates_dir = Path(agiwo.__file__).resolve().parent.parent / 'templates'; "
+        "assert templates_dir.is_dir(), templates_dir; "
+        f"required = ({required_templates},); "
+        "missing = [name for name in required if not (templates_dir / name).is_file()]; "
+        "assert not missing, missing"
+    )
 
 
 def wait_for_http(url: str, *, timeout_seconds: float) -> None:
@@ -220,6 +234,16 @@ def main() -> int:
             raise SystemExit("Expected data root to be created under mounted /data")
 
         run([docker, "exec", container, "test", "-d", "/mnt/host/workspace"])
+        run(
+            [
+                docker,
+                "exec",
+                container,
+                "python",
+                "-c",
+                build_installed_templates_check_code(),
+            ]
+        )
     finally:
         logs = subprocess.run(
             [docker, "logs", container],

--- a/scripts/smoke_release_install.py
+++ b/scripts/smoke_release_install.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 
 TIMEOUT_SECONDS = 300
+_REQUIRED_TEMPLATE_FILES = ("IDENTITY.md", "SOUL.md", "USER.md")
 
 
 def run(cmd: list[str]) -> None:
@@ -23,6 +24,27 @@ def resolve_cli_path(venv_path: Path, name: str) -> Path:
     if sys.platform == "win32":
         return venv_path / "Scripts" / f"{name}.exe"
     return venv_path / "bin" / name
+
+
+def build_sdk_smoke_code() -> str:
+    required_templates = ", ".join(repr(name) for name in _REQUIRED_TEMPLATE_FILES)
+    return (
+        "from pathlib import Path; "
+        "import agiwo; "
+        "from agiwo.llm import OpenAIModel; "
+        "from agiwo.tool.manager import ToolManager; "
+        "model = OpenAIModel(name='gpt-5.4', api_key='test-key'); "
+        "assert model.id == 'gpt-5.4'; "
+        "assert model.name == 'gpt-5.4'; "
+        "defaults = set(ToolManager().list_default_tool_names()); "
+        "assert {'bash', 'bash_process', 'web_search', 'web_reader', 'memory_retrieval'} <= defaults; "
+        "templates_dir = Path(agiwo.__file__).resolve().parent.parent / 'templates'; "
+        "assert templates_dir.is_dir(), templates_dir; "
+        f"required = ({required_templates},); "
+        "missing = [name for name in required if not (templates_dir / name).is_file()]; "
+        "assert not missing, missing; "
+        "print('release smoke ok')"
+    )
 
 
 def main() -> int:
@@ -66,16 +88,7 @@ def main() -> int:
             [
                 str(python_path),
                 "-c",
-                (
-                    "from agiwo.llm import OpenAIModel; "
-                    "from agiwo.tool.manager import ToolManager; "
-                    "model = OpenAIModel(name='gpt-5.4', api_key='test-key'); "
-                    "assert model.id == 'gpt-5.4'; "
-                    "assert model.name == 'gpt-5.4'; "
-                    "defaults = set(ToolManager().list_default_tool_names()); "
-                    "assert {'bash', 'bash_process', 'web_search', 'web_reader', 'memory_retrieval'} <= defaults; "
-                    "print('release smoke ok')"
-                ),
+                build_sdk_smoke_code(),
             ]
         )
 

--- a/tests/scripts/test_git_hooks.py
+++ b/tests/scripts/test_git_hooks.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_pre_push_branch_prefixes_allow_short_aliases() -> None:
+    hook = Path(".githooks/pre-push").read_text(encoding="utf-8")
+
+    assert "feature/" in hook
+    assert "feat/" in hook
+    assert "bugfix/" in hook
+    assert "fix/" in hook

--- a/tests/scripts/test_smoke_console_docker.py
+++ b/tests/scripts/test_smoke_console_docker.py
@@ -43,6 +43,18 @@ def test_docker_proxy_clear_build_args_blank_all_supported_proxy_variables() -> 
     assert "https_proxy=" in build_args
 
 
+def test_build_installed_templates_check_code_checks_required_templates() -> None:
+    smoke_code = smoke_console_docker.build_installed_templates_check_code()
+
+    assert (
+        "templates_dir = Path(agiwo.__file__).resolve().parent.parent / 'templates'"
+        in smoke_code
+    )
+    assert "required = ('IDENTITY.md', 'SOUL.md', 'USER.md',);" in smoke_code
+    assert "assert templates_dir.is_dir()" in smoke_code
+    assert "assert not missing, missing" in smoke_code
+
+
 def test_fix_volume_ownership_surfaces_docker_failure(
     monkeypatch,
     tmp_path,

--- a/tests/scripts/test_smoke_release_install.py
+++ b/tests/scripts/test_smoke_release_install.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import scripts.smoke_release_install as smoke_release_install
+
+
+def test_sdk_wheel_force_includes_templates() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert "[tool.hatch.build.targets.wheel.force-include]" in pyproject
+    assert '"templates" = "templates"' in pyproject
+
+
+def test_build_sdk_smoke_code_checks_installed_templates() -> None:
+    smoke_code = smoke_release_install.build_sdk_smoke_code()
+
+    assert (
+        "templates_dir = Path(agiwo.__file__).resolve().parent.parent / 'templates'"
+        in smoke_code
+    )
+    assert "assert templates_dir.is_dir()" in smoke_code
+    assert "IDENTITY.md" in smoke_code
+    assert "SOUL.md" in smoke_code
+    assert "USER.md" in smoke_code


### PR DESCRIPTION
## Summary
- include SDK prompt templates in the wheel and copy them into the Docker build context
- extend Docker smoke coverage to assert installed template files and add the repo deploy shortcut script
- clear inherited loopback proxy envs for managed containers while still allowing explicit proxy overrides, and forward `--network-mode` through `scripts/deploy_console.sh`

## Testing
- `bash -n scripts/deploy_console.sh`
- `uv run pytest tests/scripts/test_smoke_console_docker.py tests/scripts/test_smoke_release_install.py -q`
- `cd console && uv run pytest tests/test_docker_runtime.py tests/test_cli.py -q`
- `uv run python scripts/lint.py ci`
- `git push` pre-push hook also ran full SDK and console test suites
