### PR TITLE
refactor: address runtime convergence nitpicks

### DIFF
--- a/agiwo/agent/compaction.py
+++ b/agiwo/agent/compaction.py
@@ -313,9 +313,10 @@ async def _compact(
         name="compact_request",
     )
     await commit_step(state, compact_user_step, append_message=True)
+    snapshot_messages = state.snapshot_messages()
 
     started_entries = await writer.record_llm_call_started(
-        messages=state.snapshot_messages(),
+        messages=snapshot_messages,
         tools=None,
     )
     await state.session_runtime.project_run_log_entries(
@@ -330,7 +331,7 @@ async def _compact(
         model,
         state,
         abort_signal,
-        messages=state.snapshot_messages(),
+        messages=snapshot_messages,
         use_state_tools=False,
         name="compact",
     )

--- a/agiwo/agent/trace_writer.py
+++ b/agiwo/agent/trace_writer.py
@@ -131,6 +131,41 @@ def _extract_tool_args_from_committed(
     return {}
 
 
+def _remove_tool_call_index(
+    run_to_tool_calls: dict[str, set[str]] | None,
+    *,
+    run_id: str,
+    tool_call_id: str,
+) -> None:
+    if run_to_tool_calls is None:
+        return
+    tool_call_ids = run_to_tool_calls.get(run_id)
+    if not tool_call_ids:
+        return
+    tool_call_ids.discard(tool_call_id)
+    if not tool_call_ids:
+        run_to_tool_calls.pop(run_id, None)
+
+
+def _cache_assistant_tool_call(
+    assistant_cache: OrderedDict[str, AssistantStepCommitted],
+    *,
+    assistant: AssistantStepCommitted,
+    tool_call_id: str,
+    run_to_tool_calls: dict[str, set[str]] | None = None,
+) -> None:
+    previous = assistant_cache.get(tool_call_id)
+    if previous is not None and previous.run_id != assistant.run_id:
+        _remove_tool_call_index(
+            run_to_tool_calls,
+            run_id=previous.run_id,
+            tool_call_id=tool_call_id,
+        )
+    assistant_cache[tool_call_id] = assistant
+    if run_to_tool_calls is not None:
+        run_to_tool_calls.setdefault(assistant.run_id, set()).add(tool_call_id)
+
+
 def _build_tool_span_from_entry(
     trace_id: str,
     step: ToolStepCommitted,
@@ -439,12 +474,18 @@ def _apply_tool_entry_to_trace(
     *,
     run_spans: dict[str, Span],
     assistant_cache: OrderedDict[str, AssistantStepCommitted],
+    run_to_tool_calls: dict[str, set[str]] | None = None,
 ) -> bool:
     if isinstance(entry, AssistantStepCommitted) and entry.tool_calls:
         for tc in entry.tool_calls:
             tool_call_id = tc.get("id")
             if tool_call_id:
-                assistant_cache[tool_call_id] = entry
+                _cache_assistant_tool_call(
+                    assistant_cache,
+                    assistant=entry,
+                    tool_call_id=tool_call_id,
+                    run_to_tool_calls=run_to_tool_calls,
+                )
         return True
     if isinstance(entry, ToolStepCommitted):
         trace.add_span(
@@ -485,6 +526,7 @@ def _apply_entry_to_trace(
     llm_started: dict[str, LLMCallStarted],
     assistant_cache: OrderedDict[str, AssistantStepCommitted],
     preview_length: int,
+    run_to_tool_calls: dict[str, set[str]] | None = None,
 ) -> None:
     if _apply_run_entry_to_trace(
         trace,
@@ -506,6 +548,7 @@ def _apply_entry_to_trace(
         entry,
         run_spans=run_spans,
         assistant_cache=assistant_cache,
+        run_to_tool_calls=run_to_tool_calls,
     ):
         return
     _apply_runtime_entry_to_trace(
@@ -528,6 +571,7 @@ class AgentTraceCollector:
         self._assistant_committed_cache: OrderedDict[str, AssistantStepCommitted] = (
             OrderedDict()
         )
+        self._run_to_tool_calls: dict[str, set[str]] = {}
         self._llm_started: dict[str, LLMCallStarted] = {}
 
     @property
@@ -551,6 +595,7 @@ class AgentTraceCollector:
         )
         self._run_spans = {}
         self._assistant_committed_cache = OrderedDict()
+        self._run_to_tool_calls = {}
         self._llm_started = {}
 
     async def stop(self) -> None:
@@ -562,6 +607,7 @@ class AgentTraceCollector:
         self._trace = None
         self._run_spans = {}
         self._assistant_committed_cache = OrderedDict()
+        self._run_to_tool_calls = {}
         self._llm_started = {}
 
     async def on_run_log_entries(self, entries: list[RunLogEntry]) -> None:
@@ -576,9 +622,17 @@ class AgentTraceCollector:
                 llm_started=self._llm_started,
                 assistant_cache=self._assistant_committed_cache,
                 preview_length=self.PREVIEW_LENGTH,
+                run_to_tool_calls=self._run_to_tool_calls,
             )
             while len(self._assistant_committed_cache) > self._CACHE_MAX_SIZE:
-                self._assistant_committed_cache.popitem(last=False)
+                tool_call_id, assistant = self._assistant_committed_cache.popitem(
+                    last=False
+                )
+                _remove_tool_call_index(
+                    self._run_to_tool_calls,
+                    run_id=assistant.run_id,
+                    tool_call_id=tool_call_id,
+                )
             if isinstance(entry, (RunFinished, RunFailedEntry)):
                 self._purge_run_correlation_state(entry.run_id)
         await self._save_trace()
@@ -609,12 +663,7 @@ class AgentTraceCollector:
     def _purge_run_correlation_state(self, run_id: str) -> None:
         self._run_spans.pop(run_id, None)
         self._llm_started.pop(run_id, None)
-        stale_tool_calls = [
-            tool_call_id
-            for tool_call_id, assistant in self._assistant_committed_cache.items()
-            if assistant.run_id == run_id
-        ]
-        for tool_call_id in stale_tool_calls:
+        for tool_call_id in self._run_to_tool_calls.pop(run_id, set()):
             self._assistant_committed_cache.pop(tool_call_id, None)
 
     async def _save_trace(self) -> None:

--- a/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
+++ b/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
@@ -35,7 +35,7 @@
 - `tests/agent/test_compact.py`
   Cover canonical compaction LLM facts.
 - `tests/agent/test_termination.py`
-  Cover canonical termination-summary LLM facts.
+  Summarize canonical termination-summary LLM behavior.
 - `tests/observability/test_collector.py`
   Switch fully to committed-entry trace construction and assert bounded cache / persistence behavior.
 - `tests/agent/test_run_log_replay_parity.py`
@@ -228,7 +228,9 @@ async def test_run_state_writer_owns_bootstrap_state_mutations() -> None:
     state = _make_state()
     writer = RunStateWriter(state)
 
-    await writer.record_bootstrap_state(
+    await writer.record_context_assembled(
+        messages=[{"role": "system", "content": "sys"}],
+        memory_count=0,
         run_start_seq=7,
         tool_schemas=[{"type": "function", "function": {"name": "bash"}}],
         latest_compaction=None,
@@ -265,18 +267,22 @@ Expected: FAIL because bootstrap still mutates state directly and compaction sti
 ```python
 # agiwo/agent/runtime/state_writer.py
 class RunStateWriter:
-    async def record_bootstrap_state(
+    async def record_context_assembled(
         self,
         *,
+        messages: list[dict[str, Any]],
+        memory_count: int,
         run_start_seq: int,
         tool_schemas: list[dict[str, Any]] | None,
         latest_compaction: CompactMetadata | None,
-    ) -> None:
+    ) -> list[RunLogEntry]:
+        replace_messages(self._state, messages)
         self._state.ledger.run_start_seq = run_start_seq
         self._state.ledger.tool_schemas = (
             copy.deepcopy(tool_schemas) if tool_schemas is not None else None
         )
         self._state.ledger.compaction.last_metadata = latest_compaction
+        return await self.append_entries([build_context_assembled_entry(...)])
 
     async def record_llm_turn(
         self,
@@ -297,14 +303,12 @@ class RunStateWriter:
 ```python
 # agiwo/agent/run_bootstrap.py
 user_step = await _build_user_step(context, user_input)
-await writer.record_bootstrap_state(
-    run_start_seq=user_step.sequence,
-    tool_schemas=_build_tool_schemas(runtime),
-    latest_compaction=latest_compact,
-)
 await writer.record_context_assembled(
     messages=assembled_messages,
     memory_count=len(memories),
+    run_start_seq=user_step.sequence,
+    tool_schemas=_build_tool_schemas(runtime),
+    latest_compaction=latest_compact,
 )
 ```
 
@@ -606,4 +610,4 @@ Placeholder scan:
 - No `TODO`, `TBD`, or deferred implementation placeholders remain.
 
 Type consistency:
-- The plan consistently uses `peek_pending_steer_inputs`, `ack_pending_steer_inputs`, `record_bootstrap_state`, and canonical `LLMCallStarted` / `LLMCallCompleted` naming across tasks.
+- The plan consistently uses `peek_pending_steer_inputs`, `ack_pending_steer_inputs`, `record_context_assembled`, and canonical `LLMCallStarted` / `LLMCallCompleted` naming across tasks.


### PR DESCRIPTION
## What

Apply the verified nitpick follow-ups on top of the runtime convergence branch.

## Why

These were small but valid cleanup points discovered during review:
- compaction recorded and executed against two separate `state.snapshot_messages()` calls even though both should use the same precomputed request snapshot
- live trace correlation cleanup used an O(cache_size) scan on run completion
- the follow-up implementation plan still mixed `record_bootstrap_state` and `record_context_assembled`, which could cause doc drift

## How

- compute the compaction-turn request snapshot once and reuse it for both `record_llm_call_started(...)` and `stream_assistant_step(...)`
- add a `run_id -> tool_call_id set` secondary index in `AgentTraceCollector` so purge only touches tool-call ids owned by the completed run
- keep the index synchronized on cache insert, FIFO eviction, stop, and run purge
- normalize the follow-up plan doc to the current writer API name `record_context_assembled` and rephrase the nearby termination-summary bullet for readability

## Testing

- `uv run pytest tests/observability/test_collector.py tests/agent/test_compact.py tests/agent/test_storage_factory.py -v`
- `uv run python scripts/lint.py ci`
- pre-push gate also ran and passed:
  - `uv run python scripts/lint.py ci`
  - `uv run pytest tests/ -v --tb=short`
  - `cd console && uv run pytest tests/ -v --tb=short`
