### PR TITLE
refactor: finish agent runtime convergence

### DIFF
--- a/agiwo/agent/compaction.py
+++ b/agiwo/agent/compaction.py
@@ -314,6 +314,18 @@ async def _compact(
     )
     await commit_step(state, compact_user_step, append_message=True)
 
+    started_entries = await writer.record_llm_call_started(
+        messages=state.snapshot_messages(),
+        tools=None,
+    )
+    await state.session_runtime.project_run_log_entries(
+        started_entries,
+        run_id=state.run_id,
+        agent_id=state.agent_id,
+        parent_run_id=state.parent_run_id,
+        depth=state.depth,
+    )
+
     step, llm_context = await stream_assistant_step(
         model,
         state,
@@ -323,6 +335,17 @@ async def _compact(
         name="compact",
     )
     await commit_step(state, step, llm=llm_context, append_message=False)
+    completed_entries = await writer.record_llm_call_completed(
+        step=step,
+        llm=llm_context,
+    )
+    await state.session_runtime.project_run_log_entries(
+        completed_entries,
+        run_id=state.run_id,
+        agent_id=state.agent_id,
+        parent_run_id=state.parent_run_id,
+        depth=state.depth,
+    )
 
     response_content = step.content or ""
     analysis = parse_compact_response(response_content)

--- a/agiwo/agent/prompt.py
+++ b/agiwo/agent/prompt.py
@@ -1,6 +1,5 @@
 """System prompt construction."""
 
-import asyncio
 import locale
 import platform
 from datetime import datetime
@@ -204,28 +203,18 @@ def assemble_run_messages(
 
 def apply_steering_messages(
     messages: list[dict[str, Any]],
-    steering_queue: asyncio.Queue[object] | None,
+    steer_inputs: list[UserMessage] | None,
 ) -> list[dict[str, Any]]:
-    """Append any pending steer inputs to ``messages`` and return it.
+    """Append staged steer inputs to ``messages`` and return it.
 
     The caller owns ``messages`` (typically a fresh ``state.snapshot_messages()``
     deep copy).  This function mutates and returns the same list so we avoid a
     per-turn deep copy of the entire conversation history.
     """
-    if steering_queue is None or steering_queue.empty():
+    if not steer_inputs:
         return messages
 
-    while not steering_queue.empty():
-        try:
-            queued_input = steering_queue.get_nowait()
-        except asyncio.QueueEmpty:
-            break
-
-        normalized = (
-            queued_input
-            if isinstance(queued_input, UserMessage)
-            else UserMessage.from_value(queued_input)
-        )
+    for normalized in steer_inputs:
         if not normalized.has_content():
             continue
         messages.append(

--- a/agiwo/agent/run_bootstrap.py
+++ b/agiwo/agent/run_bootstrap.py
@@ -7,10 +7,6 @@ from agiwo.agent.models.run import MemoryRecord
 from agiwo.agent.models.step import StepView
 from agiwo.agent.prompt import assemble_run_messages
 from agiwo.agent.runtime.context import RunContext, RunRuntime
-from agiwo.agent.runtime.state_ops import (
-    record_compaction_metadata,
-    set_tool_schemas,
-)
 from agiwo.agent.runtime.state_writer import RunStateWriter
 
 
@@ -55,9 +51,10 @@ async def prepare_run_context(
     await writer.record_context_assembled(
         messages=assembled_messages,
         memory_count=len(memories),
+        run_start_seq=user_step.sequence,
+        tool_schemas=_build_tool_schemas(runtime),
+        latest_compaction=latest_compact,
     )
-    set_tool_schemas(context, _build_tool_schemas(runtime))
-    record_compaction_metadata(context, latest_compact)
 
     return RunBootstrapResult(
         user_step=user_step,
@@ -92,13 +89,11 @@ async def _build_user_step(
     context: RunContext,
     user_input: UserInput | None,
 ) -> StepView:
-    user_step = StepView.user(
+    return StepView.user(
         context,
         sequence=await context.session_runtime.allocate_sequence(),
         user_input=user_input,
     )
-    context.ledger.run_start_seq = user_step.sequence
-    return user_step
 
 
 async def _load_existing_steps(

--- a/agiwo/agent/run_loop.py
+++ b/agiwo/agent/run_loop.py
@@ -16,12 +16,6 @@ class CompactionCycleResult(NamedTuple):
     should_continue: bool
 
 
-def increment_compaction_failure(context: RunContext) -> int:
-    """Increment compaction failure count and return the new count."""
-    context.ledger.compaction.failure_count += 1
-    return context.ledger.compaction.failure_count
-
-
 from agiwo.agent.models.config import AgentOptions
 from agiwo.agent.hooks import HookRegistration, HookRegistry
 from agiwo.agent.models.input import UserInput
@@ -36,7 +30,7 @@ from agiwo.agent.models.step import (
     LLMCallContext,
     StepView,
 )
-from agiwo.agent.runtime.context import RunContext, RunRuntime
+from agiwo.agent.runtime.context import RunRuntime
 from agiwo.agent.runtime.step_committer import commit_step
 from agiwo.agent.runtime.state_writer import RunStateWriter
 from agiwo.agent.termination.limits import (
@@ -260,7 +254,7 @@ class RunLoopOrchestrator:
             root_path=self.runtime.root_path,
         )
         if result.failed:
-            failure_count = increment_compaction_failure(self.context)
+            failure_count = self.writer.next_compaction_failure_attempt()
             err = result.error or ""
             terminal = failure_count >= 3
             entries = await self.writer.record_compaction_failed(
@@ -311,17 +305,23 @@ class RunLoopOrchestrator:
 
     async def _run_assistant_turn(self) -> tuple[StepView, LLMCallContext]:
         """Execute an assistant turn (LLM call)."""
-        original_messages = self.context.snapshot_messages()
-        request_messages = apply_steering_messages(
-            original_messages,
-            self.context.session_runtime.steering_queue,
-        )
+        request_messages = self.context.snapshot_messages()
+        pending_steer = self.context.session_runtime.peek_pending_steer_inputs()
+        if pending_steer:
+            request_messages = apply_steering_messages(request_messages, pending_steer)
+            rebuilt_entries = await self.writer.rebuild_messages(
+                reason="before_llm",
+                messages=request_messages,
+            )
+            await self._project_entries(rebuilt_entries)
+            self.context.session_runtime.ack_pending_steer_inputs(len(pending_steer))
+        request_messages = self.context.snapshot_messages()
         modified = await self.context.hooks.before_llm_call(
             request_messages, self.context
         )
         if modified is not None:
             request_messages = modified
-        if request_messages != original_messages:
+        if request_messages != self.context.snapshot_messages():
             rebuilt_entries = await self.writer.rebuild_messages(
                 reason="before_llm",
                 messages=request_messages,

--- a/agiwo/agent/runtime/session.py
+++ b/agiwo/agent/runtime/session.py
@@ -30,13 +30,12 @@ class SessionRuntime:
         run_log_storage: RunLogStorage,
         trace_runtime: AgentTraceCollector | None = None,
         abort_signal: AbortSignal | None = None,
-        steering_queue: asyncio.Queue[object] | None = None,
     ) -> None:
         self.session_id = session_id
         self.run_log_storage = run_log_storage
         self.trace_runtime = trace_runtime
         self.abort_signal = abort_signal or AbortSignal()
-        self.steering_queue = steering_queue or asyncio.Queue()
+        self._pending_steer_inputs: list[UserMessage] = []
         self._subscribers: set[asyncio.Queue[AgentStreamItem | object]] = set()
         self._closed = False
 
@@ -110,8 +109,16 @@ class SessionRuntime:
         message = UserMessage.from_value(user_input)
         if not message.has_content():
             return False
-        await self.steering_queue.put(message)
+        self._pending_steer_inputs.append(message)
         return True
+
+    def peek_pending_steer_inputs(self) -> list[UserMessage]:
+        return [UserMessage.from_value(item) for item in self._pending_steer_inputs]
+
+    def ack_pending_steer_inputs(self, count: int) -> None:
+        if count <= 0:
+            return
+        del self._pending_steer_inputs[:count]
 
     async def publish(self, item: AgentStreamItem) -> None:
         if self._closed:

--- a/agiwo/agent/runtime/state_writer.py
+++ b/agiwo/agent/runtime/state_writer.py
@@ -28,6 +28,7 @@ from agiwo.agent.runtime.state_ops import (
     record_compaction_metadata,
     replace_messages,
     set_termination_reason,
+    set_tool_schemas,
     track_step_state,
 )
 
@@ -81,8 +82,14 @@ class RunStateWriter:
         *,
         messages: list[dict[str, Any]],
         memory_count: int,
+        run_start_seq: int,
+        tool_schemas: list[dict[str, Any]] | None,
+        latest_compaction: CompactMetadata | None,
     ) -> list[object]:
         replace_messages(self._state, messages)
+        self._state.ledger.run_start_seq = run_start_seq
+        set_tool_schemas(self._state, tool_schemas)
+        record_compaction_metadata(self._state, latest_compaction)
         return await self.append_entries(
             [
                 build_context_assembled_entry(
@@ -213,6 +220,9 @@ class RunStateWriter:
                 )
             ]
         )
+
+    def next_compaction_failure_attempt(self) -> int:
+        return self._state.ledger.compaction.failure_count + 1
 
     async def record_retrospect_applied(
         self,

--- a/agiwo/agent/termination/summarizer.py
+++ b/agiwo/agent/termination/summarizer.py
@@ -4,6 +4,7 @@ from agiwo.agent.models.config import AgentOptions
 from agiwo.agent.llm_caller import stream_assistant_step
 from agiwo.agent.models.step import StepView
 from agiwo.agent.runtime.context import RunContext
+from agiwo.agent.runtime.state_writer import RunStateWriter
 from agiwo.agent.runtime.step_committer import commit_step
 from agiwo.agent.termination.prompts import (
     DEFAULT_TERMINATION_USER_PROMPT,
@@ -36,6 +37,7 @@ async def maybe_generate_termination_summary(
         prompt_template,
         state.ledger.termination_reason,
     )
+    writer = RunStateWriter(state)
 
     sequence = await state.session_runtime.allocate_sequence()
     summary_user_step = StepView.user(
@@ -47,6 +49,17 @@ async def maybe_generate_termination_summary(
     await commit_step(state, summary_user_step, append_message=True)
 
     try:
+        started_entries = await writer.record_llm_call_started(
+            messages=state.snapshot_messages(),
+            tools=None,
+        )
+        await state.session_runtime.project_run_log_entries(
+            started_entries,
+            run_id=state.run_id,
+            agent_id=state.agent_id,
+            parent_run_id=state.parent_run_id,
+            depth=state.depth,
+        )
         step, llm_context = await stream_assistant_step(
             model,
             state,
@@ -56,6 +69,17 @@ async def maybe_generate_termination_summary(
         )
         step.name = "summary"
         await commit_step(state, step, llm=llm_context, append_message=False)
+        completed_entries = await writer.record_llm_call_completed(
+            step=step,
+            llm=llm_context,
+        )
+        await state.session_runtime.project_run_log_entries(
+            completed_entries,
+            run_id=state.run_id,
+            agent_id=state.agent_id,
+            parent_run_id=state.parent_run_id,
+            depth=state.depth,
+        )
 
         logger.info(
             "summary_generated",

--- a/agiwo/agent/trace_writer.py
+++ b/agiwo/agent/trace_writer.py
@@ -1,4 +1,4 @@
-"""Agent trace collector — build Trace/Span trees from run-log and step callbacks."""
+"""Agent trace collector — build Trace/Span trees from committed run-log entries."""
 
 import json
 from collections import OrderedDict
@@ -19,8 +19,6 @@ from agiwo.agent.models.log import (
     TerminationDecided,
     ToolStepCommitted,
 )
-from agiwo.agent.models.run import RunOutput
-from agiwo.agent.models.step import LLMCallContext, StepView
 from agiwo.observability.base import BaseTraceStorage
 from agiwo.observability.trace import Span, SpanKind, SpanStatus, Trace
 
@@ -33,160 +31,6 @@ def _utc(value: datetime | None) -> datetime | None:
     return (
         value.replace(tzinfo=timezone.utc) if value and value.tzinfo is None else value
     )
-
-
-def _resolve_parent(
-    step: StepView,
-    run_spans: dict[str, Span],
-    fallback: Span | None,
-) -> tuple[str | None, int]:
-    parent = run_spans.get(step.run_id)
-    if not parent and step.parent_run_id:
-        parent = run_spans.get(step.parent_run_id)
-    parent = parent or fallback
-    return (parent.span_id, parent.depth) if parent else (None, 0)
-
-
-def _extract_tool_args(step: StepView, cache: dict[str, StepView]) -> dict[str, Any]:
-    if not step.tool_call_id:
-        return {}
-    assistant = cache.get(step.tool_call_id)
-    if not assistant or not assistant.tool_calls:
-        return {}
-    for tc in assistant.tool_calls:
-        if tc.get("id") != step.tool_call_id:
-            continue
-        raw = tc.get("function", {}).get("arguments", "{}")
-        if isinstance(raw, str):
-            try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return {}
-        return raw if isinstance(raw, dict) else {}
-    return {}
-
-
-def _build_tool_span(
-    trace_id: str,
-    step: StepView,
-    cache: dict[str, StepView],
-    run_spans: dict[str, Span],
-    fallback: Span | None,
-) -> Span:
-    m = step.metrics
-    start = _utc((m.start_at if m and m.start_at else None) or step.created_at)
-    end = _utc(m.end_at if m else None)
-    dur = m.duration_ms if m else None
-    parent_id, parent_depth = _resolve_parent(step, run_spans, fallback)
-    is_error = step.is_error
-
-    span = Span(
-        trace_id=trace_id,
-        parent_span_id=parent_id,
-        kind=SpanKind.TOOL_CALL,
-        name=step.name or "tool",
-        depth=parent_depth + 1,
-        attributes={"tool_name": step.name, "tool_call_id": step.tool_call_id},
-        tool_details={
-            "tool_name": step.name,
-            "tool_call_id": step.tool_call_id,
-            "input_args": _extract_tool_args(step, cache),
-            "output": step.content,
-            "content_for_user": step.content_for_user,
-            "error": step.content if is_error else None,
-            "status": "error" if is_error else "completed",
-            **({"metrics": {"duration_ms": dur}} if m else {}),
-        },
-        step_id=step.id,
-        run_id=step.run_id,
-        start_time=start,
-        end_time=end,
-        duration_ms=dur,
-        status=SpanStatus.ERROR if is_error else SpanStatus.OK,
-        error_message=step.content if is_error else None,
-    )
-    if m:
-        span.metrics = {"tool.exec_time_ms": dur, "duration_ms": span.duration_ms}
-    return span
-
-
-def _build_assistant_span(
-    trace_id: str,
-    step: StepView,
-    llm: LLMCallContext | None,
-    run_spans: dict[str, Span],
-    fallback: Span | None,
-    preview_length: int,
-) -> Span:
-    m = step.metrics
-    start = _utc((m.start_at if m and m.start_at else None) or step.created_at)
-    end = _utc(m.end_at if m else None)
-    dur = m.duration_ms if m else None
-    parent_id, parent_depth = _resolve_parent(step, run_spans, fallback)
-    name = m.model_name if m and m.model_name else "llm"
-
-    llm_details: dict[str, Any] = {}
-    if llm:
-        llm_details = {
-            "request": llm.request_params or {},
-            "messages": llm.messages,
-            "tools": llm.tools,
-            "response_content": step.content,
-            "response_tool_calls": step.tool_calls,
-            "finish_reason": llm.finish_reason,
-            "status": "completed",
-        }
-        if m:
-            llm_details["metrics"] = {
-                "duration_ms": dur,
-                "first_token_ms": m.first_token_latency_ms,
-                "input_tokens": m.input_tokens,
-                "output_tokens": m.output_tokens,
-                "total_tokens": m.total_tokens,
-                "cache_read_tokens": m.cache_read_tokens,
-                "cache_creation_tokens": m.cache_creation_tokens,
-                "usage_source": m.usage_source,
-            }
-
-    span = Span(
-        trace_id=trace_id,
-        parent_span_id=parent_id,
-        kind=SpanKind.LLM_CALL,
-        name=name,
-        depth=parent_depth + 1,
-        attributes={
-            "model_name": m.model_name if m else None,
-            "provider": m.provider if m else None,
-            "has_tool_calls": bool(step.tool_calls),
-        },
-        step_id=step.id,
-        run_id=step.run_id,
-        start_time=start,
-        end_time=end,
-        duration_ms=dur,
-        status=SpanStatus.OK,
-        llm_details=llm_details,
-        output_preview=(
-            step.content[:preview_length]
-            if isinstance(step.content, str) and step.content
-            else None
-        ),
-    )
-    if m:
-        span.metrics = {
-            "tokens.input": m.input_tokens,
-            "tokens.output": m.output_tokens,
-            "tokens.total": m.total_tokens,
-            "tokens.cache_read": m.cache_read_tokens,
-            "tokens.cache_creation": m.cache_creation_tokens,
-            "token_cost": m.token_cost,
-            "first_token_ms": m.first_token_latency_ms,
-            "duration_ms": dur,
-            "model": m.model_name,
-            "provider": m.provider,
-            "usage_source": m.usage_source,
-        }
-    return span
 
 
 def _build_assistant_span_from_entries(
@@ -584,6 +428,7 @@ def _apply_llm_entry_to_trace(
                 preview_length,
             )
         )
+        llm_started.pop(entry.run_id, None)
         return True
     return False
 
@@ -674,12 +519,12 @@ class AgentTraceCollector:
     """Construct a Trace from committed run-log entries."""
 
     PREVIEW_LENGTH = 500
+    _CACHE_MAX_SIZE = 10_000
 
     def __init__(self, store: BaseTraceStorage | None = None) -> None:
         self.store = store
         self._trace: Trace | None = None
         self._run_spans: dict[str, Span] = {}
-        self._assistant_cache: OrderedDict[str, StepView] = OrderedDict()
         self._assistant_committed_cache: OrderedDict[str, AssistantStepCommitted] = (
             OrderedDict()
         )
@@ -705,90 +550,8 @@ class AgentTraceCollector:
             input_query=input_query,
         )
         self._run_spans = {}
-        self._assistant_cache = OrderedDict()
         self._assistant_committed_cache = OrderedDict()
         self._llm_started = {}
-
-    def on_run_started(
-        self,
-        *,
-        run_id: str,
-        agent_id: str,
-        session_id: str,
-        parent_run_id: str | None,
-    ) -> str:
-        trace = self._require_trace()
-        run_trace_id = trace.trace_id
-        _create_run_span(
-            trace,
-            run_id=run_id,
-            agent_id=agent_id,
-            session_id=session_id,
-            parent_run_id=parent_run_id,
-            run_spans=self._run_spans,
-        )
-        return run_trace_id
-
-    async def on_step(self, step: StepView, llm: LLMCallContext | None = None) -> None:
-        trace = self._require_trace()
-        self._cache_tool_calls(step)
-        fallback = self._run_spans.get(step.run_id) or (
-            self._run_spans.get(step.parent_run_id) if step.parent_run_id else None
-        )
-        if step.role.value == "assistant":
-            trace.add_span(
-                _build_assistant_span(
-                    trace.trace_id,
-                    step,
-                    llm,
-                    self._run_spans,
-                    fallback,
-                    self.PREVIEW_LENGTH,
-                )
-            )
-        elif step.role.value == "tool":
-            trace.add_span(
-                _build_tool_span(
-                    trace.trace_id,
-                    step,
-                    self._assistant_cache,
-                    self._run_spans,
-                    fallback,
-                )
-            )
-
-    async def on_run_completed(self, output: RunOutput, *, run_id: str) -> None:
-        trace = self._require_trace()
-        span = self._run_spans.get(run_id)
-        _complete_run_span(
-            span,
-            status=SpanStatus.OK,
-            preview_length=self.PREVIEW_LENGTH,
-            response=output.response,
-        )
-        _complete_root_trace(
-            trace,
-            span,
-            status=SpanStatus.OK,
-            response=output.response,
-        )
-        await self._save_trace()
-
-    async def on_run_failed(self, error: Exception, *, run_id: str) -> None:
-        trace = self._require_trace()
-        span = self._run_spans.get(run_id)
-        _complete_run_span(
-            span,
-            status=SpanStatus.ERROR,
-            preview_length=0,
-            error_message=str(error),
-        )
-        _complete_root_trace(
-            trace,
-            span,
-            status=SpanStatus.ERROR,
-        )
-        await self._save_trace()
 
     async def stop(self) -> None:
         if self._trace is None:
@@ -798,7 +561,6 @@ class AgentTraceCollector:
         await self._save_trace()
         self._trace = None
         self._run_spans = {}
-        self._assistant_cache = OrderedDict()
         self._assistant_committed_cache = OrderedDict()
         self._llm_started = {}
 
@@ -815,6 +577,11 @@ class AgentTraceCollector:
                 assistant_cache=self._assistant_committed_cache,
                 preview_length=self.PREVIEW_LENGTH,
             )
+            while len(self._assistant_committed_cache) > self._CACHE_MAX_SIZE:
+                self._assistant_committed_cache.popitem(last=False)
+            if isinstance(entry, (RunFinished, RunFailedEntry)):
+                self._purge_run_correlation_state(entry.run_id)
+        await self._save_trace()
 
     def build_from_entries(self, entries: list[RunLogEntry]) -> Trace:
         trace = Trace()
@@ -839,17 +606,16 @@ class AgentTraceCollector:
             raise RuntimeError("trace_not_started")
         return self._trace
 
-    _CACHE_MAX_SIZE = 10_000
-
-    def _cache_tool_calls(self, step: StepView) -> None:
-        if step.role.value != "assistant" or not step.tool_calls:
-            return
-        for tc in step.tool_calls:
-            tid = tc.get("id")
-            if tid:
-                self._assistant_cache[tid] = step
-        while len(self._assistant_cache) > self._CACHE_MAX_SIZE:
-            self._assistant_cache.popitem(last=False)
+    def _purge_run_correlation_state(self, run_id: str) -> None:
+        self._run_spans.pop(run_id, None)
+        self._llm_started.pop(run_id, None)
+        stale_tool_calls = [
+            tool_call_id
+            for tool_call_id, assistant in self._assistant_committed_cache.items()
+            if assistant.run_id == run_id
+        ]
+        for tool_call_id in stale_tool_calls:
+            self._assistant_committed_cache.pop(tool_call_id, None)
 
     async def _save_trace(self) -> None:
         if self._trace is None or self.store is None:

--- a/agiwo/observability/memory_store.py
+++ b/agiwo/observability/memory_store.py
@@ -25,10 +25,20 @@ class InMemoryTraceStorage(BaseTraceStorage):
         self._traces: deque[Trace] = deque(maxlen=buffer_size)
 
     async def save_trace(self, trace: Trace) -> None:
+        existing = next(
+            (
+                index
+                for index, item in enumerate(self._traces)
+                if item.trace_id == trace.trace_id
+            ),
+            None,
+        )
+        if existing is not None:
+            del self._traces[existing]
         self._traces.append(trace)
 
     async def get_trace(self, trace_id: str) -> Trace | None:
-        for trace in self._traces:
+        for trace in reversed(self._traces):
             if trace.trace_id == trace_id:
                 return trace
         return None

--- a/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
+++ b/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
@@ -1,0 +1,609 @@
+# Agent Runtime Final Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the strict convergence of `agiwo.agent` so steer input is lossless, `RunStateWriter` is the only committed runtime-truth write path, internal LLM turns are canonical `RunLog` facts, and trace construction/persistence is entry-only.
+
+**Architecture:** Keep `RunLoopOrchestrator` as the only phase decider, but push the remaining committed-state mutations and internal LLM facts behind `RunStateWriter`. Replace destructive steer draining with staged commit semantics, and delete `AgentTraceCollector`'s legacy callback path so live trace, replay trace, and replayable stream/query views all consume committed `RunLog` entries only.
+
+**Tech Stack:** Python 3.10+, dataclasses, `RunLogStorage`, `RunStateWriter`, `SessionRuntime`, `AgentTraceCollector`, pytest, ruff
+
+---
+
+## File Structure
+
+- `agiwo/agent/run_loop.py`
+  Replace destructive steer drain with staged commit semantics, remove direct compaction-failure counter mutation, and reuse a single projection helper.
+- `agiwo/agent/runtime/state_writer.py`
+  Add explicit writer-owned mutations for tool schemas, compaction metadata, `run_start_seq`, compaction failure count, and canonical internal LLM facts.
+- `agiwo/agent/runtime/session.py`
+  Add staged steer snapshot/ack semantics so accepted steer input is only consumed after committed message rewrite succeeds.
+- `agiwo/agent/prompt.py`
+  Remove the destructive queue-drain helper or reduce it to a pure message-shaping helper that does not own queue semantics.
+- `agiwo/agent/run_bootstrap.py`
+  Route remaining committed bootstrap state through writer methods.
+- `agiwo/agent/compaction.py`
+  Emit canonical `LLMCallStarted` / `LLMCallCompleted` for the internal compaction turn and stop mutating committed compaction state outside the writer.
+- `agiwo/agent/termination/summarizer.py`
+  Emit canonical LLM-call facts for the termination summary turn.
+- `agiwo/agent/trace_writer.py`
+  Delete legacy direct-callback APIs, bound committed caches, clear correlation state on completion, and persist live trace snapshots after committed entry batches.
+- `tests/agent/test_run_loop_contracts.py`
+  Add lossless steer and staged-consumption coverage.
+- `tests/agent/test_run_engine.py`
+  Cover `before_llm` failure after accepted steer input and bootstrap writer ownership.
+- `tests/agent/test_compact.py`
+  Cover canonical compaction LLM facts.
+- `tests/agent/test_termination.py`
+  Cover canonical termination-summary LLM facts.
+- `tests/observability/test_collector.py`
+  Switch fully to committed-entry trace construction and assert bounded cache / persistence behavior.
+- `tests/agent/test_run_log_replay_parity.py`
+  Keep live stream and replay stream parity after the steer and internal-LLM changes.
+- `console/tests/test_runtime_replay_consistency.py`
+  Verify console replay/query semantics still match committed entries.
+- `AGENTS.md`
+  Update stable runtime wording if implementation changes the documented contract surface again.
+
+### Task 1: Make Steer Consumption Lossless
+
+**Files:**
+- Modify: `agiwo/agent/runtime/session.py`
+- Modify: `agiwo/agent/run_loop.py`
+- Modify: `agiwo/agent/prompt.py`
+- Test: `tests/agent/test_run_loop_contracts.py`
+- Test: `tests/agent/test_run_engine.py`
+
+- [ ] **Step 1: Write failing tests for staged steer consumption**
+
+```python
+# tests/agent/test_run_loop_contracts.py
+import asyncio
+
+import pytest
+
+from agiwo.agent.models.input import UserMessage
+from agiwo.agent.runtime.session import SessionRuntime
+from agiwo.agent.storage.base import InMemoryRunLogStorage
+
+
+@pytest.mark.asyncio
+async def test_session_runtime_peek_steer_does_not_consume_until_ack() -> None:
+    runtime = SessionRuntime(
+        session_id="sess-1",
+        run_log_storage=InMemoryRunLogStorage(),
+    )
+    await runtime.enqueue_steer("follow up")
+
+    pending = runtime.peek_pending_steer_inputs()
+
+    assert [UserMessage.from_value(item).extract_text() for item in pending] == [
+        "follow up"
+    ]
+    assert [UserMessage.from_value(item).extract_text() for item in runtime.peek_pending_steer_inputs()] == [
+        "follow up"
+    ]
+
+    runtime.ack_pending_steer_inputs(len(pending))
+    assert runtime.peek_pending_steer_inputs() == []
+```
+
+```python
+# tests/agent/test_run_engine.py
+import pytest
+
+from agiwo.agent import Agent, AgentConfig
+from agiwo.agent.hooks import HookPhase, HookRegistry, transform
+from agiwo.agent.models.input import UserMessage
+
+
+@pytest.mark.asyncio
+async def test_before_llm_failure_does_not_lose_accepted_steer_input() -> None:
+    gate = {"calls": 0}
+
+    async def explode_once(payload: dict) -> dict:
+        gate["calls"] += 1
+        if gate["calls"] == 1:
+            raise RuntimeError("before llm boom")
+        return payload
+
+    agent = Agent(
+        AgentConfig(name="steer-lossless", description="steer-lossless"),
+        model=_FixedResponseModel(response="ok"),
+        hooks=HookRegistry(
+            [transform(HookPhase.BEFORE_LLM, "explode_once", explode_once, critical=True)]
+        ),
+    )
+
+    handle = agent.start("hello", session_id="sess-steer-lossless")
+    accepted = await handle.steer(UserMessage.from_value("follow up"))
+    assert accepted is True
+
+    with pytest.raises(RuntimeError, match="before llm boom"):
+        await handle.wait()
+
+    retry = await agent.run("retry", session_id="sess-steer-lossless")
+    assert retry.response is not None
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `uv run pytest tests/agent/test_run_loop_contracts.py::test_session_runtime_peek_steer_does_not_consume_until_ack tests/agent/test_run_engine.py::test_before_llm_failure_does_not_lose_accepted_steer_input -v`
+Expected: FAIL because `SessionRuntime` has only destructive queue consumption and `before_llm` failure can still lose accepted steer input.
+
+- [ ] **Step 3: Implement staged steer snapshot and ack semantics**
+
+```python
+# agiwo/agent/runtime/session.py
+class SessionRuntime:
+    def __init__(..., steering_queue: asyncio.Queue[object] | None = None) -> None:
+        ...
+        self.steering_queue = steering_queue or asyncio.Queue()
+        self._pending_steer_inputs: list[UserMessage] = []
+
+    async def enqueue_steer(self, user_input: UserInput) -> bool:
+        ...
+        self._pending_steer_inputs.append(message)
+        return True
+
+    def peek_pending_steer_inputs(self) -> list[UserMessage]:
+        return [UserMessage.from_value(item) for item in self._pending_steer_inputs]
+
+    def ack_pending_steer_inputs(self, count: int) -> None:
+        if count <= 0:
+            return
+        del self._pending_steer_inputs[:count]
+```
+
+```python
+# agiwo/agent/prompt.py
+def apply_steering_inputs(
+    messages: list[dict[str, Any]],
+    steer_inputs: list[UserMessage],
+) -> list[dict[str, Any]]:
+    for normalized in steer_inputs:
+        if normalized.has_content():
+            messages.append(
+                {
+                    "role": "user",
+                    "content": normalized.to_message_content(),
+                }
+            )
+    return messages
+```
+
+```python
+# agiwo/agent/run_loop.py
+pending_steer = self.context.session_runtime.peek_pending_steer_inputs()
+request_messages = apply_steering_inputs(
+    self.context.snapshot_messages(),
+    pending_steer,
+)
+modified = await self.context.hooks.before_llm_call(request_messages, self.context)
+if modified is not None:
+    request_messages = modified
+if request_messages != self.context.snapshot_messages():
+    rebuilt_entries = await self.writer.rebuild_messages(
+        reason="before_llm",
+        messages=request_messages,
+    )
+    await self._project_entries(rebuilt_entries)
+    self.context.session_runtime.ack_pending_steer_inputs(len(pending_steer))
+```
+
+- [ ] **Step 4: Run the focused tests and parity check**
+
+Run: `uv run pytest tests/agent/test_run_loop_contracts.py tests/agent/test_run_engine.py::test_before_llm_failure_does_not_lose_accepted_steer_input tests/agent/test_run_log_replay_parity.py -v`
+Expected: PASS with steer inputs preserved until the `MessagesRebuilt(reason="before_llm")` commit succeeds and live/replay parity unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agiwo/agent/runtime/session.py agiwo/agent/run_loop.py agiwo/agent/prompt.py tests/agent/test_run_loop_contracts.py tests/agent/test_run_engine.py tests/agent/test_run_log_replay_parity.py
+git commit -m "refactor: make steer consumption lossless"
+```
+
+### Task 2: Move Remaining Bootstrap And Compaction State Behind The Writer
+
+**Files:**
+- Modify: `agiwo/agent/runtime/state_writer.py`
+- Modify: `agiwo/agent/run_bootstrap.py`
+- Modify: `agiwo/agent/run_loop.py`
+- Modify: `agiwo/agent/compaction.py`
+- Test: `tests/agent/test_state_tracking.py`
+- Test: `tests/agent/test_run_engine.py`
+- Test: `tests/agent/test_compact.py`
+
+- [ ] **Step 1: Write failing tests for remaining writer ownership**
+
+```python
+# tests/agent/test_state_tracking.py
+import pytest
+
+from agiwo.agent.runtime.state_writer import RunStateWriter
+
+
+@pytest.mark.asyncio
+async def test_run_state_writer_owns_bootstrap_state_mutations() -> None:
+    state = _make_state()
+    writer = RunStateWriter(state)
+
+    await writer.record_bootstrap_state(
+        run_start_seq=7,
+        tool_schemas=[{"type": "function", "function": {"name": "bash"}}],
+        latest_compaction=None,
+    )
+
+    assert state.ledger.run_start_seq == 7
+    assert state.ledger.tool_schemas == [{"type": "function", "function": {"name": "bash"}}]
+    assert state.ledger.compaction.last_metadata is None
+```
+
+```python
+# tests/agent/test_compact.py
+from agiwo.agent.models.log import LLMCallCompleted, LLMCallStarted
+
+
+@pytest.mark.asyncio
+async def test_compaction_writes_canonical_llm_call_facts(tmp_path) -> None:
+    ...
+    result = await compact_if_needed(...)
+    assert result.metadata is not None
+
+    entries = await session_runtime.list_run_log_entries(run_id="run-1")
+    assert any(isinstance(entry, LLMCallStarted) for entry in entries)
+    assert any(isinstance(entry, LLMCallCompleted) for entry in entries)
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `uv run pytest tests/agent/test_state_tracking.py::test_run_state_writer_owns_bootstrap_state_mutations tests/agent/test_compact.py::test_compaction_writes_canonical_llm_call_facts -v`
+Expected: FAIL because bootstrap still mutates state directly and compaction still commits internal steps without canonical LLM-call facts.
+
+- [ ] **Step 3: Add explicit writer-owned bootstrap and internal-LLM methods**
+
+```python
+# agiwo/agent/runtime/state_writer.py
+class RunStateWriter:
+    async def record_bootstrap_state(
+        self,
+        *,
+        run_start_seq: int,
+        tool_schemas: list[dict[str, Any]] | None,
+        latest_compaction: CompactMetadata | None,
+    ) -> None:
+        self._state.ledger.run_start_seq = run_start_seq
+        self._state.ledger.tool_schemas = (
+            copy.deepcopy(tool_schemas) if tool_schemas is not None else None
+        )
+        self._state.ledger.compaction.last_metadata = latest_compaction
+
+    async def record_llm_turn(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        step: StepView,
+        llm: LLMCallContext,
+    ) -> list[RunLogEntry]:
+        started = build_llm_call_started_entry(...)
+        completed = build_llm_call_completed_entry(...)
+        return await self.append_entries([started, completed])
+
+    async def set_compaction_failure_count(self, attempt: int) -> None:
+        self._state.ledger.compaction.failure_count = attempt
+```
+
+```python
+# agiwo/agent/run_bootstrap.py
+user_step = await _build_user_step(context, user_input)
+await writer.record_bootstrap_state(
+    run_start_seq=user_step.sequence,
+    tool_schemas=_build_tool_schemas(runtime),
+    latest_compaction=latest_compact,
+)
+await writer.record_context_assembled(
+    messages=assembled_messages,
+    memory_count=len(memories),
+)
+```
+
+```python
+# agiwo/agent/compaction.py
+request_entries = await writer.record_llm_call_started(
+    messages=state.snapshot_messages(),
+    tools=None,
+)
+await state.session_runtime.project_run_log_entries(request_entries, ...)
+step, llm_context = await stream_assistant_step(...)
+await commit_step(state, step, llm=llm_context, append_message=False)
+completion_entries = await writer.record_llm_call_completed(step=step, llm=llm_context)
+await state.session_runtime.project_run_log_entries(completion_entries, ...)
+```
+
+- [ ] **Step 4: Run the focused tests and engine coverage**
+
+Run: `uv run pytest tests/agent/test_state_tracking.py tests/agent/test_run_engine.py tests/agent/test_compact.py -v`
+Expected: PASS with bootstrap state owned by the writer, compaction failure count updated by writer methods, and compaction internal LLM turns represented by canonical LLM facts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agiwo/agent/runtime/state_writer.py agiwo/agent/run_bootstrap.py agiwo/agent/run_loop.py agiwo/agent/compaction.py tests/agent/test_state_tracking.py tests/agent/test_run_engine.py tests/agent/test_compact.py
+git commit -m "refactor: route bootstrap and compaction state through writer"
+```
+
+### Task 3: Make Termination Summary A Canonical Internal LLM Turn
+
+**Files:**
+- Modify: `agiwo/agent/termination/summarizer.py`
+- Modify: `agiwo/agent/runtime/state_writer.py`
+- Test: `tests/agent/test_termination.py`
+
+- [ ] **Step 1: Write the failing test for termination-summary LLM facts**
+
+```python
+# tests/agent/test_termination.py
+import pytest
+
+from agiwo.agent import Agent, AgentConfig, TerminationReason
+from agiwo.agent.models.config import AgentOptions
+from agiwo.agent.models.log import LLMCallCompleted, LLMCallStarted
+
+
+@pytest.mark.asyncio
+async def test_termination_summary_writes_canonical_llm_call_facts() -> None:
+    agent = Agent(
+        AgentConfig(
+            name="termination-summary",
+            description="termination-summary",
+            options=AgentOptions(max_steps=0, enable_termination_summary=True),
+        ),
+        model=_FixedResponseModel(response="summary"),
+    )
+
+    result = await agent.run("hello", session_id="termination-summary-session")
+
+    assert result.termination_reason == TerminationReason.MAX_STEPS
+    entries = await agent.run_log_storage.list_entries(
+        session_id="termination-summary-session"
+    )
+    assert any(
+        isinstance(entry, LLMCallStarted) and entry.run_id == result.run_id
+        for entry in entries
+    )
+    assert any(
+        isinstance(entry, LLMCallCompleted) and entry.run_id == result.run_id
+        for entry in entries
+    )
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `uv run pytest tests/agent/test_termination.py::test_termination_summary_writes_canonical_llm_call_facts -v`
+Expected: FAIL because termination summary currently commits only steps and no canonical LLM-call facts.
+
+- [ ] **Step 3: Route termination-summary request and completion through the writer**
+
+```python
+# agiwo/agent/termination/summarizer.py
+writer = RunStateWriter(state)
+summary_user_step = StepView.user(
+    state,
+    sequence=await state.session_runtime.allocate_sequence(),
+    content=user_prompt,
+    name="summary_request",
+)
+await commit_step(state, summary_user_step, append_message=True)
+started_entries = await writer.record_llm_call_started(
+    messages=state.snapshot_messages(),
+    tools=None,
+)
+await state.session_runtime.project_run_log_entries(started_entries, ...)
+step, llm_context = await stream_assistant_step(
+    model,
+    state,
+    abort_signal,
+    messages=state.snapshot_messages(),
+    use_state_tools=False,
+)
+step.name = "summary"
+await commit_step(state, step, llm=llm_context, append_message=False)
+completed_entries = await writer.record_llm_call_completed(step=step, llm=llm_context)
+await state.session_runtime.project_run_log_entries(completed_entries, ...)
+```
+
+- [ ] **Step 4: Run the focused termination tests**
+
+Run: `uv run pytest tests/agent/test_termination.py -v`
+Expected: PASS with termination summary preserving existing best-effort behavior while also writing canonical internal LLM facts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agiwo/agent/termination/summarizer.py agiwo/agent/runtime/state_writer.py tests/agent/test_termination.py
+git commit -m "refactor: make termination summary a canonical llm turn"
+```
+
+### Task 4: Delete Legacy Trace Callbacks And Persist Trace From Entry Batches
+
+**Files:**
+- Modify: `agiwo/agent/trace_writer.py`
+- Modify: `agiwo/agent/runtime/session.py`
+- Test: `tests/observability/test_collector.py`
+- Test: `tests/agent/test_run_log_replay_parity.py`
+- Test: `console/tests/test_runtime_replay_consistency.py`
+
+- [ ] **Step 1: Write failing tests for entry-only trace behavior, bounded cache, and save-on-entry**
+
+```python
+# tests/observability/test_collector.py
+from collections import OrderedDict
+
+import pytest
+
+from agiwo.agent.models.log import AssistantStepCommitted, LLMCallCompleted, LLMCallStarted, RunFinished, RunStarted
+from agiwo.agent.trace_writer import AgentTraceCollector
+from agiwo.observability.memory_store import InMemoryTraceStorage
+
+
+@pytest.mark.asyncio
+async def test_collector_persists_trace_after_run_log_entry_batch() -> None:
+    store = InMemoryTraceStorage()
+    collector = AgentTraceCollector(store=store)
+    collector.start(trace_id="trace-1", agent_id="agent-1", session_id="sess-1")
+
+    await collector.on_run_log_entries(
+        [
+            RunStarted(sequence=1, session_id="sess-1", run_id="run-1", agent_id="agent-1", user_input="hello"),
+            RunFinished(sequence=2, session_id="sess-1", run_id="run-1", agent_id="agent-1", response="done"),
+        ]
+    )
+
+    saved = await store.get_trace("trace-1")
+    assert saved is not None
+    assert saved.final_output == "done"
+
+
+def test_collector_no_longer_exposes_legacy_trace_callbacks() -> None:
+    collector = AgentTraceCollector()
+    assert not hasattr(collector, "on_run_started")
+    assert not hasattr(collector, "on_step")
+    assert not hasattr(collector, "on_run_completed")
+    assert not hasattr(collector, "on_run_failed")
+```
+
+```python
+# tests/observability/test_collector.py
+@pytest.mark.asyncio
+async def test_collector_bounds_committed_caches() -> None:
+    collector = AgentTraceCollector()
+    collector.start(trace_id="trace-2", agent_id="agent-1", session_id="sess-1")
+
+    entries = [
+        RunStarted(sequence=1, session_id="sess-1", run_id="run-1", agent_id="agent-1", user_input="hello")
+    ]
+    entries.extend(
+        AssistantStepCommitted(
+            sequence=idx + 2,
+            session_id="sess-1",
+            run_id="run-1",
+            agent_id="agent-1",
+            step_id=f"step-{idx}",
+            role=MessageRole.ASSISTANT,
+            content="tool call",
+            tool_calls=[{"id": f"call-{idx}", "function": {"name": "bash", "arguments": "{}"}}],
+        )
+        for idx in range(collector._CACHE_MAX_SIZE + 5)
+    )
+
+    await collector.on_run_log_entries(entries)
+
+    assert len(collector._assistant_committed_cache) == collector._CACHE_MAX_SIZE
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `uv run pytest tests/observability/test_collector.py::test_collector_persists_trace_after_run_log_entry_batch tests/observability/test_collector.py::test_collector_no_longer_exposes_legacy_trace_callbacks tests/observability/test_collector.py::test_collector_bounds_committed_caches -v`
+Expected: FAIL because the legacy callback methods still exist, committed caches are unbounded, and entry-batch application does not persist the trace snapshot immediately.
+
+- [ ] **Step 3: Delete legacy callbacks and make entry batches the only live trace path**
+
+```python
+# agiwo/agent/trace_writer.py
+class AgentTraceCollector:
+    _CACHE_MAX_SIZE = 10_000
+
+    async def on_run_log_entries(self, entries: list[RunLogEntry]) -> None:
+        trace = self._trace
+        if trace is None:
+            return
+        for entry in entries:
+            _apply_entry_to_trace(
+                trace,
+                entry,
+                run_spans=self._run_spans,
+                llm_started=self._llm_started,
+                assistant_cache=self._assistant_committed_cache,
+                preview_length=self.PREVIEW_LENGTH,
+            )
+            if isinstance(entry, LLMCallCompleted):
+                self._llm_started.pop(entry.run_id, None)
+            if isinstance(entry, RunFinished | RunFailedEntry):
+                self._llm_started.pop(entry.run_id, None)
+        while len(self._assistant_committed_cache) > self._CACHE_MAX_SIZE:
+            self._assistant_committed_cache.popitem(last=False)
+        await self._save_trace()
+```
+
+```python
+# agiwo/agent/trace_writer.py
+# delete:
+# - on_run_started(...)
+# - on_step(...)
+# - on_run_completed(...)
+# - on_run_failed(...)
+```
+
+- [ ] **Step 4: Run trace, parity, and console replay coverage**
+
+Run: `uv run pytest tests/observability/test_collector.py tests/agent/test_run_log_replay_parity.py console/tests/test_runtime_replay_consistency.py -v`
+Expected: PASS with trace built and persisted only from committed entries, live/replay parity preserved, and no production dependency on direct callback trace construction.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agiwo/agent/trace_writer.py agiwo/agent/runtime/session.py tests/observability/test_collector.py tests/agent/test_run_log_replay_parity.py console/tests/test_runtime_replay_consistency.py
+git commit -m "refactor: make trace entry-only and persist live projections"
+```
+
+### Task 5: Run Full Verification And Update Runtime Docs
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update runtime wording if implementation changed contract details**
+
+```markdown
+### Storage & Observability
+
+- accepted steer input is staged and only consumed after the writer commits the resulting `MessagesRebuilt` fact
+- internal canonical LLM turns such as `compaction` and termination summary also emit `LLMCallStarted` / `LLMCallCompleted`
+- `AgentTraceCollector` no longer exposes legacy direct callbacks; live and replay trace both consume committed `RunLog` entries only
+```
+
+- [ ] **Step 2: Run the full lint and affected test suites**
+
+Run: `uv run python scripts/lint.py ci`
+Expected: PASS with formatting, lint, import-linter, and repo guard all green.
+
+Run: `uv run pytest tests/agent/test_run_loop_contracts.py tests/agent/test_run_engine.py tests/agent/test_state_tracking.py tests/agent/test_compact.py tests/agent/test_termination.py tests/observability/test_collector.py tests/agent/test_run_log_replay_parity.py tests/scheduler/test_runtime_facts.py -v`
+Expected: PASS with steer, writer, internal-LLM, trace, and replay coverage green.
+
+Run: `uv run pytest console/tests/test_runtime_replay_consistency.py -v`
+Expected: PASS with console replay/query semantics still matching committed `RunLog`.
+
+Run: `uv run python scripts/check.py console-tests`
+Expected: PASS for the console backend suite.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: align runtime contract with final convergence"
+```
+
+## Self-Review
+
+Spec coverage:
+- Lossless steer consumption is covered by Task 1.
+- Remaining writer bypass removal is covered by Task 2.
+- Internal canonical LLM turns are covered by Tasks 2 and 3.
+- Entry-only trace construction and live trace persistence are covered by Task 4.
+- Final contract wording and full verification are covered by Task 5.
+
+Placeholder scan:
+- No `TODO`, `TBD`, or deferred implementation placeholders remain.
+
+Type consistency:
+- The plan consistently uses `peek_pending_steer_inputs`, `ack_pending_steer_inputs`, `record_bootstrap_state`, and canonical `LLMCallStarted` / `LLMCallCompleted` naming across tasks.

--- a/docs/superpowers/specs/2026-04-23-agent-runtime-final-convergence-design.md
+++ b/docs/superpowers/specs/2026-04-23-agent-runtime-final-convergence-design.md
@@ -1,0 +1,311 @@
+# Agent Runtime Final Convergence Design
+
+**Goal:** Finish the strict convergence of `agiwo.agent` so `RunStateWriter` is the only committed runtime-truth write path, `RunLog` is the only replayable truth source, and no legacy trace or message-mutation path remains in production.
+
+**Architecture:** Keep `RunLoopOrchestrator` as the only phase decider. Move every committed runtime mutation, including remaining bootstrap and steer-adjacent state writes, behind `RunStateWriter`. Delete the legacy direct-trace callback path and make live trace, replay trace, and replayable stream/query views all consume committed `RunLog` entries only.
+
+**This document is a follow-up to:** [2026-04-22-agent-runtime-strict-convergence-design.md](./2026-04-22-agent-runtime-strict-convergence-design.md)
+
+## Why Another Follow-up
+
+PR #76 completed most of the strict convergence work, but review of the merged implementation still found four remaining gaps:
+
+1. accepted steer input can be drained before any committed runtime fact is written
+2. `AgentTraceCollector` still contains a legacy direct-callback construction path
+3. a few committed runtime fields are still mutated outside `RunStateWriter`
+4. internal LLM turns and live trace persistence are not yet fully aligned with the canonical replay model
+
+This follow-up closes those gaps without preserving backward compatibility.
+
+## Scope
+
+This pass covers only the remaining convergence work inside `agiwo.agent` and its immediate query/observability consumers.
+
+This pass does not cover:
+
+1. unrelated scheduler semantics changes
+2. new public product features
+3. migration layers for old internal APIs
+
+## Final Contract
+
+The final runtime contract after this pass is:
+
+1. `RunLoopOrchestrator` decides runtime phases
+2. `RunStateWriter` is the only path allowed to mutate committed runtime truth
+3. committed runtime truth means:
+   - mutable in-memory committed runtime state
+   - typed append-only `RunLog` entries
+4. `SessionRuntime` may:
+   - allocate sequences
+   - append committed entries
+   - project views from committed entries
+5. `SessionRuntime` may not:
+   - mutate committed runtime truth directly
+   - synthesize replayable facts independently of committed entries
+6. `TraceBuilder`, `StreamBuilder`, and query builders are pure `RunLog` consumers
+7. `StepDeltaEvent` remains the only live-only transport exception
+8. no legacy trace callback path remains in production code
+
+## Problem Details
+
+### 1. Steer Is Not Yet Lossless
+
+`apply_steering_messages(...)` drains `steering_queue` before the runtime commits any canonical fact describing the consumed steer input.
+
+If a fatal `before_llm` hook failure or writer/storage failure happens after queue drain but before commit, the accepted steer input disappears without a matching committed runtime fact.
+
+That violates the strict truth contract.
+
+### 2. Trace Still Has A Dual Architecture
+
+`AgentTraceCollector` now supports committed-entry projection, but it still exposes and implements:
+
+1. `on_run_started(...)`
+2. `on_step(...)`
+3. `on_run_completed(...)`
+4. `on_run_failed(...)`
+
+Those methods build trace state independently of committed `RunLog` entries. Keeping them around preserves a second architecture and invites future drift.
+
+### 3. Remaining Writer Bypasses Still Exist
+
+The merged code still mutates some committed runtime state outside `RunStateWriter`, including:
+
+1. bootstrap tool schema state
+2. bootstrap compaction metadata state
+3. bootstrap `run_start_seq`
+4. compaction failure counters
+
+These are small, but they still violate the strict rule.
+
+### 4. Internal LLM Turns Are Not Fully Canonical
+
+Normal assistant turns write `LLMCallStarted` and `LLMCallCompleted`.
+
+Internal LLM turns such as:
+
+1. `compaction`
+2. termination summary generation
+
+still commit steps but do not consistently commit canonical LLM-call facts through the same path.
+
+That makes replayed trace structure weaker than live runtime intent.
+
+### 5. Live Trace Persistence Is Too Deferred
+
+`on_run_log_entries(...)` updates in-memory trace state but does not persist the updated trace snapshot immediately.
+
+For long-lived persistent runtimes, console trace queries can lag behind the actual committed runtime facts until close/final stop.
+
+## Design
+
+### A. Lossless Steer Consumption
+
+Steer handling becomes a staged commit flow.
+
+The runtime must distinguish between:
+
+1. pending steer inputs not yet committed into the current request state
+2. committed message-state rewrites that now include steer input
+
+The new rule is:
+
+1. reading pending steer input is allowed
+2. draining/removing it from pending state is not considered complete until the resulting message rewrite is committed through `RunStateWriter`
+
+Implementation shape:
+
+1. replace the current destructive queue-drain helper with a helper that stages pending steer inputs without final consumption
+2. apply `before_llm` transforms to the staged message set
+3. if the staged message set differs from current committed messages, commit it through `RunStateWriter` as `MessagesRebuilt(reason="before_llm")`
+4. only after that commit succeeds may the staged steer items be considered consumed
+5. if commit fails, the steer input must remain recoverable for a future retry in the same session runtime
+
+This keeps accepted steer input lossless.
+
+### B. `RunStateWriter` Owns The Remaining Runtime Mutations
+
+`RunStateWriter` gains explicit ownership over the remaining committed-state fields that still bypass it.
+
+That includes:
+
+1. tool schema state for the active run
+2. latest compaction metadata state
+3. `run_start_seq`
+4. compaction failure count updates
+
+The rule is:
+
+1. if a field influences later committed runtime behavior or replay semantics, it belongs to writer-owned committed runtime state
+2. direct mutation helpers may remain only for explicitly ephemeral state that is documented as non-canonical
+
+This pass does not introduce new ambiguous middle ground.
+
+### C. Internal LLM Turns Become Canonical LLM Facts
+
+Internal LLM turns that are part of the runtime contract must use the same writer-mediated LLM fact pipeline as ordinary assistant turns.
+
+That means `compaction` and termination summary generation must commit:
+
+1. `LLMCallStarted`
+2. committed step facts
+3. `LLMCallCompleted`
+
+using the same canonical sequence:
+
+1. writer commits request fact
+2. stream delta remains live-only if applicable
+3. final committed assistant step goes through writer
+4. final LLM completion fact goes through writer
+5. trace and replayable stream project from those entries
+
+No special hidden trace-only path is allowed.
+
+### D. Trace Becomes Entry-Only
+
+`AgentTraceCollector` keeps only:
+
+1. `start(...)`
+2. `on_run_log_entries(...)`
+3. `build_from_entries(...)`
+4. `stop()`
+
+The legacy direct-callback methods are removed.
+
+Tests and callers must build trace state only from committed entries.
+
+The collector must also manage projection state with bounded memory:
+
+1. committed assistant-tool-call cache gets an explicit cap, matching the previous legacy cache safety level
+2. `LLMCallStarted` correlation state is cleared once a matching completion is processed or the run reaches terminal state
+
+### E. Live Trace Persistence Tracks Committed Facts
+
+Whenever committed entries are applied to the live trace, the updated trace snapshot must be persisted frequently enough that console queries observe current committed runtime truth during long-lived sessions.
+
+The required rule is:
+
+1. after a committed entry batch is applied to the live trace, the collector persists the updated trace snapshot
+2. this persistence remains best-effort and may warn on failure without breaking the runtime
+3. replay and live query surfaces must not depend on session close to become accurate
+
+This keeps trace storage aligned with persistent scheduler-managed runtimes.
+
+### F. Query / Debug Visibility
+
+First-class runtime facts must remain practically observable.
+
+For this pass:
+
+1. `HookFailed` remains a committed first-class `RunLog` fact
+2. it must remain replayable from storage and available to runtime/debug query flows
+3. no separate compatibility event layer is introduced just to preserve old paths
+
+This pass does not require adding a new end-user public stream event for `HookFailed` unless implementation naturally reuses an existing runtime-debug view.
+
+## Required Deletions
+
+This pass explicitly deletes:
+
+1. legacy direct trace callback construction paths
+2. production code paths that mutate committed runtime truth before writer commit
+3. hidden internal LLM call handling that bypasses canonical LLM facts
+
+Backward compatibility for those internal paths is out of scope.
+
+## File-Level Impact
+
+Primary modules expected to change:
+
+1. `agiwo/agent/run_loop.py`
+2. `agiwo/agent/runtime/state_writer.py`
+3. `agiwo/agent/runtime/session.py`
+4. `agiwo/agent/trace_writer.py`
+5. `agiwo/agent/run_bootstrap.py`
+6. `agiwo/agent/compaction.py`
+7. `agiwo/agent/termination/summarizer.py`
+8. `agiwo/agent/prompt.py` or a replacement runtime helper if steer staging is moved out of prompt helpers
+9. `tests/agent/test_run_loop_contracts.py`
+10. `tests/agent/test_run_engine.py`
+11. `tests/observability/test_collector.py`
+12. `tests/agent/test_run_log_replay_parity.py`
+13. `console/tests/test_runtime_replay_consistency.py`
+
+## Error Handling Rules
+
+### Steer Failure
+
+If staging or committing steer-derived message rewrites fails:
+
+1. no silent steer loss is allowed
+2. the pending steer input remains recoverable
+3. fatal run failure still writes `RunFailed` if the run had already started
+
+### Trace Persistence Failure
+
+If trace snapshot persistence fails:
+
+1. committed runtime execution continues
+2. warning-level logging is emitted
+3. replay from `RunLog` remains the correctness fallback
+
+### Internal LLM Failure
+
+If an internal LLM turn fails:
+
+1. any already-committed facts remain canonical
+2. fatal propagation still ends in `RunFailed` where applicable
+3. best-effort summary generation may still degrade gracefully, but it may not bypass canonical fact-writing for the facts it does commit
+
+## Acceptance Criteria
+
+This cleanup is complete only when all of the following are true:
+
+1. accepted steer input cannot be silently lost before a committed runtime fact exists
+2. `RunStateWriter` owns all committed runtime-truth mutations remaining in bootstrap, compaction, and related flows
+3. internal canonical LLM turns write `LLMCallStarted` and `LLMCallCompleted`
+4. production trace building uses only committed `RunLog` entry projection
+5. legacy direct trace callback methods are removed from production code
+6. live trace storage stays aligned with committed runtime facts during long-lived sessions
+7. committed trace-correlation caches are memory-bounded
+8. no production code path mutates committed runtime truth outside `RunStateWriter`
+9. live replayable stream parity and live/replayed trace parity still hold
+
+## Testing Strategy
+
+The implementation must add or update tests at four layers:
+
+1. unit tests
+   - writer-owned state mutations
+   - steer staging semantics
+   - trace cache cleanup and bounds
+2. runtime integration tests
+   - `before_llm` failure after accepted steer input
+   - compaction internal LLM facts
+   - termination summary internal LLM facts
+3. parity tests
+   - live stream vs replay stream
+   - live trace vs replay trace
+4. guardrail tests
+   - fail if production code still uses legacy trace callback APIs
+   - fail if known committed-state bypass points reappear
+
+## Non-Goals
+
+This pass does not:
+
+1. redesign scheduler semantics
+2. add new product-facing observability UIs beyond what the cleaned runtime contract requires
+3. keep deprecated internal APIs alive
+
+## Final Statement
+
+After this pass, the runtime contract is intentionally simple:
+
+1. orchestrator decides
+2. writer commits runtime truth
+3. session runtime appends and projects
+4. trace/stream/query consume committed entries
+
+That is the final strict-convergence end state for the current runtime architecture.

--- a/tests/agent/test_compact.py
+++ b/tests/agent/test_compact.py
@@ -11,7 +11,12 @@ from agiwo.agent.compaction import (
     compact_if_needed,
 )
 from agiwo.agent.hooks import HookPhase, HookRegistry, observe
-from agiwo.agent.models.log import CompactionFailed, RunLogEntryKind
+from agiwo.agent.models.log import (
+    CompactionFailed,
+    LLMCallCompleted,
+    LLMCallStarted,
+    RunLogEntryKind,
+)
 from agiwo.agent.models.run import CompactMetadata, RunIdentity
 from agiwo.agent.run_loop import RunLoopOrchestrator
 from agiwo.agent.runtime.context import RunContext, RunRuntime
@@ -164,8 +169,18 @@ async def test_compact_if_needed_uses_the_same_step_commit_pipeline_as_run_loop(
     assert persisted == metadata
     entries = await session_runtime.list_run_log_entries(run_id="run-1")
     kinds = [entry.kind for entry in entries]
+    llm_started = [entry for entry in entries if isinstance(entry, LLMCallStarted)]
+    llm_completed = [entry for entry in entries if isinstance(entry, LLMCallCompleted)]
     assert RunLogEntryKind.MESSAGES_REBUILT in kinds
     assert RunLogEntryKind.COMPACTION_APPLIED in kinds
+    assert len(llm_started) == 1
+    assert len(llm_completed) == 1
+    assert (
+        llm_started[0]
+        .messages[-1]["content"]
+        .startswith("**IMPORTANT: Context Compression Required**")
+    )
+    assert llm_completed[0].content == '{"summary": "compressed"}'
     assert [
         item.type
         for item in published

--- a/tests/agent/test_run_engine.py
+++ b/tests/agent/test_run_engine.py
@@ -6,13 +6,20 @@ from agiwo.agent import Agent, AgentConfig, TerminationReason
 from agiwo.agent.hooks import HookPhase, HookRegistry, transform
 from agiwo.agent.models.log import (
     AssistantStepCommitted,
+    HookFailed,
     LLMCallStarted,
     MessagesRebuilt,
     RunFinished,
     RunLogEntryKind,
 )
+from agiwo.agent.models.config import AgentOptions
+from agiwo.agent.models.run import RunIdentity
 from agiwo.agent.models.stream import stream_items_from_entries
 from agiwo.agent.models.step import MessageRole
+from agiwo.agent.run_loop import RunLoopOrchestrator
+from agiwo.agent.runtime.context import RunContext, RunRuntime
+from agiwo.agent.runtime.session import SessionRuntime
+from agiwo.agent.storage.base import InMemoryRunLogStorage
 from agiwo.llm.base import Model, StreamChunk
 
 
@@ -134,6 +141,83 @@ async def test_before_llm_message_rewrite_becomes_messages_rebuilt_fact() -> Non
         "content": "steered follow-up",
     }
     assert llm_started.messages == rebuilt.messages
+
+
+@pytest.mark.asyncio
+async def test_before_llm_failure_records_accepted_steer_input_before_run_failed() -> (
+    None
+):
+    async def explode(payload: dict) -> dict:
+        assert payload["messages"][-1] == {
+            "role": "user",
+            "content": "follow up",
+        }
+        raise RuntimeError("before llm boom")
+
+    session_runtime = SessionRuntime(
+        session_id="steer-failure-session",
+        run_log_storage=InMemoryRunLogStorage(),
+    )
+    context = RunContext(
+        identity=RunIdentity(
+            run_id="run-1",
+            agent_id="agent-1",
+            agent_name="agent",
+        ),
+        session_runtime=session_runtime,
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ],
+    )
+    hooks = HookRegistry(
+        [
+            transform(
+                HookPhase.BEFORE_LLM,
+                "explode",
+                explode,
+                critical=True,
+            )
+        ]
+    )
+    context.hooks = hooks
+    runtime = RunRuntime(
+        session_runtime=session_runtime,
+        config=AgentOptions(),
+        hooks=hooks,
+        model=_NeverCalledModel(),
+        tools_map={},
+        abort_signal=None,
+        root_path=".",
+        compact_start_seq=0,
+        max_input_tokens_per_call=0,
+        max_context_window=None,
+        compact_prompt=None,
+    )
+    orchestrator = RunLoopOrchestrator(context, runtime)
+
+    await orchestrator._start_run("hello")
+    accepted = await session_runtime.enqueue_steer("follow up")
+
+    assert accepted is True
+
+    with pytest.raises(RuntimeError, match="before llm boom") as exc_info:
+        await orchestrator._run_assistant_turn()
+    await orchestrator._fail_run(exc_info.value)
+
+    entries = await session_runtime.list_run_log_entries(run_id="run-1")
+    rebuilt = next(entry for entry in entries if isinstance(entry, MessagesRebuilt))
+    hook_failed = next(entry for entry in entries if isinstance(entry, HookFailed))
+
+    assert rebuilt.reason == "before_llm"
+    assert rebuilt.messages[-1] == {
+        "role": "user",
+        "content": "follow up",
+    }
+    assert hook_failed.phase == "before_llm"
+    assert hook_failed.handler_name == "explode"
+    assert rebuilt.sequence < hook_failed.sequence < entries[-1].sequence
+    assert entries[-1].kind.value == "run_failed"
 
 
 def test_stream_items_from_entries_reuses_nested_run_context_without_run_started() -> (

--- a/tests/agent/test_run_loop_contracts.py
+++ b/tests/agent/test_run_loop_contracts.py
@@ -67,7 +67,7 @@ async def test_apply_steering_messages_preserves_multimodal_payloads() -> None:
 
     updated = apply_steering_messages(
         [{"role": "assistant", "content": "waiting"}],
-        session_runtime.steering_queue,
+        session_runtime.peek_pending_steer_inputs(),
     )
 
     assert updated[-1] == {
@@ -80,6 +80,27 @@ async def test_apply_steering_messages_preserves_multimodal_payloads() -> None:
             },
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_session_runtime_peek_steer_does_not_consume_until_ack() -> None:
+    session_runtime = _make_session_runtime()
+
+    await session_runtime.enqueue_steer("follow up")
+
+    pending = session_runtime.peek_pending_steer_inputs()
+
+    assert [UserMessage.from_value(item).extract_text() for item in pending] == [
+        "follow up"
+    ]
+    assert [
+        UserMessage.from_value(item).extract_text()
+        for item in session_runtime.peek_pending_steer_inputs()
+    ] == ["follow up"]
+
+    session_runtime.ack_pending_steer_inputs(len(pending))
+
+    assert session_runtime.peek_pending_steer_inputs() == []
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_state_tracking.py
+++ b/tests/agent/test_state_tracking.py
@@ -92,6 +92,40 @@ async def test_run_state_writer_commit_step_updates_state_and_returns_entry() ->
     assert state.ledger.messages[-1]["role"] == "user"
 
 
+@pytest.mark.asyncio
+async def test_run_state_writer_owns_bootstrap_state_mutations() -> None:
+    state = _make_state()
+    writer = RunStateWriter(state)
+    metadata = CompactMetadata(
+        session_id="session-1",
+        agent_id="agent-1",
+        start_seq=1,
+        end_seq=2,
+        before_token_estimate=100,
+        after_token_estimate=10,
+        message_count=2,
+        transcript_path="/tmp/t.jsonl",
+        analysis={"summary": "summary"},
+        created_at=datetime(2026, 3, 26, 12, 0, 0),
+    )
+
+    entries = await writer.record_context_assembled(
+        messages=[{"role": "system", "content": "sys"}],
+        memory_count=0,
+        run_start_seq=7,
+        tool_schemas=[{"type": "function", "function": {"name": "bash"}}],
+        latest_compaction=metadata,
+    )
+
+    assert entries[0].kind.value == "context_assembled"
+    assert state.ledger.messages == [{"role": "system", "content": "sys"}]
+    assert state.ledger.run_start_seq == 7
+    assert state.ledger.tool_schemas == [
+        {"type": "function", "function": {"name": "bash"}}
+    ]
+    assert state.ledger.compaction.last_metadata == metadata
+
+
 def test_runtime_state_ops_only_touch_mutable_ledger_state() -> None:
     state = _make_state()
 

--- a/tests/agent/test_termination.py
+++ b/tests/agent/test_termination.py
@@ -4,7 +4,11 @@ from collections.abc import AsyncIterator
 import pytest
 
 from agiwo.agent import Agent, AgentConfig
-from agiwo.agent.models.log import RunLogEntryKind
+from agiwo.agent.models.log import (
+    LLMCallCompleted,
+    LLMCallStarted,
+    RunLogEntryKind,
+)
 from agiwo.agent.models.config import AgentOptions
 from agiwo.agent.models.run import RunIdentity
 from agiwo.agent.models.step import LLMCallContext, StepMetrics, StepView
@@ -12,6 +16,7 @@ from agiwo.agent import TerminationReason
 from agiwo.agent.runtime.context import RunContext
 from agiwo.agent.runtime.session import SessionRuntime
 from agiwo.agent.storage.base import InMemoryRunLogStorage
+from agiwo.agent.termination.summarizer import maybe_generate_termination_summary
 from agiwo.llm.base import Model, StreamChunk
 
 
@@ -139,3 +144,27 @@ async def test_run_records_termination_decision_entry() -> None:
     assert termination_entry.termination_reason == TerminationReason.MAX_STEPS
     assert termination_entry.phase == "pre_llm"
     assert termination_entry.source == "non_recoverable_limit"
+
+
+@pytest.mark.asyncio
+async def test_termination_summary_writes_canonical_llm_call_facts() -> None:
+    state = _make_context()
+    state.ledger.termination_reason = TerminationReason.MAX_STEPS
+    state.ledger.messages = [{"role": "user", "content": "hello"}]
+
+    await maybe_generate_termination_summary(
+        state=state,
+        options=AgentOptions(enable_termination_summary=True),
+        model=_FixedResponseModel(response="summary response"),
+        abort_signal=None,
+    )
+
+    entries = await state.session_runtime.list_run_log_entries(run_id="run-1")
+    llm_started = [entry for entry in entries if isinstance(entry, LLMCallStarted)]
+    llm_completed = [entry for entry in entries if isinstance(entry, LLMCallCompleted)]
+
+    assert len(llm_started) == 1
+    assert len(llm_completed) == 1
+    assert "Execution Limit Reached" in llm_started[0].messages[-1]["content"]
+    assert "Please provide a summary report" in llm_started[0].messages[-1]["content"]
+    assert llm_completed[0].content == "summary response"

--- a/tests/observability/test_collector.py
+++ b/tests/observability/test_collector.py
@@ -2,109 +2,148 @@ from datetime import datetime, timezone
 
 import pytest
 
-from agiwo.agent import (
-    LLMCallContext,
-    MessageRole,
-    RunOutput,
-    StepMetrics,
-    StepView,
-    TerminationReason,
-)
+from agiwo.agent import StepMetrics, TerminationReason
 from agiwo.agent.models.log import (
+    AssistantStepCommitted,
     CompactionApplied,
+    LLMCallCompleted,
+    LLMCallStarted,
     RetrospectApplied,
+    RunFinished,
     RunStarted,
     TerminationDecided,
+    ToolStepCommitted,
 )
+from agiwo.agent.models.step import MessageRole
 from agiwo.agent.trace_writer import AgentTraceCollector
-from agiwo.observability.trace import SpanKind
+from agiwo.observability.base import BaseTraceStorage, TraceQuery
+from agiwo.observability.trace import SpanKind, Trace
+
+
+class _RecordingTraceStorage(BaseTraceStorage):
+    def __init__(self) -> None:
+        self.saved: list[Trace] = []
+
+    async def save_trace(self, trace: Trace) -> None:
+        self.saved.append(trace.model_copy(deep=True))
+
+    async def get_trace(self, trace_id: str) -> Trace | None:
+        for trace in reversed(self.saved):
+            if trace.trace_id == trace_id:
+                return trace
+        return None
+
+    async def query_traces(self, query: TraceQuery | dict) -> list[Trace]:
+        del query
+        return list(self.saved)
+
+    async def close(self) -> None:
+        self.saved.clear()
 
 
 @pytest.mark.asyncio
-async def test_collect_routes_assistant_and_tool_steps() -> None:
-    collector = AgentTraceCollector()
+async def test_collects_trace_from_committed_run_log_entries_only() -> None:
+    storage = _RecordingTraceStorage()
+    collector = AgentTraceCollector(store=storage)
     collector.start(
         trace_id="trace-1",
         agent_id="agent-1",
         session_id="session-1",
         input_query="search for updates",
     )
-    collector.on_run_started(
-        run_id="run-1",
-        agent_id="agent-1",
-        session_id="session-1",
-        parent_run_id=None,
+
+    tool_call = {
+        "id": "call-1",
+        "function": {
+            "name": "web_search",
+            "arguments": '{"query": "latest updates"}',
+        },
+    }
+    metrics = StepMetrics(
+        start_at=datetime(2026, 3, 10, 10, 0, 0, tzinfo=timezone.utc),
+        end_at=datetime(2026, 3, 10, 10, 0, 1, tzinfo=timezone.utc),
+        duration_ms=1000.0,
+        input_tokens=120,
+        output_tokens=30,
+        total_tokens=150,
+        usage_source="provider",
+        model_name="test-model",
+        provider="test-provider",
     )
 
-    assistant_step = StepView(
-        session_id="session-1",
-        run_id="run-1",
-        sequence=1,
-        role=MessageRole.ASSISTANT,
-        content="Let me search that.",
-        tool_calls=[
-            {
-                "id": "call-1",
-                "function": {
-                    "name": "web_search",
-                    "arguments": '{"query": "latest updates"}',
-                },
-            }
-        ],
-        metrics=StepMetrics(
-            start_at=datetime(2026, 3, 10, 10, 0, 0, tzinfo=timezone.utc),
-            end_at=datetime(2026, 3, 10, 10, 0, 1, tzinfo=timezone.utc),
-            duration_ms=1000.0,
-            input_tokens=120,
-            output_tokens=30,
-            total_tokens=150,
-            usage_source="provider",
-            model_name="test-model",
-            provider="test-provider",
-        ),
-    )
-    await collector.on_step(
-        assistant_step,
-        LLMCallContext(
-            messages=[{"role": "user", "content": "search"}],
-            tools=[{"name": "web_search"}],
-            request_params={"temperature": 0.1},
-            finish_reason="tool_calls",
-        ),
-    )
-
-    tool_step = StepView(
-        session_id="session-1",
-        run_id="run-1",
-        sequence=2,
-        role=MessageRole.TOOL,
-        tool_call_id="call-1",
-        name="web_search",
-        content="Found matching documents",
-        content_for_user="Found matching documents",
-        metrics=StepMetrics(duration_ms=75.0),
-    )
-    await collector.on_step(tool_step)
-    await collector.on_run_completed(
-        RunOutput(
-            session_id="session-1",
-            run_id="run-1",
-            response="Found matching documents",
-            termination_reason=TerminationReason.COMPLETED,
-        ),
-        run_id="run-1",
+    await collector.on_run_log_entries(
+        [
+            RunStarted(
+                sequence=1,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                user_input="search for updates",
+            ),
+            LLMCallStarted(
+                sequence=2,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                messages=[{"role": "user", "content": "search"}],
+                tools=[{"name": "web_search"}],
+            ),
+            AssistantStepCommitted(
+                sequence=3,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                step_id="step-1",
+                role=MessageRole.ASSISTANT,
+                content="Let me search that.",
+                tool_calls=[tool_call],
+                metrics=metrics,
+            ),
+            LLMCallCompleted(
+                sequence=4,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                content="Let me search that.",
+                tool_calls=[tool_call],
+                finish_reason="tool_calls",
+                metrics=metrics,
+            ),
+            ToolStepCommitted(
+                sequence=5,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                step_id="step-2",
+                role=MessageRole.TOOL,
+                tool_call_id="call-1",
+                name="web_search",
+                content="Found matching documents",
+                content_for_user="Found matching documents",
+                metrics=StepMetrics(duration_ms=75.0),
+            ),
+            RunFinished(
+                sequence=6,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                response="Found matching documents",
+                termination_reason=TerminationReason.COMPLETED,
+            ),
+        ]
     )
 
     trace = collector._trace
     assert trace is not None
+    assert len(storage.saved) == 1
 
     llm_span = next(span for span in trace.spans if span.kind == SpanKind.LLM_CALL)
     assert llm_span.llm_details == {
-        "request": {"temperature": 0.1},
+        "request": {},
         "messages": [{"role": "user", "content": "search"}],
         "tools": [{"name": "web_search"}],
         "response_content": "Let me search that.",
-        "response_tool_calls": assistant_step.tool_calls,
+        "response_tool_calls": [tool_call],
         "finish_reason": "tool_calls",
         "status": "completed",
         "metrics": {
@@ -130,22 +169,24 @@ async def test_collect_routes_assistant_and_tool_steps() -> None:
 
 @pytest.mark.asyncio
 async def test_collector_records_runtime_run_log_entries() -> None:
-    collector = AgentTraceCollector()
+    storage = _RecordingTraceStorage()
+    collector = AgentTraceCollector(store=storage)
     collector.start(
         trace_id="trace-2",
         agent_id="agent-1",
         session_id="session-1",
         input_query="hello",
     )
-    collector.on_run_started(
-        run_id="run-1",
-        agent_id="agent-1",
-        session_id="session-1",
-        parent_run_id=None,
-    )
 
     await collector.on_run_log_entries(
         [
+            RunStarted(
+                sequence=1,
+                session_id="session-1",
+                run_id="run-1",
+                agent_id="agent-1",
+                user_input="hello",
+            ),
             CompactionApplied(
                 sequence=3,
                 session_id="session-1",
@@ -186,6 +227,7 @@ async def test_collector_records_runtime_run_log_entries() -> None:
 
     trace = collector._trace
     assert trace is not None
+    assert len(storage.saved) == 1
     runtime_spans = [span for span in trace.spans if span.kind == SpanKind.RUNTIME]
     assert [span.name for span in runtime_spans] == [
         "compaction",


### PR DESCRIPTION
## What

Finish the remaining strict convergence work for the agent runtime so committed `RunLog` entries become the single runtime truth for stream, trace, and internal runtime decisions.

## Why

PR #76 completed the first phase, but several paths still had split semantics:
- accepted steer input could race with `before_llm` failure and not become a committed fact
- bootstrap and compaction state still had direct ledger mutations outside `RunStateWriter`
- compaction and termination summary internal LLM turns were not canonical `RunLog` facts
- live trace still retained a legacy callback-based construction path instead of consuming committed entries only

This PR removes those remaining inconsistencies and fully converges the runtime around committed entry batches.

## How

- make steer consumption staged and lossless via `SessionRuntime.peek_pending_steer_inputs()` / `ack_pending_steer_inputs()` and commit `MessagesRebuilt(reason="before_llm")` before consuming accepted steer input
- route bootstrap-owned committed state (`run_start_seq`, tool schemas, latest compaction metadata) through `RunStateWriter.record_context_assembled(...)`
- make compaction failure counting writer-owned and delete the shadow steer queue compatibility path
- emit canonical `LLMCallStarted` / `LLMCallCompleted` for compaction and termination-summary internal turns
- delete legacy `AgentTraceCollector` run/step callback APIs so live trace is built and persisted only from committed run-log entry batches
- update in-memory trace storage to replace same-`trace_id` snapshots instead of accumulating duplicates
- expand tests around steer losslessness, writer ownership, canonical internal LLM facts, and entry-only trace construction

## Testing

- `uv run python scripts/lint.py ci`
- `uv run pytest tests/agent/test_run_loop_contracts.py tests/agent/test_run_engine.py::test_before_llm_failure_records_accepted_steer_input_before_run_failed tests/agent/test_run_log_replay_parity.py tests/agent/test_state_tracking.py tests/agent/test_compact.py tests/agent/test_termination.py tests/observability/test_collector.py tests/agent/test_storage_factory.py -v`
- pre-push gate also ran and passed:
  - `uv run python scripts/lint.py ci`
  - `uv run pytest tests/ -v --tb=short`
  - `cd console && uv run pytest tests/ -v --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated potential loss of steering inputs during execution.
  * Improved persistence of trace data for extended sessions.

* **Improvements**
  * Enhanced logging and observability for internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->