### PR TITLE
feat: harden runtime tool surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,15 +109,15 @@
 - `enable_skill`、Agent 级 `skills_dirs` 等历史 skill 开关/目录字段已删除；发现旧字段时直接 fast-fail，不保留静默兼容层。
 - `agiwo/skill/allowlist.py` 是唯一的 allowlist 归一化/展开/校验入口：pattern 展开、显式 skill 名合法性校验、runtime 前的“必须已展开”校验都收口在这里。
 - 只有最外层输入面可以接收 skill pattern：Console env/default-agent 配置和 Agents API。进入内部模型后，只允许显式 skill 名列表。
-- `Agent`、`AgentConfigRecord`、scheduler child override、`spawn_agent.allowed_skills` 都只接受“展开后的显式 skill 名列表”；未知 skill 名和 pattern 都必须在边界被拒绝。
+- `Agent`、`AgentConfigRecord`、scheduler child override、`spawn_child_agent.allowed_skills` 都只接受“展开后的显式 skill 名列表”；未知 skill 名和 pattern 都必须在边界被拒绝。
 - 子 Agent 的 `allowed_skills` 必须是父 Agent `allowed_skills` 的子集；如果父 Agent 未限制 skills，child 才能继承 `None` 语义。
 - `SkillManager` 的全局实例 key 由 `root_path + skills_dirs` 决定；`settings.skills_dirs` 变化时，后续 `get_global_skill_manager()` 会切到新的 manager。
 
 ### Scheduler
 
 - `Scheduler` 是 Agent 之上的编排层；依赖方向保持 `scheduler -> agent`。
-- Scheduler runtime tools（`SpawnAgentTool`、`SleepAndWaitTool` 等）通过 `runtime_agent.inject_system_tools(...)` 注入，不混入 `tools`（extra_tools），不受 `allowed_tools` 约束。
-- 子 Agent 的 system_tools 由 `SchedulerRunner` 从父 Agent 的 `system_tools` 派生；非 fork 模式排除 `spawn_agent`，fork 模式继承全部（gate 检查仍阻止实际 spawn）。
+- Scheduler runtime tools（`SpawnChildAgentTool`、`ForkChildAgentTool`、`SleepAndWaitTool` 等）通过 `runtime_agent.inject_system_tools(...)` 注入，不混入 `tools`（extra_tools），不受 `allowed_tools` 约束。
+- 子 Agent 的 system_tools 由 `SchedulerRunner` 从父 Agent 的 `system_tools` 派生；非 fork 模式排除 `spawn_child_agent` / `fork_child_agent`，fork 模式继承全部（gate 检查仍阻止实际继续派生 child）。
 - 当前公开编排接口包括：`route_root_input`（统一入口）、`enqueue_input`、`wait_for`、`steer`、`cancel`、`shutdown`，以及查询面 `list_states`、`list_events`、`get_stats`、`rebind_agent`。`submit`、`run`、`stream` 已合并到 `route_root_input` 或改为内部方法。
 - `Scheduler` 只做 facade 和 lifecycle；所有编排语义统一收口到 engine 层（facade 直接委托给 `_tick`、`_stream`、`_tree_ops` 等同包 helper）。
 - `SchedulerRunner` 只负责单次 dispatch action；`TaskGuard` 是 spawn/wake 的唯一护栏入口。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@
 - `SessionRuntime` 统一负责 sequence 分配、run-log 追加、把同一批 committed entries 喂给 trace writer，并基于同批 entries 投影 replayable `AgentStreamItem`；`trace`/`stream` 是 `RunLog` 的 view builder，不得各自维护独立 runtime 真相。
 - `StepDeltaEvent` 是当前唯一允许保留的 live-only stream 例外；除它之外，所有可重放 stream 事件都应由 committed `RunLog` entries 投影产生。
 - Agent 运行记录通过 session runtime 统一提交；流式输出通过 `Agent.start()` 返回的 handle 暴露 `AgentStreamItem`。
-- `BaseTraceStorage` 支持查询和实时订阅。
+- `BaseTraceStorage` 当前提供 `save_trace` / `get_trace` / `query_traces` / `close` 基础接口；live trace 更新由 agent runtime 通过 committed `RunLog` entry batches 驱动写入。
 
 ## Architecture Boundaries
 

--- a/agiwo/agent/agent.py
+++ b/agiwo/agent/agent.py
@@ -202,8 +202,9 @@ class Agent:
         """Inject system-level tools and rebuild the resolved tool list.
 
         This is a scheduler-internal API used to inject runtime tools
-        (e.g. ``SpawnAgentTool``, ``SleepAndWaitTool``) after construction.
-        System tools bypass ``allowed_tools`` filtering.
+        (e.g. ``SpawnChildAgentTool``, ``ForkChildAgentTool``,
+        ``SleepAndWaitTool``) after construction. System tools bypass
+        ``allowed_tools`` filtering.
 
         **Note**: This method is intended for scheduler use only. Do not call
         this method directly in application code unless you are implementing

--- a/agiwo/agent/compaction.py
+++ b/agiwo/agent/compaction.py
@@ -4,6 +4,7 @@ Compaction runtime — context compression for long conversations.
 Merges compaction/runtime.py + messages.py + parser.py + prompt.py + transcript.py.
 """
 
+import copy
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -316,7 +317,7 @@ async def _compact(
     snapshot_messages = state.snapshot_messages()
 
     started_entries = await writer.record_llm_call_started(
-        messages=snapshot_messages,
+        messages=copy.deepcopy(snapshot_messages),
         tools=None,
     )
     await state.session_runtime.project_run_log_entries(

--- a/agiwo/agent/compaction.py
+++ b/agiwo/agent/compaction.py
@@ -313,9 +313,10 @@ async def _compact(
         name="compact_request",
     )
     await commit_step(state, compact_user_step, append_message=True)
+    snapshot_messages = state.snapshot_messages()
 
     started_entries = await writer.record_llm_call_started(
-        messages=state.snapshot_messages(),
+        messages=snapshot_messages,
         tools=None,
     )
     await state.session_runtime.project_run_log_entries(
@@ -330,7 +331,7 @@ async def _compact(
         model,
         state,
         abort_signal,
-        messages=state.snapshot_messages(),
+        messages=snapshot_messages,
         use_state_tools=False,
         name="compact",
     )

--- a/agiwo/agent/trace_writer.py
+++ b/agiwo/agent/trace_writer.py
@@ -131,6 +131,41 @@ def _extract_tool_args_from_committed(
     return {}
 
 
+def _remove_tool_call_index(
+    run_to_tool_calls: dict[str, set[str]] | None,
+    *,
+    run_id: str,
+    tool_call_id: str,
+) -> None:
+    if run_to_tool_calls is None:
+        return
+    tool_call_ids = run_to_tool_calls.get(run_id)
+    if not tool_call_ids:
+        return
+    tool_call_ids.discard(tool_call_id)
+    if not tool_call_ids:
+        run_to_tool_calls.pop(run_id, None)
+
+
+def _cache_assistant_tool_call(
+    assistant_cache: OrderedDict[str, AssistantStepCommitted],
+    *,
+    assistant: AssistantStepCommitted,
+    tool_call_id: str,
+    run_to_tool_calls: dict[str, set[str]] | None = None,
+) -> None:
+    previous = assistant_cache.get(tool_call_id)
+    if previous is not None and previous.run_id != assistant.run_id:
+        _remove_tool_call_index(
+            run_to_tool_calls,
+            run_id=previous.run_id,
+            tool_call_id=tool_call_id,
+        )
+    assistant_cache[tool_call_id] = assistant
+    if run_to_tool_calls is not None:
+        run_to_tool_calls.setdefault(assistant.run_id, set()).add(tool_call_id)
+
+
 def _build_tool_span_from_entry(
     trace_id: str,
     step: ToolStepCommitted,
@@ -439,12 +474,18 @@ def _apply_tool_entry_to_trace(
     *,
     run_spans: dict[str, Span],
     assistant_cache: OrderedDict[str, AssistantStepCommitted],
+    run_to_tool_calls: dict[str, set[str]] | None = None,
 ) -> bool:
     if isinstance(entry, AssistantStepCommitted) and entry.tool_calls:
         for tc in entry.tool_calls:
             tool_call_id = tc.get("id")
             if tool_call_id:
-                assistant_cache[tool_call_id] = entry
+                _cache_assistant_tool_call(
+                    assistant_cache,
+                    assistant=entry,
+                    tool_call_id=tool_call_id,
+                    run_to_tool_calls=run_to_tool_calls,
+                )
         return True
     if isinstance(entry, ToolStepCommitted):
         trace.add_span(
@@ -485,6 +526,7 @@ def _apply_entry_to_trace(
     llm_started: dict[str, LLMCallStarted],
     assistant_cache: OrderedDict[str, AssistantStepCommitted],
     preview_length: int,
+    run_to_tool_calls: dict[str, set[str]] | None = None,
 ) -> None:
     if _apply_run_entry_to_trace(
         trace,
@@ -506,6 +548,7 @@ def _apply_entry_to_trace(
         entry,
         run_spans=run_spans,
         assistant_cache=assistant_cache,
+        run_to_tool_calls=run_to_tool_calls,
     ):
         return
     _apply_runtime_entry_to_trace(
@@ -528,6 +571,7 @@ class AgentTraceCollector:
         self._assistant_committed_cache: OrderedDict[str, AssistantStepCommitted] = (
             OrderedDict()
         )
+        self._run_to_tool_calls: dict[str, set[str]] = {}
         self._llm_started: dict[str, LLMCallStarted] = {}
 
     @property
@@ -551,6 +595,7 @@ class AgentTraceCollector:
         )
         self._run_spans = {}
         self._assistant_committed_cache = OrderedDict()
+        self._run_to_tool_calls = {}
         self._llm_started = {}
 
     async def stop(self) -> None:
@@ -562,6 +607,7 @@ class AgentTraceCollector:
         self._trace = None
         self._run_spans = {}
         self._assistant_committed_cache = OrderedDict()
+        self._run_to_tool_calls = {}
         self._llm_started = {}
 
     async def on_run_log_entries(self, entries: list[RunLogEntry]) -> None:
@@ -576,9 +622,17 @@ class AgentTraceCollector:
                 llm_started=self._llm_started,
                 assistant_cache=self._assistant_committed_cache,
                 preview_length=self.PREVIEW_LENGTH,
+                run_to_tool_calls=self._run_to_tool_calls,
             )
             while len(self._assistant_committed_cache) > self._CACHE_MAX_SIZE:
-                self._assistant_committed_cache.popitem(last=False)
+                tool_call_id, assistant = self._assistant_committed_cache.popitem(
+                    last=False
+                )
+                _remove_tool_call_index(
+                    self._run_to_tool_calls,
+                    run_id=assistant.run_id,
+                    tool_call_id=tool_call_id,
+                )
             if isinstance(entry, (RunFinished, RunFailedEntry)):
                 self._purge_run_correlation_state(entry.run_id)
         await self._save_trace()
@@ -609,12 +663,7 @@ class AgentTraceCollector:
     def _purge_run_correlation_state(self, run_id: str) -> None:
         self._run_spans.pop(run_id, None)
         self._llm_started.pop(run_id, None)
-        stale_tool_calls = [
-            tool_call_id
-            for tool_call_id, assistant in self._assistant_committed_cache.items()
-            if assistant.run_id == run_id
-        ]
-        for tool_call_id in stale_tool_calls:
+        for tool_call_id in self._run_to_tool_calls.pop(run_id, set()):
             self._assistant_committed_cache.pop(tool_call_id, None)
 
     async def _save_trace(self) -> None:

--- a/agiwo/scheduler/engine.py
+++ b/agiwo/scheduler/engine.py
@@ -41,11 +41,12 @@ from agiwo.scheduler.runtime_facts import SchedulerRuntimeFacts
 from agiwo.scheduler.runtime_state import RuntimeState, list_all_states
 from agiwo.scheduler.runtime_tools import (
     CancelAgentTool,
+    ForkChildAgentTool,
     ListAgentsTool,
     QuerySpawnedAgentTool,
     RetrospectToolResultTool,
     SleepAndWaitTool,
-    SpawnAgentTool,
+    SpawnChildAgentTool,
 )
 from agiwo.scheduler.store import create_agent_state_storage
 from agiwo.scheduler.store.base import AgentStateStorage
@@ -86,7 +87,8 @@ class Scheduler:
             state_list_page_size=self._config.state_list_page_size,
         )
         self._scheduling_tools = (
-            SpawnAgentTool(self._tool_control),
+            SpawnChildAgentTool(self._tool_control),
+            ForkChildAgentTool(self._tool_control),
             SleepAndWaitTool(self._tool_control),
             QuerySpawnedAgentTool(self._tool_control),
             CancelAgentTool(self._tool_control),

--- a/agiwo/scheduler/formatting.py
+++ b/agiwo/scheduler/formatting.py
@@ -239,8 +239,9 @@ def summarize_text(text: str | None, limit: int) -> str | None:
 
 _FORK_NOTICE = _system_notice(
     "You are a forked child agent. Your conversation history has been "
-    "inherited from the parent agent. Do NOT use spawn_agent — it is "
-    "unavailable to you. Complete the following task directly."
+    "inherited from the parent agent. Do NOT use spawn_child_agent or "
+    "fork_child_agent — child agents cannot spawn further child agents. "
+    "Complete the following task directly."
 )
 
 

--- a/agiwo/scheduler/runner.py
+++ b/agiwo/scheduler/runner.py
@@ -48,7 +48,9 @@ from agiwo.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-_CHILD_EXCLUDED_SYSTEM_TOOLS: frozenset[str] = frozenset({"spawn_agent"})
+_CHILD_EXCLUDED_SYSTEM_TOOLS: frozenset[str] = frozenset(
+    {"spawn_child_agent", "fork_child_agent"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,9 +138,9 @@ class SchedulerRunner:
         """Create a child agent for a pending scheduler state.
 
         System tools (scheduler runtime tools) are passed separately from
-        functional/user tools.  ``spawn_agent`` is excluded for non-fork
-        children; fork children inherit ALL system tools for KV cache reuse
-        (the gate check on ``SpawnAgentTool`` still blocks actual spawning).
+        functional/user tools.  Child-spawn runtime tools are excluded for
+        non-fork children; fork children inherit ALL system tools for KV cache
+        reuse and rely on runtime gate checks to block further child spawning.
         """
         parent = self._ctx.rt.agents.get(state.parent_id or "")
         if parent is None:

--- a/agiwo/scheduler/runtime_tools.py
+++ b/agiwo/scheduler/runtime_tools.py
@@ -38,71 +38,36 @@ def _build_failed_result(
     )
 
 
-class SpawnAgentTool(BaseTool):
-    """Spawn a child agent to handle a sub-task."""
+def _parse_optional_string_list(
+    value: object,
+    *,
+    field_name: str,
+) -> list[str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return list(value)
 
-    name = "spawn_agent"
-    description = """Spawn a child agent to handle independent sub-tasks asynchronously.
-Only use for genuine parallel execution or delegation, such as concurrent data fetching and parallel analysis.
-Do not use for simple actions you can do directly.
-The child agent cannot spawn further agents.
-Call sleep_and_wait to wait for completion if needed."""
+
+class _BaseSpawnChildTool(BaseTool):
+    """Shared scheduler child-spawn runtime tool behavior."""
+
+    _fork: bool = False
+    _success_verb = "Spawned"
 
     def __init__(self, port: SchedulerToolControl) -> None:
         self._port = port
         super().__init__()
-
-    def get_parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "task": {
-                    "type": "string",
-                    "description": """Brief, complete task for child agent, including necessary context like background, dependencies, goal and expected outcome. Specify desired outcome, not process.Do not ask it to spawn additional agents.""",
-                },
-                "instruction": {
-                    "type": "string",
-                    "description": "Optional instruction: guide the child agent to finish the task in a more efficient, elegant, and effective way.",
-                },
-                "allowed_skills": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional explicit skill name list the child agent is allowed to use. Must already be expanded and must be a subset of the parent allowed skills. If omitted, inherits the parent skills.",
-                },
-                "fork": {
-                    "type": "boolean",
-                    "description": """If true, child agent inherits parent full conversation history and tool definitions for LLM KV cache reuse. When fork=true, instruction and system_prompt are forbidden to keep the prompt prefix consistent. Child cannot spawn further agents.""",
-                    "default": False,
-                },
-            },
-            "required": ["task"],
-        }
 
     async def gate(
         self,
         parameters: dict[str, Any],
         context: ToolContext,
     ) -> ToolGateDecision:
+        del parameters
         if context.depth > 0:
             return ToolGateDecision.deny("Child agents cannot spawn further agents.")
-
-        fork = bool(parameters.get("fork", False))
-        if fork:
-            conflicting = []
-            if parameters.get("instruction"):
-                conflicting.append("instruction")
-            if parameters.get("system_prompt"):
-                conflicting.append("system_prompt")
-            if parameters.get("allowed_skills"):
-                conflicting.append("allowed_skills")
-
-            if conflicting:
-                return ToolGateDecision.deny(
-                    f"Cannot set {', '.join(conflicting)} when fork=true. "
-                    "These parameters are ignored in fork mode. "
-                    "Set fork=false to use custom configuration."
-                )
-
         return ToolGateDecision.allow()
 
     async def execute(
@@ -124,22 +89,16 @@ Call sleep_and_wait to wait for completion if needed."""
             )
 
         task = parameters.get("task", "")
-        fork = bool(parameters.get("fork", False))
-        instruction = None if fork else parameters.get("instruction")
-        custom_child_id = parameters.get("child_id")
-        system_prompt = None if fork else parameters.get("system_prompt")
-        allowed_skills = None if fork else parameters.get("allowed_skills")
         try:
             state = await self._port.spawn_child(
                 SpawnChildRequest(
                     parent_agent_id=parent_agent_id,
                     session_id=context.session_id,
                     task=task,
-                    instruction=instruction,
-                    system_prompt=system_prompt,
-                    custom_child_id=custom_child_id,
-                    allowed_skills=allowed_skills,
-                    fork=fork,
+                    instruction=self._get_instruction(parameters),
+                    allowed_skills=self._get_allowed_skills(parameters),
+                    allowed_tools=self._get_allowed_tools(parameters),
+                    fork=self._fork,
                 )
             )
         except ValueError as exc:
@@ -155,10 +114,98 @@ Call sleep_and_wait to wait for completion if needed."""
             tool_name=self.name,
             tool_call_id=context.tool_call_id,
             input_args={"task": task, "child_id": state.id},
-            content=f"Spawned child agent '{state.id}' for task: {task}",
+            content=f"{self._success_verb} child agent '{state.id}' for task: {task}",
             output={"child_id": state.id, "status": "pending"},
             start_time=start_time,
         )
+
+    def _get_instruction(self, parameters: dict[str, Any]) -> str | None:
+        del parameters
+        return None
+
+    def _get_allowed_skills(self, parameters: dict[str, Any]) -> list[str] | None:
+        del parameters
+        return None
+
+    def _get_allowed_tools(self, parameters: dict[str, Any]) -> list[str] | None:
+        del parameters
+        return None
+
+
+class SpawnChildAgentTool(_BaseSpawnChildTool):
+    """Spawn a regular child agent to handle an independent sub-task."""
+
+    name = "spawn_child_agent"
+    description = """Spawn a child agent to handle an independent sub-task asynchronously.
+Use this for genuine delegation or parallel work.
+Do not use it for simple actions you can do directly.
+The child agent cannot spawn further child agents.
+Call sleep_and_wait to wait for completion if needed."""
+
+    def get_parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": """Brief, complete task for the child agent, including the goal, required context, and expected outcome. Specify the outcome, not a process script. Do not ask it to spawn additional child agents.""",
+                },
+                "instruction": {
+                    "type": "string",
+                    "description": "Optional instruction that guides how the child agent should approach the task.",
+                },
+                "allowed_tools": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional explicit functional tool list for the child agent. Must be a subset of the parent agent's allowed_tools when the parent is restricted.",
+                },
+                "allowed_skills": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional explicit skill name list for the child agent. Must already be expanded and must be a subset of the parent allowed skills.",
+                },
+            },
+            "required": ["task"],
+        }
+
+    def _get_instruction(self, parameters: dict[str, Any]) -> str | None:
+        instruction = parameters.get("instruction")
+        return instruction if isinstance(instruction, str) else None
+
+    def _get_allowed_skills(self, parameters: dict[str, Any]) -> list[str] | None:
+        return _parse_optional_string_list(
+            parameters.get("allowed_skills"),
+            field_name="allowed_skills",
+        )
+
+    def _get_allowed_tools(self, parameters: dict[str, Any]) -> list[str] | None:
+        return _parse_optional_string_list(
+            parameters.get("allowed_tools"),
+            field_name="allowed_tools",
+        )
+
+
+class ForkChildAgentTool(_BaseSpawnChildTool):
+    """Fork the current agent into a child that inherits parent context."""
+
+    name = "fork_child_agent"
+    description = """Fork the current agent into a child that inherits the parent conversation context.
+Use this only when the child should continue from the same prompt and context prefix.
+The child agent cannot spawn further child agents."""
+    _fork = True
+    _success_verb = "Forked"
+
+    def get_parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Brief task for the forked child agent to complete using the inherited parent context.",
+                },
+            },
+            "required": ["task"],
+        }
 
 
 class SleepAndWaitTool(BaseTool):

--- a/agiwo/tool/builtin/bash_tool/parameter_parser.py
+++ b/agiwo/tool/builtin/bash_tool/parameter_parser.py
@@ -16,7 +16,7 @@ class BashParameterParser:
     """Parses and validates raw tool parameters into typed values."""
 
     @staticmethod
-    def parse_bool(value: Any) -> bool | None:
+    def parse_bool(value: object) -> bool | None:
         if value is None:
             return None
         if isinstance(value, bool):
@@ -61,6 +61,8 @@ class BashParameterParser:
             return None
         if not isinstance(stdin_value, str):
             return ParseError("stdin must be a string")
+        if stdin_value == "":
+            return None
         return stdin_value
 
     def parse_modes(self, parameters: dict[str, Any]) -> tuple[bool, bool] | ParseError:

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -31,40 +31,6 @@ await scheduler.stop()
 
 ## Core Orchestration Methods
 
-### `run()`
-
-```python
-async def run(
-    self,
-    agent: Agent,
-    user_input: UserInput,
-    *,
-    session_id: str | None = None,
-    timeout: float | None = None,
-    abort_signal: AbortSignal | None = None,
-    persistent: bool = False,
-) -> RunOutput
-```
-
-提交 root 并等待结果。
-
-### `submit()`
-
-```python
-async def submit(
-    self,
-    agent: Agent,
-    user_input: UserInput,
-    *,
-    session_id: str | None = None,
-    abort_signal: AbortSignal | None = None,
-    persistent: bool = False,
-    agent_config_id: str | None = None,
-) -> str
-```
-
-立即创建并启动 root，返回 `state_id`。
-
 ### `enqueue_input()`
 
 ```python
@@ -77,7 +43,7 @@ async def enqueue_input(
 ) -> None
 ```
 
-给 persistent root 的下一轮输入赋值。当前只接受 `IDLE` 或 `FAILED` 的 persistent root。
+给 persistent root 的下一轮输入赋值。当前只接受 `IDLE` 或 `FAILED` 的 persistent root；它不是消息队列，也不会并发堆积多条待处理输入。
 
 ### `route_root_input()`
 
@@ -94,34 +60,22 @@ async def route_root_input(
     agent_config_id: str | None = None,
     timeout: float | None = None,
     include_child_events: bool = True,
+    stream_mode: RouteStreamMode = RouteStreamMode.RUN_END,
 ) -> RouteResult
 ```
 
-集成侧高层入口。它会根据当前 root state 自动决定：
+集成侧 canonical 高层入口。它会根据当前 root state 自动决定：
 
 - `submitted`
 - `enqueued`
 - `steered`
 
-### `stream()`
+返回值里的 `RouteResult.stream` 是对应 root 的流式事件迭代器。对同一个 root `state_id`，同时只允许一个活跃 subscriber。
 
-```python
-async def stream(
-    self,
-    user_input: UserInput,
-    *,
-    agent: Agent | None = None,
-    state_id: str | None = None,
-    session_id: str | None = None,
-    abort_signal: AbortSignal | None = None,
-    persistent: bool = False,
-    agent_config_id: str | None = None,
-    timeout: float | None = None,
-    include_child_events: bool = True,
-) -> AsyncIterator[AgentStreamItem]
-```
+`stream_mode` 控制 stream 生命周期：
 
-流式消费 root 执行事件。对同一个 root `state_id`，同时只允许一个活跃 subscriber。
+- `RouteStreamMode.RUN_END`：root 当前这次 run 结束就关闭 stream
+- `RouteStreamMode.UNTIL_SETTLED`：持续到 root 收敛到 `IDLE` / `COMPLETED` / `FAILED`
 
 ### `wait_for()`
 
@@ -193,7 +147,7 @@ async def steer(
 ) -> bool
 ```
 
-对 `RUNNING` root 直接转给 live handle；对 `WAITING/QUEUED` root 会落成 `USER_HINT` event。
+对 `RUNNING` state 直接转给 live handle；否则会把输入记录成 `USER_HINT` event 并唤醒 scheduler loop。
 
 ### `cancel()`
 
@@ -246,6 +200,7 @@ class SchedulerConfig:
     task_limits: TaskLimits = ...
     event_debounce_min_count: int = 3
     event_debounce_max_wait_seconds: float = 10.0
+    state_list_page_size: int = 1000
 ```
 
 `state_storage.storage_type` 当前支持：
@@ -285,6 +240,16 @@ class RouteResult:
     action: Literal["submitted", "enqueued", "steered"]
     state_id: str
     stream: AsyncIterator[AgentStreamItem] | None = None
+```
+
+`route_root_input()` 在所有非 `RUNNING` 路径都会返回非空 `stream`。只有 `steered + RUNNING` 场景下，`stream` 为 `None`，因为原有 live subscriber 会继续消费同一 root 的流。
+
+### `RouteStreamMode`
+
+```python
+class RouteStreamMode(str, Enum):
+    RUN_END = "run_end"
+    UNTIL_SETTLED = "until_settled"
 ```
 
 ### `DispatchAction`

--- a/docs/architecture/scheduler-console-runtime-refactor.md
+++ b/docs/architecture/scheduler-console-runtime-refactor.md
@@ -74,7 +74,7 @@ flowchart TD
 
 ### 2. Child tool 语义与 root 不对称
 
-当前 child 派生时只排除了 `spawn_agent`，其他工具基本沿用 parent，并且 default builtin tools 还会被 SDK 的 tool assembly 自动补回。
+当前 child 派生时只排除了 child-spawn runtime tools，其他工具基本沿用 parent，并且 default builtin tools 还会被 SDK 的 tool assembly 自动补回。
 
 结果：
 
@@ -124,7 +124,7 @@ flowchart TD
 重构后建议满足以下目标：
 
 1. root runtime 保留原工具，并追加 scheduler tools
-2. child runtime 继承父能力，但明确禁止 `spawn_agent`
+2. child runtime 继承父能力，但明确禁止继续 child-spawn
 3. root runtime 和 child runtime 使用两条显式、独立的派生路径
 4. Console 侧只有一个统一的 Agent materialization 入口
 5. Web / Feishu / API 统一走同一套 session execution flow
@@ -153,7 +153,7 @@ flowchart TD
     RUN --> CTRL["SchedulerToolControl"]
     CTRL --> STATE["AgentState / PendingEvent"]
     STATE --> TICK["tick / dispatch"]
-    TICK --> CHILD["Prepare Child Runtime<br/>继承父工具 - spawn_agent"]
+    TICK --> CHILD["Prepare Child Runtime<br/>继承父工具 - child spawn tools"]
     CHILD --> RUN
 ```
 
@@ -221,7 +221,7 @@ flowchart TD
 期望效果：
 
 - root 仍然可以正常使用 `bash`、`bash_process`、`web_search`、`web_reader`、`memory_retrieval`
-- 同时获得 `spawn_agent`、`sleep_and_wait`、`query_spawned_agent`、`cancel_agent`、`list_agents`
+- 同时获得 `spawn_child_agent`、`fork_child_agent`、`sleep_and_wait`、`query_spawned_agent`、`cancel_agent`、`list_agents`
 
 #### 2. Child runtime preparation
 
@@ -233,7 +233,7 @@ flowchart TD
 规则：
 
 - 继承 parent 的正常执行能力
-- 明确移除 `spawn_agent`
+- 明确移除 `spawn_child_agent` / `fork_child_agent`
 - 保留其他 scheduler tools
 - child runtime 的“不可再派生”约束要在这里显式表达，而不是靠 incidental side effect
 
@@ -241,7 +241,7 @@ flowchart TD
 
 - child 可以执行真正的工作
 - child 可以 `sleep_and_wait`、查询 sibling/self state、取消自身可见 subtree
-- child 不能无限继续 `spawn_agent`
+- child 不能无限继续派生 child agent
 
 ### D. 统一 Console 的 session execution 入口
 
@@ -293,7 +293,7 @@ SessionExecutionService.execute(session_id, user_input)
 结果：
 
 - root: 原工具 + scheduler tools
-- child: 继承父工具，但无 `spawn_agent`
+- child: 继承父工具，但无 `spawn_child_agent` / `fork_child_agent`
 
 ### Phase 2. 收口 Console materialization
 
@@ -339,7 +339,7 @@ SessionExecutionService.execute(session_id, user_input)
 完成后，应满足以下可验证结果：
 
 1. Console session chat 下，root agent 可见原配置工具与 scheduler tools
-2. child agent 不可调用 `spawn_agent`
+2. child agent 不可调用 `spawn_child_agent` / `fork_child_agent`
 3. child agent 仍可使用其他允许的 builtin tools
 4. Web / Feishu 使用统一的 canonical Agent materialization 路径
 5. Scheduler 内部不再通过 child-style 逻辑准备 root runtime

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -119,7 +119,7 @@ Agiwo assembles tools through `ToolManager`:
 - `SkillTool` when skills are enabled
 - scheduler runtime tools when the agent is executed under `Scheduler`
 
-Scheduler tools such as `spawn_agent` and `sleep_and_wait` are runtime-owned system tools. They are not registered manually on the agent.
+Scheduler tools such as `spawn_child_agent`, `fork_child_agent`, and `sleep_and_wait` are runtime-owned system tools. They are not registered manually on the agent.
 
 ## Agent-As-Tool
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -32,7 +32,7 @@ Agent(
     *,
     model: Model,
     tools: list[BaseTool] | None = None,
-    hooks: AgentHooks | None = None,
+    hooks: HookRegistry | list[HookRegistration] | None = None,
     id: str | None = None,
 )
 ```
@@ -149,7 +149,7 @@ from agiwo.agent import (
     AgentConfig,
     AgentOptions,
     AgentStorageOptions,
-    RunStepStorageConfig,
+    RunLogStorageConfig,
     TraceStorageConfig,
 )
 
@@ -157,7 +157,7 @@ config = AgentConfig(
     name="assistant",
     options=AgentOptions(
         storage=AgentStorageOptions(
-            run_step_storage=RunStepStorageConfig(
+            run_log_storage=RunLogStorageConfig(
                 storage_type="sqlite",
                 config={"db_path": "runs.db"},
             ),

--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -189,7 +189,8 @@ flowchart TD
 
 | Tool | Purpose |
 | --- | --- |
-| `spawn_agent` | 派生 child agent |
+| `spawn_child_agent` | 派生一个新的 child agent |
+| `fork_child_agent` | fork 当前 agent 为继承上下文的 child |
 | `sleep_and_wait` | 让当前 agent 进入 `WAITING` |
 | `query_spawned_agent` | 查看 child state |
 | `cancel_agent` | 取消 child subtree |

--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -15,7 +15,7 @@
 ```mermaid
 flowchart LR
     Caller["Caller / Console"] --> Facade["Scheduler"]
-    Facade --> Engine["SchedulerEngine"]
+    Facade --> Engine["Engine Helpers"]
     Engine --> Store["AgentState + PendingEvent"]
     Engine --> Runtime["RuntimeState"]
     Engine --> Runner["SchedulerRunner"]
@@ -25,7 +25,7 @@ flowchart LR
 可以把 scheduler 看成两层：
 
 - 持久化层：`AgentState` + `PendingEvent`
-- 执行层：`SchedulerEngine` 决定谁该跑，`SchedulerRunner` 负责把一轮 run 跑完
+- 执行层：engine helpers 决定谁该跑，`SchedulerRunner` 负责把一轮 run 跑完
 
 ## Quick Start
 
@@ -48,7 +48,12 @@ async def main() -> None:
     )
 
     async with Scheduler() as scheduler:
-        result = await scheduler.run(agent, "Research two approaches and compare them.")
+        route = await scheduler.route_root_input(
+            "Research two approaches and compare them.",
+            agent=agent,
+            persistent=False,
+        )
+        result = await scheduler.wait_for(route.state_id)
         print(result.response)
 
 
@@ -60,14 +65,23 @@ asyncio.run(main())
 ### One-shot root
 
 ```python
-result = await scheduler.run(agent, "Do something complex")
+route = await scheduler.route_root_input(
+    "Do something complex",
+    agent=agent,
+    persistent=False,
+)
+result = await scheduler.wait_for(route.state_id)
 ```
 
-### Submit and wait later
+### Route and wait later
 
 ```python
-state_id = await scheduler.submit(agent, "Background work")
-result = await scheduler.wait_for(state_id, timeout=30)
+route = await scheduler.route_root_input(
+    "Background work",
+    agent=agent,
+    persistent=False,
+)
+result = await scheduler.wait_for(route.state_id, timeout=30)
 ```
 
 ### Persistent root
@@ -75,7 +89,12 @@ result = await scheduler.wait_for(state_id, timeout=30)
 `enqueue_input()` 只接受 `IDLE` 或 `FAILED` 的 persistent root，不是消息队列。
 
 ```python
-state_id = await scheduler.submit(agent, "First message", persistent=True)
+route = await scheduler.route_root_input(
+    "First message",
+    agent=agent,
+    persistent=True,
+)
+state_id = route.state_id
 await scheduler.wait_for(state_id)
 
 await scheduler.enqueue_input(state_id, "Second message")
@@ -84,7 +103,7 @@ await scheduler.wait_for(state_id)
 
 ### Route root input from an integration
 
-`route_root_input()` 是 Console/Channel 集成用的高层入口。它会根据当前 root state 自动决定 `submit` / `enqueue_input` / `steer`。
+`route_root_input()` 是 Console/Channel 集成用的高层入口。它会根据当前 root state 自动决定返回 `submitted` / `enqueued` / `steered`。
 
 ```python
 result = await scheduler.route_root_input(
@@ -100,7 +119,14 @@ print(result.state_id)
 ### Stream output
 
 ```python
-async for item in scheduler.stream("Write a summary", agent=agent):
+route = await scheduler.route_root_input(
+    "Write a summary",
+    agent=agent,
+    persistent=False,
+)
+assert route.stream is not None
+
+async for item in route.stream:
     if item.type == "step_delta" and item.delta.content:
         print(item.delta.content, end="", flush=True)
 ```
@@ -121,7 +147,7 @@ async for item in scheduler.stream("Write a summary", agent=agent):
 
 ```mermaid
 stateDiagram-v2
-    [*] --> RUNNING: submit(root)
+    [*] --> RUNNING: route_root_input(submitted)
     RUNNING --> WAITING: sleep_and_wait(...)
     RUNNING --> IDLE: persistent root finished
     IDLE --> QUEUED: enqueue_input(...)
@@ -140,13 +166,13 @@ stateDiagram-v2
 
 ## Tick Model
 
-后台 loop 会周期性调用 `engine.tick()`，但 `submit()` 是直接启动，不等 tick。
+后台 loop 会周期性调用 `tick()`；初次 root submit 会直接 dispatch，而 `QUEUED` / `WAITING` 的后续推进由 tick 驱动。
 
 ```mermaid
 flowchart TD
-    Loop["Scheduler._loop()"] --> Tick["engine.tick()"]
+    Loop["Scheduler._loop()"] --> Tick["tick()"]
     Tick --> Plan["plan DispatchAction"]
-    Plan --> Dispatch["runner.run(action)"]
+    Plan --> Dispatch["dispatch_action(...) / runner"]
     Dispatch --> Loop
 ```
 
@@ -168,6 +194,7 @@ flowchart TD
 | `query_spawned_agent` | 查看 child state |
 | `cancel_agent` | 取消 child subtree |
 | `list_agents` | 列出直接 child |
+| `retrospect_tool_result` | 对最近一次工具结果写回 retrospect 反馈 |
 
 这些 tools 由 `Scheduler` 自动注入，不需要手动注册。
 
@@ -192,7 +219,7 @@ RuntimeState(
 
 1. `route_root_input()` 决定 root 输入怎么进入系统
 2. `tick()` 决定哪些 state 该被 dispatch
-3. `runner.run()` 执行一次 dispatch action，并把结果翻译回 state
+3. dispatch path 执行一次 action，并把结果翻译回 state
 
 ## Console and Feishu Integration
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -1,174 +1,290 @@
 # Hooks
 
-Hooks let you observe and intercept agent lifecycle events. They're optional callbacks organized in a dataclass.
+Hooks are registered through the phase-based `HookRegistry`. The old
+single-slot `AgentHooks` dataclass is no longer part of the public API.
 
-## Hook Types
+## Quick Start
 
 ```python
-from agiwo.agent import AgentHooks
-
-hooks = AgentHooks(
-    on_before_run=my_before_run_hook,
-    on_after_run=my_after_run_hook,
-    on_before_tool_call=my_before_tool_call_hook,
-    on_after_tool_call=my_after_tool_call_hook,
-    on_before_llm_call=my_before_llm_call_hook,
-    on_after_llm_call=my_after_llm_call_hook,
-    on_step=my_on_step_hook,
-    on_memory_write=my_memory_write_hook,
-    on_memory_retrieve=my_memory_retrieve_hook,
-    on_compaction_failed=my_compaction_failed_hook,
+from agiwo.agent import (
+    Agent,
+    AgentConfig,
+    HookPhase,
+    HookRegistry,
+    observe,
+    transform,
 )
-```
 
-## Available Hooks
 
-### Run Lifecycle
+async def add_prelude(payload: dict) -> dict:
+    updated = dict(payload)
+    updated["prelude_text"] = "Please be concise."
+    return updated
 
-```python
-async def on_before_run(user_input, context) -> str | None:
-    """Called before a run starts."""
-    print(f"Run {context.run_id} starting")
-    return None
 
-async def on_after_run(result, context) -> None:
-    """Called after a run completes."""
-    preview = (result.response or "")[:100]
-    print(f"Run {context.run_id} ended: {preview}")
-```
+async def log_step(payload: dict) -> None:
+    step = payload["step"]
+    print(f"{step.role.value} step committed: {step.sequence}")
 
-### Tool Execution
 
-```python
-async def on_before_tool_call(tool_call_id, tool_name, parameters) -> dict | None:
-    """Called before a tool executes."""
-    print(f"Tool {tool_name} starting with {parameters}")
-    return None
+hooks = HookRegistry(
+    [
+        transform(HookPhase.PREPARE, "add_prelude", add_prelude),
+        observe(HookPhase.AFTER_STEP_COMMIT, "log_step", log_step),
+    ]
+)
 
-async def on_after_tool_call(tool_call_id, tool_name, parameters, result) -> None:
-    """Called after a tool completes."""
-    print(f"Tool {result.tool_name} finished in {result.duration:.2f}s")
-```
-
-### LLM Calls
-
-```python
-async def on_before_llm_call(messages) -> list[dict] | None:
-    """Called before an LLM request."""
-    print(f"LLM call with {len(messages)} messages")
-    return None
-
-async def on_after_llm_call(step) -> None:
-    """Called after an assistant step is committed."""
-    print(f"Assistant step finished: {step.id}")
-```
-
-### Steps
-
-```python
-async def on_step(step) -> None:
-    """Called when any step (user/assistant/tool) is committed."""
-    print(f"Committed {step.role.value} step {step.sequence}")
-```
-
-### Memory
-
-```python
-async def on_memory_write(user_input, result, context) -> None:
-    """Called after a successful run to persist external memory."""
-    print(f"Persisting memory for run {context.run_id}")
-
-async def on_memory_retrieve(user_input, context) -> list[MemoryRecord]:
-    """Called before execution to fetch memories.
-    Return a list of MemoryRecord objects, or empty list."""
-    from agiwo.agent.models.run import MemoryRecord
-    print(f"Retrieving memories for run {context.run_id}")
-    return []
-```
-
-### Compaction Failure
-
-```python
-async def on_compaction_failed(error, context) -> None:
-    """Called when context compaction fails."""
-    print(f"Compaction failed: {error}")
-```
-
-## Using Hooks
-
-Pass hooks when creating an Agent:
-
-```python
 agent = Agent(
-    AgentConfig(name="assistant", description="...", system_prompt="..."),
+    AgentConfig(name="assistant", description="..."),
     model=model,
-    hooks=my_hooks,
+    hooks=hooks,
 )
 ```
 
-Or update hooks after creation:
+## Core Types
 
 ```python
-agent.hooks = new_hooks
+from agiwo.agent import (
+    HookCapability,
+    HookGroup,
+    HookPhase,
+    HookRegistration,
+    HookRegistry,
+    decision_support,
+    observe,
+    transform,
+)
 ```
 
-## Use Cases
+- `HookPhase`: lifecycle phase enum
+- `HookCapability`: `observe_only`, `transform`, `decision_support`
+- `HookGroup`: execution group ordering (`system`, `runtime_adapter`, `user`)
+- `HookRegistration`: one registered phase handler
+- `HookRegistry`: ordered collection of registrations
 
-### Logging and Tracing
+## Ordering And Failure Rules
+
+- Execution order is `group -> order -> registration order`.
+- Only early phases may be marked `critical=True`:
+  - `prepare`
+  - `assemble_context`
+  - `before_llm`
+  - `before_tool_call`
+- Non-critical hook failures are isolated, logged, and recorded as `HookFailed`
+  run-log facts.
+- Critical hook failures are re-raised and fail the run.
+
+## Public Phases
 
 ```python
-async def tracing_on_after_tool_call(tool_call_id, tool_name, parameters, result):
-    logger.info(
-        "tool_executed",
-        tool_call_id=tool_call_id,
-        tool=tool_name,
-        parameters=parameters,
-        duration=result.duration,
-        success=result.is_success,
+from agiwo.agent import HookPhase
+
+HookPhase.PREPARE
+HookPhase.ASSEMBLE_CONTEXT
+HookPhase.BEFORE_LLM
+HookPhase.AFTER_LLM
+HookPhase.BEFORE_TOOL_CALL
+HookPhase.AFTER_TOOL_CALL
+HookPhase.BEFORE_COMPACTION
+HookPhase.AFTER_COMPACTION
+HookPhase.BEFORE_RETROSPECT
+HookPhase.AFTER_RETROSPECT
+HookPhase.BEFORE_TERMINATION
+HookPhase.AFTER_TERMINATION
+HookPhase.AFTER_STEP_COMMIT
+HookPhase.RUN_FINALIZED
+HookPhase.MEMORY_PERSIST
+HookPhase.COMPACTION_FAILED
+```
+
+## Payload Contracts
+
+Handlers always receive a single `payload: dict[str, Any]`.
+
+### Transform Phases
+
+These phases may return a partial dict that only changes allowlisted fields.
+
+#### `prepare`
+
+Input payload:
+
+```python
+{
+    "user_input": user_input,
+    "context": context,
+    "prelude_text": None,
+}
+```
+
+Allowlisted output fields:
+
+```python
+{"prelude_text": "Please answer in Chinese."}
+```
+
+#### `assemble_context`
+
+Input payload:
+
+```python
+{
+    "user_input": user_input,
+    "context": context,
+    "memories": [],
+    "context_additions": [],
+}
+```
+
+Allowlisted output fields:
+
+```python
+{"memories": memories, "context_additions": []}
+```
+
+#### `before_llm`
+
+Input payload:
+
+```python
+{
+    "messages": messages,
+    "context": context,
+    "model_settings_override": None,
+    "llm_advice": None,
+}
+```
+
+Allowlisted transform fields:
+
+```python
+{"messages": updated_messages, "model_settings_override": None}
+```
+
+#### `before_tool_call`
+
+Input payload:
+
+```python
+{
+    "tool_call_id": tool_call_id,
+    "tool_name": tool_name,
+    "parameters": parameters,
+    "context": context,
+    "tool_advice": None,
+}
+```
+
+Allowlisted transform fields:
+
+```python
+{"parameters": updated_parameters}
+```
+
+### Decision-Support Phases
+
+Decision-support handlers also return partial dicts, but may only write the
+phase-specific `*_advice` field:
+
+- `before_llm`: `llm_advice`
+- `before_tool_call`: `tool_advice`
+- `before_compaction`: `compaction_advice`
+- `before_retrospect`: `retrospect_advice`
+- `before_termination`: `termination_advice`
+
+### Observe-Only Phases
+
+These phases should return nothing useful; results are ignored.
+
+- `after_llm`
+- `after_tool_call`
+- `after_compaction`
+- `after_retrospect`
+- `after_termination`
+- `after_step_commit`
+- `run_finalized`
+- `memory_persist`
+- `compaction_failed`
+
+## Examples
+
+### Rewrite Messages Before LLM
+
+```python
+from agiwo.agent import HookPhase, HookRegistry, transform
+
+
+async def prepend_notice(payload: dict) -> dict:
+    updated = dict(payload)
+    messages = list(payload["messages"])
+    messages.append({"role": "user", "content": "Double-check file paths."})
+    updated["messages"] = messages
+    return updated
+
+
+hooks = HookRegistry(
+    [transform(HookPhase.BEFORE_LLM, "prepend_notice", prepend_notice)]
+)
+```
+
+### Observe Each Tool Call
+
+```python
+from agiwo.agent import HookPhase, HookRegistry, observe
+
+
+async def log_tool_call(payload: dict) -> None:
+    print(
+        payload["tool_call_id"],
+        payload["tool_name"],
+        payload["parameters"],
     )
+
+
+hooks = HookRegistry(
+    [observe(HookPhase.BEFORE_TOOL_CALL, "log_tool_call", log_tool_call)]
+)
 ```
 
-### Cost Tracking
+### Track Committed Steps
 
 ```python
-total_tokens = 0
+from agiwo.agent import HookPhase, HookRegistry, observe
 
-async def cost_on_after_llm(step):
-    global total_tokens
-    if step.metrics and step.metrics.total_tokens:
-        total_tokens += step.metrics.total_tokens
-        print(f"Total tokens so far: {total_tokens}")
+
+async def log_step(payload: dict) -> None:
+    step = payload["step"]
+    print(step.role.value, step.sequence, step.id)
+
+
+hooks = HookRegistry(
+    [observe(HookPhase.AFTER_STEP_COMMIT, "log_step", log_step)]
+)
 ```
 
-### Rate Limiting
+### Persist External Memory
 
 ```python
-import asyncio
-import time
+from agiwo.agent import HookPhase, HookRegistry, observe
 
-last_call = 0
 
-async def rate_limit_on_before_llm(messages):
-    global last_call
-    elapsed = time.time() - last_call
-    if elapsed < 1.0:
-        await asyncio.sleep(1.0 - elapsed)
-    last_call = time.time()
-```
+async def write_external_memory(payload: dict) -> None:
+    user_input = payload["user_input"]
+    result = payload["result"]
+    context = payload["context"]
+    print(context.run_id, user_input, result.response)
 
-### Debugging
 
-```python
-async def debug_on_step(step):
-    print(f"=== Step {step.sequence} ({step.role.value}) ===")
-    print(f"Content: {step.content}")
-    print(f"Tool calls: {step.tool_calls}")
-    print()
+hooks = HookRegistry(
+    [observe(HookPhase.MEMORY_PERSIST, "write_external_memory", write_external_memory)]
+)
 ```
 
 ## Notes
 
-- All hooks are async functions
-- Each lifecycle point has a single callback slot on `AgentHooks`
-- Hook exceptions propagate and will fail the run unless you handle them yourself
-- Hook context provides run_id, session_id, agent_id, and other runtime metadata
+- Prefer `observe(...)`, `transform(...)`, and `decision_support(...)` over
+  constructing `HookRegistration` directly.
+- If a transform hook returns fields outside the phase allowlist, registration
+  succeeds but dispatch fails with a validation error when the hook runs.
+- `context` is included in runtime payloads so hooks can inspect run/session
+  metadata without importing agent internals directly.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -17,9 +17,7 @@ from agiwo.agent import (
 
 
 async def add_prelude(payload: dict) -> dict:
-    updated = dict(payload)
-    updated["prelude_text"] = "Please be concise."
-    return updated
+    return {"prelude_text": "Please be concise."}
 
 
 async def log_step(payload: dict) -> None:
@@ -215,11 +213,9 @@ from agiwo.agent import HookPhase, HookRegistry, transform
 
 
 async def prepend_notice(payload: dict) -> dict:
-    updated = dict(payload)
     messages = list(payload["messages"])
     messages.append({"role": "user", "content": "Double-check file paths."})
-    updated["messages"] = messages
-    return updated
+    return {"messages": messages}
 
 
 hooks = HookRegistry(

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -94,7 +94,8 @@ Agents running under the scheduler automatically get orchestration tools:
 # Inside an agent's system prompt:
 """
 You can use these tools to coordinate work:
-- spawn_agent: Create a child agent for a sub-task
+- spawn_child_agent: Create a fresh child agent for a sub-task
+- fork_child_agent: Fork the current agent into a child that inherits context
 - query_spawned_agent: Check on a child's progress
 - cancel_agent: Stop a child that's no longer needed
 - list_agents: See all active children
@@ -180,7 +181,7 @@ async with Scheduler() as scheduler:
     )
     supervisor_id = route.state_id
 
-    # The supervisor uses spawn_agent internally to create workers
+    # The supervisor uses spawn_child_agent / fork_child_agent internally to create workers
     # External input can steer the supervisor
     await scheduler.enqueue_input(supervisor_id, "Priority: process batch 42 first")
 ```

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -50,15 +50,16 @@ The supported public composition API is `Agent.as_tool()`. If you need child age
 For long-running, persistent multi-agent setups, use the Scheduler:
 
 ```python
-from agiwo.scheduler import Scheduler, SchedulerConfig
+from agiwo.scheduler import Scheduler
 
 async with Scheduler() as scheduler:
-    # Submit a persistent orchestrator
-    orchestrator_id = await scheduler.submit(
-        orchestrator,
+    # Create a persistent root via the canonical routing entrypoint
+    route = await scheduler.route_root_input(
         "Coordinate the research pipeline",
+        agent=orchestrator,
         persistent=True,  # Stays alive after completion
     )
+    orchestrator_id = route.state_id
 
     # Wait until the first round settles to IDLE
     await scheduler.wait_for(orchestrator_id)
@@ -66,11 +67,15 @@ async with Scheduler() as scheduler:
     # Feed more input later
     await scheduler.enqueue_input(orchestrator_id, "Now analyze the cost implications")
 
-    # Stream events
-    async for event in scheduler.stream(
+    # Open a fresh stream for the next routed turn
+    route = await scheduler.route_root_input(
         "Update the analysis",
+        agent=orchestrator,
         state_id=orchestrator_id,
-    ):
+    )
+    assert route.stream is not None
+
+    async for event in route.stream:
         if event.type == "step_delta" and event.delta.content:
             print(event.delta.content, end="", flush=True)
 
@@ -94,6 +99,7 @@ You can use these tools to coordinate work:
 - cancel_agent: Stop a child that's no longer needed
 - list_agents: See all active children
 - sleep_and_wait: Wait for a condition before continuing
+- retrospect_tool_result: Rewrite the latest tool result with structured feedback
 """
 ```
 
@@ -106,19 +112,28 @@ Chain agents sequentially:
 ```python
 async with Scheduler() as scheduler:
     # Step 1: Research
-    research_result = await scheduler.run(researcher, "Gather facts about X")
+    research_route = await scheduler.route_root_input(
+        "Gather facts about X",
+        agent=researcher,
+        persistent=False,
+    )
+    research_result = await scheduler.wait_for(research_route.state_id)
 
     # Step 2: Analyze using research output
-    analysis_result = await scheduler.run(
-        analyzer,
+    analysis_route = await scheduler.route_root_input(
         f"Analyze these findings: {research_result.response}",
+        agent=analyzer,
+        persistent=False,
     )
+    analysis_result = await scheduler.wait_for(analysis_route.state_id)
 
     # Step 3: Write report
-    report = await scheduler.run(
-        writer,
+    report_route = await scheduler.route_root_input(
         f"Write a report based on: {analysis_result.response}",
+        agent=writer,
+        persistent=False,
     )
+    report = await scheduler.wait_for(report_route.state_id)
 ```
 
 ### Fan-out / Fan-in
@@ -130,8 +145,12 @@ async with Scheduler() as scheduler:
     # Fan out
     ids = []
     for topic in ["topic_a", "topic_b", "topic_c"]:
-        state_id = await scheduler.submit(researcher, f"Research {topic}")
-        ids.append(state_id)
+        route = await scheduler.route_root_input(
+            f"Research {topic}",
+            agent=researcher,
+            persistent=False,
+        )
+        ids.append(route.state_id)
 
     # Fan in
     results = []
@@ -140,10 +159,12 @@ async with Scheduler() as scheduler:
         results.append(result.response)
 
     # Synthesize
-    final = await scheduler.run(
-        synthesizer,
+    final_route = await scheduler.route_root_input(
         f"Synthesize these findings: {results}",
+        agent=synthesizer,
+        persistent=False,
     )
+    final = await scheduler.wait_for(final_route.state_id)
 ```
 
 ### Supervisor Pattern
@@ -152,11 +173,12 @@ A persistent supervisor coordinates transient workers:
 
 ```python
 async with Scheduler() as scheduler:
-    supervisor_id = await scheduler.submit(
-        supervisor_agent,
+    route = await scheduler.route_root_input(
         "Manage the data processing pipeline",
+        agent=supervisor_agent,
         persistent=True,
     )
+    supervisor_id = route.state_id
 
     # The supervisor uses spawn_agent internally to create workers
     # External input can steer the supervisor

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -1,36 +1,41 @@
 # Storage & Observability
 
-Agiwo separates storage into two independent concerns: run/step persistence and trace collection.
+Agiwo separates storage into two independent concerns: run-log persistence and
+trace collection.
 
 ## Storage Layers
 
 | Layer | Purpose | Interface |
 |-------|---------|-----------|
-| Run/Step Storage | Persist agent run and step records | `RunStepStorage` |
-| Trace Storage | Distributed traces for observability | `BaseTraceStorage` |
+| Run Log Storage | Persist canonical runtime facts and replayable views | `RunLogStorage` |
+| Trace Storage | Persist trace snapshots built from committed run-log facts | `BaseTraceStorage` |
 
-## Run/Step Storage
+## Run Log Storage
 
-Records every agent execution with full step details:
+Records canonical runtime facts as append-only `RunLog` entries:
 
 ```python
-from agiwo.agent import RunStepStorageConfig
-from agiwo.agent.storage.factory import create_run_step_storage
+from agiwo.agent import RunLogStorageConfig
+from agiwo.agent.storage.factory import create_run_log_storage
 
 # SQLite backend
-storage = create_run_step_storage(
-    RunStepStorageConfig(storage_type="sqlite", config={"db_path": "runs.db"})
+storage = create_run_log_storage(
+    RunLogStorageConfig(storage_type="sqlite", config={"db_path": "runs.db"})
 )
 
 # Memory backend (for testing)
-storage = create_run_step_storage(RunStepStorageConfig(storage_type="memory"))
+storage = create_run_log_storage(RunLogStorageConfig(storage_type="memory"))
 ```
 
 ### What gets stored
 
-- **Run records**: input, output, timestamps, token usage, status
-- **Step records**: LLM messages, tool calls, tool results, intermediate reasoning
-- **Cost tracking**: per-step and per-run token counts and estimated costs
+- **Run facts**: `RunStarted`, `RunFinished`, `RunFailed`, `TerminationDecided`
+- **LLM facts**: `LLMCallStarted`, `LLMCallCompleted`
+- **Committed step facts**: user, assistant, and tool step commits
+- **Runtime decisions**: compaction, retrospect, rollback, hook failures
+
+Replay/query helpers such as `list_step_views(...)`, `list_run_views(...)`, and
+`get_runtime_decision_state(...)` are rebuilt from the stored `RunLog`.
 
 ## Session Storage
 
@@ -38,7 +43,7 @@ The SDK does not expose a standalone session storage abstraction. Session lifecy
 
 ## Trace Storage
 
-Collects distributed traces for debugging and monitoring:
+Collects trace snapshots for debugging and monitoring:
 
 ```python
 from agiwo.agent import TraceStorageConfig
@@ -85,7 +90,7 @@ agent = Agent(
 ### Trace Structure
 
 ```
-Trace (one per run)
+Trace (one per session/runtime trace id)
 ├── Span: Agent Execution
 │   ├── Span: LLM Call (with token usage)
 │   ├── Span: Tool Execution (with duration)
@@ -119,12 +124,12 @@ traces = await trace_storage.query_traces(
 Storage constructors are config-driven:
 
 ```python
-from agiwo.agent import RunStepStorageConfig, TraceStorageConfig
-from agiwo.agent.storage.factory import create_run_step_storage
+from agiwo.agent import RunLogStorageConfig, TraceStorageConfig
+from agiwo.agent.storage.factory import create_run_log_storage
 from agiwo.observability import create_trace_storage
 
-run_step_storage = create_run_step_storage(
-    RunStepStorageConfig(
+run_log_storage = create_run_log_storage(
+    RunLogStorageConfig(
         storage_type="sqlite",
         config={"db_path": "./data/runs.db"},
     )
@@ -137,6 +142,34 @@ trace_storage = create_trace_storage(
             "db_path": "./data/traces.db",
         },
     )
+)
+```
+
+Or configure storage through `AgentOptions.storage`:
+
+```python
+from agiwo.agent import (
+    AgentConfig,
+    AgentOptions,
+    AgentStorageOptions,
+    RunLogStorageConfig,
+    TraceStorageConfig,
+)
+
+config = AgentConfig(
+    name="assistant",
+    options=AgentOptions(
+        storage=AgentStorageOptions(
+            run_log_storage=RunLogStorageConfig(
+                storage_type="sqlite",
+                config={"db_path": "./data/runs.db"},
+            ),
+            trace_storage=TraceStorageConfig(
+                storage_type="sqlite",
+                config={"db_path": "./data/traces.db"},
+            ),
+        )
+    ),
 )
 ```
 
@@ -157,5 +190,5 @@ model = OpenAIModel(
 # After run:
 result = await agent.run("Hello")
 print(result.metrics)  # Token counts and cost
-# Cost is recorded in run/step storage
+# Cost is reflected in committed step/run facts
 ```

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -1,6 +1,6 @@
 # Streaming
 
-Agiwo is streaming-first. All LLM responses flow through the same streaming pipeline, whether you use `run()`, `run_stream()`, or `start()`.
+Agiwo is streaming-first. All LLM responses flow through the same streaming pipeline, whether you use `run()`, `run_stream()`, `start()`, or scheduler `route_root_input()`.
 
 ## Streaming with `run_stream()`
 
@@ -20,7 +20,13 @@ async for event in agent.run_stream("Tell me about Python"):
 |------------|---------|
 | `run_started` | run/session metadata |
 | `step_delta` | incremental assistant deltas via `event.delta` |
-| `step_completed` | committed `StepRecord` via `event.step` |
+| `step_completed` | committed `StepView` via `event.step` |
+| `messages_rebuilt` | rebuilt prompt messages after runtime mutation |
+| `compaction_applied` | committed compaction summary + transcript range |
+| `compaction_failed` | committed compaction failure fact |
+| `retrospect_applied` | committed retrospect rewrite fact |
+| `termination_decided` | committed termination decision fact |
+| `run_rolled_back` | committed rollback range |
 | `run_completed` | final response, metrics, termination reason |
 | `run_failed` | final error |
 
@@ -46,11 +52,19 @@ result = await handle.wait()
 
 ## Scheduler Streaming
 
-The Scheduler exposes the same streaming interface:
+The Scheduler reuses the same stream protocol, but the public entrypoint is
+`route_root_input()`. Consume `RouteResult.stream`:
 
 ```python
 async with Scheduler() as scheduler:
-    async for event in scheduler.stream("Research topic X", agent=agent):
+    route = await scheduler.route_root_input(
+        "Research topic X",
+        agent=agent,
+        persistent=False,
+    )
+    assert route.stream is not None
+
+    async for event in route.stream:
         if event.type == "step_delta" and event.delta.content:
             print(event.delta.content, end="", flush=True)
 ```
@@ -58,12 +72,20 @@ async with Scheduler() as scheduler:
 For an existing agent state:
 
 ```python
-async for event in scheduler.stream(
+route = await scheduler.route_root_input(
     "Continue the analysis",
+    agent=agent,
     state_id=existing_state_id,
-):
+)
+assert route.stream is not None
+
+async for event in route.stream:
     process(event)
 ```
+
+Only one live stream subscriber is allowed per root `state_id`. If you steer a
+currently `RUNNING` root, `RouteResult.stream` is `None` because the existing
+subscriber continues consuming that root's stream.
 
 ## Stream Consumption
 
@@ -91,4 +113,4 @@ Agent.run_stream()
                            └─► AgentStreamItem (normalized)
 ```
 
-All execution paths — `run()`, `run_stream()`, Scheduler — share this pipeline. The difference is only in how the consumer processes events.
+All execution paths — `run()`, `run_stream()`, `start()`, and scheduler `route_root_input()` — share this pipeline. The difference is only in how the consumer processes events.

--- a/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
+++ b/docs/superpowers/plans/2026-04-23-agent-runtime-final-convergence.md
@@ -35,7 +35,7 @@
 - `tests/agent/test_compact.py`
   Cover canonical compaction LLM facts.
 - `tests/agent/test_termination.py`
-  Cover canonical termination-summary LLM facts.
+  Summarize canonical termination-summary LLM behavior.
 - `tests/observability/test_collector.py`
   Switch fully to committed-entry trace construction and assert bounded cache / persistence behavior.
 - `tests/agent/test_run_log_replay_parity.py`
@@ -228,7 +228,9 @@ async def test_run_state_writer_owns_bootstrap_state_mutations() -> None:
     state = _make_state()
     writer = RunStateWriter(state)
 
-    await writer.record_bootstrap_state(
+    await writer.record_context_assembled(
+        messages=[{"role": "system", "content": "sys"}],
+        memory_count=0,
         run_start_seq=7,
         tool_schemas=[{"type": "function", "function": {"name": "bash"}}],
         latest_compaction=None,
@@ -265,18 +267,22 @@ Expected: FAIL because bootstrap still mutates state directly and compaction sti
 ```python
 # agiwo/agent/runtime/state_writer.py
 class RunStateWriter:
-    async def record_bootstrap_state(
+    async def record_context_assembled(
         self,
         *,
+        messages: list[dict[str, Any]],
+        memory_count: int,
         run_start_seq: int,
         tool_schemas: list[dict[str, Any]] | None,
         latest_compaction: CompactMetadata | None,
-    ) -> None:
+    ) -> list[RunLogEntry]:
+        replace_messages(self._state, messages)
         self._state.ledger.run_start_seq = run_start_seq
         self._state.ledger.tool_schemas = (
             copy.deepcopy(tool_schemas) if tool_schemas is not None else None
         )
         self._state.ledger.compaction.last_metadata = latest_compaction
+        return await self.append_entries([build_context_assembled_entry(...)])
 
     async def record_llm_turn(
         self,
@@ -297,14 +303,12 @@ class RunStateWriter:
 ```python
 # agiwo/agent/run_bootstrap.py
 user_step = await _build_user_step(context, user_input)
-await writer.record_bootstrap_state(
-    run_start_seq=user_step.sequence,
-    tool_schemas=_build_tool_schemas(runtime),
-    latest_compaction=latest_compact,
-)
 await writer.record_context_assembled(
     messages=assembled_messages,
     memory_count=len(memories),
+    run_start_seq=user_step.sequence,
+    tool_schemas=_build_tool_schemas(runtime),
+    latest_compaction=latest_compact,
 )
 ```
 
@@ -606,4 +610,4 @@ Placeholder scan:
 - No `TODO`, `TBD`, or deferred implementation placeholders remain.
 
 Type consistency:
-- The plan consistently uses `peek_pending_steer_inputs`, `ack_pending_steer_inputs`, `record_bootstrap_state`, and canonical `LLMCallStarted` / `LLMCallCompleted` naming across tasks.
+- The plan consistently uses `peek_pending_steer_inputs`, `ack_pending_steer_inputs`, `record_context_assembled`, and canonical `LLMCallStarted` / `LLMCallCompleted` naming across tasks.

--- a/docs/superpowers/specs/2026-04-23-runtime-tool-surface-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-23-runtime-tool-surface-hardening-design.md
@@ -1,0 +1,148 @@
+# Runtime Tool Surface Hardening Design
+
+## Context
+
+Feishu channel testing exposed two recurring runtime-tool failures:
+
+- `bash` calls failed with `stdin requires pty=true` when the model supplied
+  `stdin: ""` together with `pty: false`.
+- `spawn_agent` calls failed because the single tool exposed two different
+  modes through a `fork` boolean. The model combined `fork=true` with custom
+  parameters, then later used tool names as `allowed_skills`.
+
+The Feishu channel and scheduler dispatch path worked correctly. The failures
+came from a public tool surface that made invalid parameter combinations easy
+for the model to produce.
+
+## Goals
+
+- Make child-agent creation tools harder to misuse by splitting regular spawn
+  and fork semantics into separate tools.
+- Let regular child-agent spawning explicitly restrict available tools through
+  `allowed_tools`.
+- Keep `allowed_skills` scoped to skills only.
+- Treat empty bash stdin as absent stdin so harmless model-generated
+  `stdin: ""` does not require PTY mode.
+- Avoid compatibility shims for historical `spawn_agent` calls; old test data
+  will be cleared.
+
+## Non-Goals
+
+- Do not migrate existing scheduler state or historical run data.
+- Do not preserve `spawn_agent` as an alias.
+- Do not split the internal scheduler command model unless required by tests.
+- Do not relax bash safety checks for non-empty stdin.
+
+## Public Tool API
+
+### `spawn_child_agent`
+
+Creates a regular child agent for an independent subtask.
+
+Parameters:
+
+- `task: string` required.
+- `instruction: string | null` optional child guidance.
+- `allowed_tools: list[str] | null` optional explicit functional tool list.
+- `allowed_skills: list[str] | null` optional explicit skill list.
+
+Semantics:
+
+- Creates `SpawnChildRequest(..., fork=False)`.
+- `allowed_tools` is validated as a child subset of the parent agent's
+  `allowed_tools` when the parent has a restriction.
+- `allowed_skills` is validated through the global skill manager and remains
+  skill-only.
+- Child agents cannot spawn further child agents.
+
+### `fork_child_agent`
+
+Creates a forked child agent that inherits parent conversation context.
+
+Parameters:
+
+- `task: string` required.
+
+Semantics:
+
+- Creates `SpawnChildRequest(..., fork=True)`.
+- Does not expose `instruction`, `allowed_tools`, or `allowed_skills`.
+- Inherits parent runtime context according to the existing fork path.
+- Child agents cannot spawn further child agents.
+
+### Removed Tool
+
+`spawn_agent` is removed from the scheduler runtime tool registry. If an old
+prompt or stale conversation calls it, the normal unknown-tool path should
+surface the error.
+
+## Internal Implementation
+
+The internal scheduler primitive remains `SpawnChildRequest` with `fork: bool`
+for this change. That keeps the implementation focused on the public tool
+surface while reusing the existing scheduler flow:
+
+- `agiwo.scheduler.commands.SpawnChildRequest`
+- `agiwo.scheduler.tool_control.SchedulerToolControl.spawn_child`
+- `agiwo.scheduler.runner.SchedulerRunner._ensure_child_agent`
+
+`SpawnChildRequest.allowed_tools` already exists and should be wired from the
+new `spawn_child_agent` tool.
+
+The runtime tool module should replace `SpawnAgentTool` with two concrete tool
+classes:
+
+- `SpawnChildAgentTool`
+- `ForkChildAgentTool`
+
+Both can share a small private helper for common spawn result formatting and
+error conversion.
+
+## Bash Stdin Normalization
+
+Normalize bash stdin during parameter parsing:
+
+- Missing `stdin` remains `None`.
+- `stdin == ""` becomes `None`.
+- Non-string stdin remains a parse error.
+- Non-empty stdin with `pty=false` still fails with `stdin requires pty=true`.
+
+This keeps the safety boundary intact while removing a common false-positive
+failure caused by model-generated empty strings.
+
+## Error Handling
+
+- Invalid `allowed_tools` still returns a failed tool result with the existing
+  child-subset validation message.
+- Invalid `allowed_skills` still returns a failed tool result with the existing
+  skill validation message.
+- Calls to removed `spawn_agent` should not be intercepted or rewritten.
+- `fork_child_agent` should not need fork-specific parameter conflict errors
+  because its schema does not expose conflicting parameters.
+
+## Tests
+
+Add or update tests for:
+
+- Bash parser normalizes `stdin: ""` to `None`.
+- Bash still rejects non-empty stdin when `pty=false`.
+- Scheduler runtime tools expose `spawn_child_agent` and `fork_child_agent`,
+  and no longer expose `spawn_agent`.
+- `spawn_child_agent` passes `allowed_tools` into `SpawnChildRequest` and child
+  overrides.
+- `fork_child_agent` creates a forked child without custom tool or skill
+  parameters.
+- Existing child-agent spawn, wait, query, cancel, and list behavior remains
+  intact under the new tool names.
+
+## Documentation Updates
+
+Update references in:
+
+- `AGENTS.md`
+- multi-agent docs and website docs
+- scheduler/runtime-tool tests and expected prompt strings
+
+The docs should describe `spawn_child_agent` and `fork_child_agent` as separate
+tools instead of documenting a single `spawn_agent(fork=...)` interface.
+

--- a/tests/agent/test_definition_contracts.py
+++ b/tests/agent/test_definition_contracts.py
@@ -105,9 +105,9 @@ async def test_create_child_agent_applies_overrides() -> None:
     assert clone.config.options.enable_termination_summary is True
 
 
-class SpawnAgentDummy(BaseTool):
-    name = "spawn_agent"
-    description = "Dummy spawn_agent for testing"
+class SpawnChildAgentDummy(BaseTool):
+    name = "spawn_child_agent"
+    description = "Dummy spawn_child_agent for testing"
 
     def get_parameters(self) -> dict:
         return {"type": "object", "properties": {}}
@@ -119,9 +119,9 @@ class SpawnAgentDummy(BaseTool):
 
 @pytest.mark.asyncio
 async def test_create_child_agent_inherits_extra_tools() -> None:
-    """Extra tools (including spawn_agent) are inherited by children.
+    """Extra tools (including spawn_child_agent) are inherited by children.
 
-    spawn_agent exclusion is the scheduler's responsibility, not Agent's.
+    Child-spawn tool exclusion is the scheduler's responsibility, not Agent's.
     """
     agent = Agent(
         config=AgentConfig(
@@ -132,12 +132,12 @@ async def test_create_child_agent_inherits_extra_tools() -> None:
         ),
         id="definition-agent",
         model=MockModel(id="mock", name="mock", provider="openai"),
-        tools=[DummyTool(), SpawnAgentDummy()],
+        tools=[DummyTool(), SpawnChildAgentDummy()],
     )
     child = await agent.create_child_agent(child_id="child")
     child_tool_names = {t.name for t in child.tools}
     assert "dummy_tool" in child_tool_names
-    assert "spawn_agent" in child_tool_names
+    assert "spawn_child_agent" in child_tool_names
 
 
 @pytest.mark.asyncio
@@ -156,11 +156,11 @@ async def test_create_child_agent_receives_system_tools() -> None:
     )
     child = await agent.create_child_agent(
         child_id="sys-child",
-        system_tools=[SpawnAgentDummy()],
+        system_tools=[SpawnChildAgentDummy()],
     )
     child_tool_names = {t.name for t in child.tools}
     assert "dummy_tool" in child_tool_names
-    assert "spawn_agent" in child_tool_names
+    assert "spawn_child_agent" in child_tool_names
 
 
 def test_agent_constructor_does_not_expose_skill_manager(

--- a/tests/scheduler/test_models.py
+++ b/tests/scheduler/test_models.py
@@ -347,5 +347,5 @@ class TestBuildForkTaskNotice:
         result = build_fork_task_notice("Analyze data")
         assert "<system-notice>" in result
         assert "forked child agent" in result
-        assert "Do NOT use spawn_agent" in result
+        assert "Do NOT use spawn_child_agent or fork_child_agent" in result
         assert result.endswith("Analyze data")

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -572,16 +572,9 @@ class TestSchedulerCreateChildAgent:
         parent_has_fork = "fork_child_agent" in parent_tool_names
         child_has_fork = "fork_child_agent" in child_tool_names
 
-        if parent_has_spawn and not child_has_spawn:
+        if parent_has_spawn != child_has_spawn or parent_has_fork != child_has_fork:
             mismatches.append(
-                f"TOOLS MISMATCH: Parent has spawn_child_agent but child does not.\n"
-                f"  Parent tools: {parent_tool_names}\n"
-                f"  Child tools:  {child_tool_names}"
-            )
-
-        if parent_has_fork and not child_has_fork:
-            mismatches.append(
-                f"TOOLS MISMATCH: Parent has fork_child_agent but child does not.\n"
+                "TOOLS MISMATCH:\n"
                 f"  Parent tools: {parent_tool_names}\n"
                 f"  Child tools:  {child_tool_names}"
             )

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -242,7 +242,8 @@ class TestSchedulerPrepareAgent:
             assert registered is not agent
 
             tool_names = {t.name for t in registered.tools}
-            assert "spawn_agent" in tool_names
+            assert "spawn_child_agent" in tool_names
+            assert "fork_child_agent" in tool_names
             assert "sleep_and_wait" in tool_names
             assert "query_spawned_agent" in tool_names
 
@@ -260,7 +261,8 @@ class TestSchedulerPrepareAgent:
             )
 
             tool_names = {t.name for t in agent.tools}
-            assert "spawn_agent" not in tool_names
+            assert "spawn_child_agent" not in tool_names
+            assert "fork_child_agent" not in tool_names
             assert "sleep_and_wait" not in tool_names
             assert "query_spawned_agent" not in tool_names
             assert agent.options.enable_termination_summary is False
@@ -402,7 +404,8 @@ class TestSchedulerCreateChildAgent:
         child_prompt = await child_agent.get_effective_system_prompt()
         assert "Be helpful" in child_prompt
         child_tool_names = {t.name for t in child_agent.tools}
-        assert "spawn_agent" not in child_tool_names
+        assert "spawn_child_agent" not in child_tool_names
+        assert "fork_child_agent" not in child_tool_names
         assert "sleep_and_wait" in child_tool_names
         assert "query_spawned_agent" in child_tool_names
         await scheduler.stop()
@@ -559,17 +562,26 @@ class TestSchedulerCreateChildAgent:
             )
 
         # ═══════════════════════════════════════════════════════════════════
-        # Verify child has spawn_agent tool (excluded in normal mode, included in fork)
+        # Verify fork child inherits both child-spawn tools for cache-stable tool layout.
         # ═══════════════════════════════════════════════════════════════════
         parent_tool_names = {t.name for t in parent_runtime.tools}
         child_tool_names = {t.name for t in child_agent.tools}
 
-        parent_has_spawn = "spawn_agent" in parent_tool_names
-        child_has_spawn = "spawn_agent" in child_tool_names
+        parent_has_spawn = "spawn_child_agent" in parent_tool_names
+        child_has_spawn = "spawn_child_agent" in child_tool_names
+        parent_has_fork = "fork_child_agent" in parent_tool_names
+        child_has_fork = "fork_child_agent" in child_tool_names
 
         if parent_has_spawn and not child_has_spawn:
             mismatches.append(
-                f"TOOLS MISMATCH: Parent has spawn_agent but child does not.\n"
+                f"TOOLS MISMATCH: Parent has spawn_child_agent but child does not.\n"
+                f"  Parent tools: {parent_tool_names}\n"
+                f"  Child tools:  {child_tool_names}"
+            )
+
+        if parent_has_fork and not child_has_fork:
+            mismatches.append(
+                f"TOOLS MISMATCH: Parent has fork_child_agent but child does not.\n"
                 f"  Parent tools: {parent_tool_names}\n"
                 f"  Child tools:  {child_tool_names}"
             )
@@ -632,7 +644,8 @@ class TestSchedulerCreateChildAgent:
             )
 
         # Basic assertions for clarity
-        assert child_has_spawn, "Fork child should inherit spawn_agent tool"
+        assert child_has_spawn, "Fork child should inherit spawn_child_agent tool"
+        assert child_has_fork, "Fork child should inherit fork_child_agent tool"
         assert len(child_steps) == 2, f"Expected 2 steps, got {len(child_steps)}"
         assert "sleep_and_wait" in child_tool_names
         assert "query_spawned_agent" in child_tool_names

--- a/tests/scheduler/test_tools.py
+++ b/tests/scheduler/test_tools.py
@@ -21,11 +21,12 @@ from agiwo.scheduler.models import (
 )
 from agiwo.scheduler.runtime_tools import (
     CancelAgentTool,
+    ForkChildAgentTool,
     ListAgentsTool,
     QuerySpawnedAgentTool,
     RetrospectToolResultTool,
     SleepAndWaitTool,
-    SpawnAgentTool,
+    SpawnChildAgentTool,
 )
 from agiwo.scheduler.store.memory import InMemoryAgentStateStorage
 from agiwo.tool.builtin.bash_tool.process_tool import (
@@ -85,11 +86,11 @@ async def _register_parent(store, agent_id="orch", depth=0):
     return parent_state
 
 
-class TestSpawnAgentTool:
+class TestSpawnChildAgentTool:
     @pytest.mark.asyncio
     async def test_spawn_creates_pending_state(self, store, control, context):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
         tool_result = await tool.execute(
             {"task": "Research topic A", "tool_call_id": "tc-1"},
             context,
@@ -108,58 +109,22 @@ class TestSpawnAgentTool:
         assert state.depth == 1
 
     @pytest.mark.asyncio
-    async def test_spawn_with_custom_child_id(self, store, control, context):
+    async def test_spawn_persists_allowed_tools_override(self, store, control, context):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
-        tool_result = await tool.execute(
-            {"task": "Task", "child_id": "my-child", "tool_call_id": "tc-1"},
-            context,
-        )
-        assert tool_result.output["child_id"] == "my-child"
-        state = await store.get_state("my-child")
-        assert state is not None
-
-    @pytest.mark.asyncio
-    async def test_spawn_with_system_prompt_override(self, store, control, context):
-        await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
         tool_result = await tool.execute(
             {
                 "task": "Task",
-                "system_prompt": "You are a specialist.",
+                "allowed_tools": ["bash", "web_search"],
                 "tool_call_id": "tc-1",
             },
             context,
         )
+
         child_id = tool_result.output["child_id"]
         state = await store.get_state(child_id)
         assert state is not None
-        assert state.config_overrides["system_prompt"] == "You are a specialist."
-
-    @pytest.mark.asyncio
-    async def test_spawn_rejects_custom_child_id_collision(
-        self, store, control, context
-    ):
-        await _register_parent(store)
-        existing = AgentState(
-            id="my-child",
-            session_id="sess-1",
-            status=AgentStateStatus.PENDING,
-            task="existing task",
-            parent_id="orch",
-            depth=1,
-        )
-        await store.save_state(existing)
-
-        tool = SpawnAgentTool(control)
-        tool_result = await tool.execute(
-            {"task": "Task", "child_id": "my-child", "tool_call_id": "tc-1"},
-            context,
-        )
-
-        assert tool_result.termination_reason is None
-        assert tool_result.is_success is False
-        assert "already exists" in tool_result.content
+        assert state.config_overrides["allowed_tools"] == ("bash", "web_search")
 
     @pytest.mark.asyncio
     async def test_spawn_fails_without_agent_id(self, store, control):
@@ -169,14 +134,14 @@ class TestSpawnAgentTool:
             agent_id="",
             agent_name="",
         )
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
         tool_result = await tool.execute({"task": "Task", "tool_call_id": "tc-1"}, ctx)
         assert not tool_result.is_success
 
     @pytest.mark.asyncio
     async def test_spawn_generates_unique_ids(self, store, control, context):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
         r1 = await tool.execute({"task": "A", "tool_call_id": "tc-1"}, context)
         r2 = await tool.execute({"task": "B", "tool_call_id": "tc-2"}, context)
         assert r1.output["child_id"] != r2.output["child_id"]
@@ -192,7 +157,7 @@ class TestSpawnAgentTool:
             semaphore=asyncio.Semaphore(10),
         )
         await _register_parent(store, depth=2)
-        tool = SpawnAgentTool(eng._tool_control)
+        tool = SpawnChildAgentTool(eng._tool_control)
         tool_result = await tool.execute(
             {"task": "Deep task", "tool_call_id": "tc-1"},
             context,
@@ -211,35 +176,26 @@ class TestSpawnAgentTool:
             semaphore=asyncio.Semaphore(10),
         )
         await _register_parent(store)
-        tool = SpawnAgentTool(eng._tool_control)
-        await tool.execute(
-            {"task": "A", "child_id": "c1", "tool_call_id": "tc-1"}, context
-        )
-        await tool.execute(
-            {"task": "B", "child_id": "c2", "tool_call_id": "tc-2"}, context
-        )
-        tool_result = await tool.execute(
-            {"task": "C", "child_id": "c3", "tool_call_id": "tc-3"}, context
-        )
+        tool = SpawnChildAgentTool(eng._tool_control)
+        await tool.execute({"task": "A", "tool_call_id": "tc-1"}, context)
+        await tool.execute({"task": "B", "tool_call_id": "tc-2"}, context)
+        tool_result = await tool.execute({"task": "C", "tool_call_id": "tc-3"}, context)
         assert not tool_result.is_success
         assert "Spawn rejected" in tool_result.content
 
     @pytest.mark.asyncio
     async def test_spawn_inherits_depth(self, store, control, context):
         await _register_parent(store, depth=3)
-        tool = SpawnAgentTool(control)
-        await tool.execute(
-            {"task": "Task", "child_id": "deep-child", "tool_call_id": "tc-1"},
-            context,
-        )
-        state = await store.get_state("deep-child")
+        tool = SpawnChildAgentTool(control)
+        result = await tool.execute({"task": "Task", "tool_call_id": "tc-1"}, context)
+        state = await store.get_state(result.output["child_id"])
         assert state is not None
         assert state.depth == 4
 
     @pytest.mark.asyncio
     async def test_spawn_rejects_non_list_allowed_skills(self, store, control, context):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
 
         tool_result = await tool.execute(
             {"task": "Task", "allowed_skills": "audit", "tool_call_id": "tc-1"},
@@ -250,6 +206,19 @@ class TestSpawnAgentTool:
         assert "allowed_skills must be a list of strings" in tool_result.content
 
     @pytest.mark.asyncio
+    async def test_spawn_rejects_non_list_allowed_tools(self, store, control, context):
+        await _register_parent(store)
+        tool = SpawnChildAgentTool(control)
+
+        tool_result = await tool.execute(
+            {"task": "Task", "allowed_tools": "bash", "tool_call_id": "tc-1"},
+            context,
+        )
+
+        assert not tool_result.is_success
+        assert "allowed_tools must be a list of strings" in tool_result.content
+
+    @pytest.mark.asyncio
     async def test_spawn_rejects_unknown_exact_allowed_skill(
         self,
         store,
@@ -257,7 +226,7 @@ class TestSpawnAgentTool:
         context,
     ):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
 
         tool_result = await tool.execute(
             {
@@ -277,7 +246,7 @@ class TestSpawnAgentTool:
     @pytest.mark.asyncio
     async def test_spawn_rejects_wildcard_allowed_skills(self, store, control, context):
         await _register_parent(store)
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
 
         tool_result = await tool.execute(
             {"task": "Task", "allowed_skills": ["skill*"], "tool_call_id": "tc-1"},
@@ -288,51 +257,6 @@ class TestSpawnAgentTool:
         assert "explicit skill names" in tool_result.content
 
     @pytest.mark.asyncio
-    async def test_spawn_fork_creates_state_with_fork_flag(
-        self, store, control, context
-    ):
-        await _register_parent(store)
-        tool = SpawnAgentTool(control)
-        tool_result = await tool.execute(
-            {
-                "task": "Continue analysis",
-                "fork": True,
-                "child_id": "fork-child",
-                "tool_call_id": "tc-1",
-            },
-            context,
-        )
-        assert tool_result.is_success
-        state = await store.get_state("fork-child")
-        assert state is not None
-        assert state.config_overrides.get("fork") is True
-        assert state.config_overrides.get("instruction") is None
-
-    @pytest.mark.asyncio
-    async def test_spawn_fork_ignores_instruction_and_skills(
-        self, store, control, context
-    ):
-        await _register_parent(store)
-        tool = SpawnAgentTool(control)
-        tool_result = await tool.execute(
-            {
-                "task": "Do work",
-                "fork": True,
-                "instruction": "Use fast mode",
-                "allowed_skills": ["audit"],
-                "child_id": "fork-child-2",
-                "tool_call_id": "tc-1",
-            },
-            context,
-        )
-        assert tool_result.is_success
-        state = await store.get_state("fork-child-2")
-        assert state is not None
-        assert state.config_overrides.get("instruction") is None
-        assert state.config_overrides.get("allowed_skills") is None
-        assert state.config_overrides.get("fork") is True
-
-    @pytest.mark.asyncio
     async def test_gate_denies_spawn_from_child_agent(self, store, control):
         child_context = build_tool_context(
             session_id="sess-1",
@@ -341,7 +265,40 @@ class TestSpawnAgentTool:
             agent_name="child",
             depth=1,
         )
-        tool = SpawnAgentTool(control)
+        tool = SpawnChildAgentTool(control)
+        decision = await tool.gate({"task": "Sub-task"}, child_context)
+        assert decision.action == "deny"
+        assert "cannot spawn" in decision.reason.lower()
+
+
+class TestForkChildAgentTool:
+    @pytest.mark.asyncio
+    async def test_fork_creates_state_with_fork_flag(self, store, control, context):
+        await _register_parent(store)
+        tool = ForkChildAgentTool(control)
+        tool_result = await tool.execute(
+            {"task": "Continue analysis", "tool_call_id": "tc-1"},
+            context,
+        )
+
+        assert tool_result.is_success
+        state = await store.get_state(tool_result.output["child_id"])
+        assert state is not None
+        assert state.config_overrides.get("fork") is True
+        assert state.config_overrides.get("instruction") is None
+        assert state.config_overrides.get("allowed_skills") is None
+        assert state.config_overrides.get("allowed_tools") is None
+
+    @pytest.mark.asyncio
+    async def test_gate_denies_fork_from_child_agent(self, store, control):
+        child_context = build_tool_context(
+            session_id="sess-1",
+            run_id="run-1",
+            agent_id="child-1",
+            agent_name="child",
+            depth=1,
+        )
+        tool = ForkChildAgentTool(control)
         decision = await tool.gate({"task": "Sub-task"}, child_context)
         assert decision.action == "deny"
         assert "cannot spawn" in decision.reason.lower()
@@ -351,12 +308,12 @@ class TestSleepAndWaitTool:
     @pytest.mark.asyncio
     async def test_sleep_waitset(self, store, control, context):
         await _register_parent(store)
-        spawn_tool = SpawnAgentTool(control)
-        await spawn_tool.execute(
-            {"task": "A", "child_id": "child-1", "tool_call_id": "tc-1"}, context
+        spawn_tool = SpawnChildAgentTool(control)
+        child_1 = await spawn_tool.execute(
+            {"task": "A", "tool_call_id": "tc-1"}, context
         )
-        await spawn_tool.execute(
-            {"task": "B", "child_id": "child-2", "tool_call_id": "tc-2"}, context
+        child_2 = await spawn_tool.execute(
+            {"task": "B", "tool_call_id": "tc-2"}, context
         )
 
         sleep_tool = SleepAndWaitTool(control)
@@ -373,19 +330,18 @@ class TestSleepAndWaitTool:
         assert state.status == AgentStateStatus.WAITING
         assert state.wake_condition is not None
         assert state.wake_condition.type == WakeType.WAITSET
-        assert set(state.wake_condition.wait_for) == {"child-1", "child-2"}
+        assert set(state.wake_condition.wait_for) == {
+            child_1.output["child_id"],
+            child_2.output["child_id"],
+        }
         assert state.wake_condition.timeout_at is not None
 
     @pytest.mark.asyncio
     async def test_sleep_waitset_any_mode(self, store, control, context):
         await _register_parent(store)
-        spawn_tool = SpawnAgentTool(control)
-        await spawn_tool.execute(
-            {"task": "A", "child_id": "child-1", "tool_call_id": "tc-1"}, context
-        )
-        await spawn_tool.execute(
-            {"task": "B", "child_id": "child-2", "tool_call_id": "tc-2"}, context
-        )
+        spawn_tool = SpawnChildAgentTool(control)
+        await spawn_tool.execute({"task": "A", "tool_call_id": "tc-1"}, context)
+        await spawn_tool.execute({"task": "B", "tool_call_id": "tc-2"}, context)
 
         sleep_tool = SleepAndWaitTool(control)
         await sleep_tool.execute(
@@ -399,22 +355,22 @@ class TestSleepAndWaitTool:
     @pytest.mark.asyncio
     async def test_sleep_waitset_explicit_wait_for(self, store, control, context):
         await _register_parent(store)
-        spawn_tool = SpawnAgentTool(control)
-        await spawn_tool.execute(
-            {"task": "A", "child_id": "child-1", "tool_call_id": "tc-1"}, context
-        )
-        await spawn_tool.execute(
-            {"task": "B", "child_id": "child-2", "tool_call_id": "tc-2"}, context
-        )
+        spawn_tool = SpawnChildAgentTool(control)
+        child = await spawn_tool.execute({"task": "A", "tool_call_id": "tc-1"}, context)
+        await spawn_tool.execute({"task": "B", "tool_call_id": "tc-2"}, context)
 
         sleep_tool = SleepAndWaitTool(control)
         await sleep_tool.execute(
-            {"wake_type": "waitset", "wait_for": ["child-1"], "tool_call_id": "tc-3"},
+            {
+                "wake_type": "waitset",
+                "wait_for": [child.output["child_id"]],
+                "tool_call_id": "tc-3",
+            },
             context,
         )
 
         state = await store.get_state("orch")
-        assert state.wake_condition.wait_for == ("child-1",)
+        assert state.wake_condition.wait_for == (child.output["child_id"],)
 
     @pytest.mark.asyncio
     async def test_sleep_timer(self, store, control, context):
@@ -464,10 +420,8 @@ class TestSleepAndWaitTool:
     @pytest.mark.asyncio
     async def test_sleep_waitset_with_custom_timeout(self, store, control, context):
         await _register_parent(store)
-        spawn_tool = SpawnAgentTool(control)
-        await spawn_tool.execute(
-            {"task": "A", "child_id": "child-1", "tool_call_id": "tc-1"}, context
-        )
+        spawn_tool = SpawnChildAgentTool(control)
+        await spawn_tool.execute({"task": "A", "tool_call_id": "tc-1"}, context)
 
         sleep_tool = SleepAndWaitTool(control)
         await sleep_tool.execute(

--- a/tests/tool/test_bash_tool.py
+++ b/tests/tool/test_bash_tool.py
@@ -81,6 +81,16 @@ class TestBashToolBasic:
         assert result.output["ok"] is False
         assert "stdin requires pty=true" in result.output["stderr"]
 
+    async def test_empty_stdin_does_not_require_pty(self, bash_tool, mock_context):
+        result = await bash_tool.execute(
+            {"command": "echo hi", "stdin": "", "tool_call_id": "tc_005d"},
+            mock_context,
+        )
+
+        assert result.output["ok"] is True
+        call = bash_tool.config.sandbox.execute_calls[-1]
+        assert call["stdin"] is None
+
     async def test_pty_foreground_uses_default_tty_size(self, bash_tool, mock_context):
         result = await bash_tool.execute(
             {

--- a/website/src/content/docs/docs/concepts/scheduler.mdx
+++ b/website/src/content/docs/docs/concepts/scheduler.mdx
@@ -36,6 +36,7 @@ You can think of the scheduler as two layers:
 
 | State | Meaning |
 | --- | --- |
+| `PENDING` | Child state is persisted but this round has not started yet |
 | `RUNNING` | Currently executing an agent cycle |
 | `WAITING` | Waiting for a wake condition |
 | `IDLE` | Persistent root finished the current round and is ready |
@@ -50,5 +51,8 @@ The high-level integration API is `route_root_input(...)`. It decides whether th
 - submit a new root
 - enqueue input for the next round
 - steer a currently active root
+
+For non-`RUNNING` paths, it also returns a `RouteResult.stream` iterator for the
+root turn that was just routed.
 
 That is why Console and channel integrations do not need to reimplement root lifecycle logic.

--- a/website/src/content/docs/docs/concepts/tool.mdx
+++ b/website/src/content/docs/docs/concepts/tool.mdx
@@ -22,7 +22,7 @@ These are the tools controlled by `allowed_tools`:
 These are runtime-owned tools and are not filtered by `allowed_tools`:
 
 - `SkillTool`
-- scheduler runtime tools such as `spawn_agent` and `sleep_and_wait`
+- scheduler runtime tools such as `spawn_child_agent`, `fork_child_agent`, and `sleep_and_wait`
 
 ## Stable contract
 

--- a/website/src/content/docs/docs/guides/hooks.mdx
+++ b/website/src/content/docs/docs/guides/hooks.mdx
@@ -1,50 +1,101 @@
 ---
 title: Hooks
-description: Observe and extend Agiwo agent lifecycle events with AgentHooks.
+description: Observe and extend Agiwo agent lifecycle events with the phase-based HookRegistry.
 ---
 
 # Hooks
 
-Hooks let you observe or extend lifecycle points in the agent runtime. They are optional async callbacks grouped in `AgentHooks`.
+Hooks are registered through the phase-based `HookRegistry`. The old
+single-slot `AgentHooks` dataclass is no longer part of the public API.
 
-## Typical hook surfaces
-
-- before and after a run
-- before and after a tool call
-- before and after an LLM call
-- after a step is committed
-- memory write and memory retrieve hooks
-- compaction failure handling
-
-## Example
+## Quick start
 
 ```python
-from agiwo.agent import Agent, AgentConfig, AgentHooks
+from agiwo.agent import (
+    Agent,
+    AgentConfig,
+    HookPhase,
+    HookRegistry,
+    observe,
+    transform,
+)
 
 
-async def on_after_tool_call(tool_call_id, tool_name, parameters, result) -> None:
-    print(f"{tool_name} finished in {result.duration:.2f}s")
+async def add_prelude(payload: dict) -> dict:
+    updated = dict(payload)
+    updated["prelude_text"] = "Please be concise."
+    return updated
 
 
-hooks = AgentHooks(on_after_tool_call=on_after_tool_call)
+async def log_step(payload: dict) -> None:
+    step = payload["step"]
+    print(f"{step.role.value} step committed: {step.sequence}")
+
+
+hooks = HookRegistry(
+    [
+        transform(HookPhase.PREPARE, "add_prelude", add_prelude),
+        observe(HookPhase.AFTER_STEP_COMMIT, "log_step", log_step),
+    ]
+)
 
 agent = Agent(
-    AgentConfig(
-        name="assistant",
-        description="Helpful assistant",
-        system_prompt="Answer concisely.",
-    ),
+    AgentConfig(name="assistant", description="Helpful assistant"),
     model=model,
     hooks=hooks,
 )
 ```
 
+## Core types
+
+- `HookPhase`: lifecycle phase enum
+- `HookCapability`: `observe_only`, `transform`, `decision_support`
+- `HookGroup`: execution group ordering
+- `HookRegistration`: one registered phase handler
+- `HookRegistry`: ordered collection of registrations
+
+## Ordering and failures
+
+- Execution order is `group -> order -> registration order`
+- Only early phases may be marked `critical=True`
+- Non-critical hook failures are isolated, logged, and recorded as `HookFailed`
+  run-log facts
+- Critical hook failures are re-raised and fail the run
+
+## Public phases
+
+- `prepare`
+- `assemble_context`
+- `before_llm`
+- `after_llm`
+- `before_tool_call`
+- `after_tool_call`
+- `before_compaction`
+- `after_compaction`
+- `before_retrospect`
+- `after_retrospect`
+- `before_termination`
+- `after_termination`
+- `after_step_commit`
+- `run_finalized`
+- `memory_persist`
+- `compaction_failed`
+
+## Payload model
+
+Every handler receives a single `payload: dict[str, Any]`.
+
+- Transform phases may return a partial dict that only changes allowlisted fields
+- Decision-support phases may only write the phase-specific `*_advice` field
+- Observe-only phases should not return anything meaningful
+
 ## Good uses for hooks
 
 - logging and tracing
-- token and cost accounting
+- message rewrites before LLM calls
 - lightweight guardrails
-- memory integration
-- debugging run behavior
+- external memory integration
+- debugging committed step flow
 
-Hook exceptions propagate by default, so treat hooks as production code rather than best-effort callbacks.
+Prefer `observe(...)`, `transform(...)`, and `decision_support(...)` over
+constructing `HookRegistration` directly.

--- a/website/src/content/docs/docs/guides/hooks.mdx
+++ b/website/src/content/docs/docs/guides/hooks.mdx
@@ -22,9 +22,7 @@ from agiwo.agent import (
 
 
 async def add_prelude(payload: dict) -> dict:
-    updated = dict(payload)
-    updated["prelude_text"] = "Please be concise."
-    return updated
+    return {"prelude_text": "Please be concise."}
 
 
 async def log_step(payload: dict) -> None:

--- a/website/src/content/docs/docs/guides/multi-agent.mdx
+++ b/website/src/content/docs/docs/guides/multi-agent.mdx
@@ -5,7 +5,8 @@ description: Compose agents with Agent.as_tool() or use the Scheduler for persis
 
 # Multi-Agent
 
-Agiwo supports two public ways to compose agents: agent-as-tool composition and scheduler-managed orchestration.
+Agiwo supports two public ways to compose agents: agent-as-tool composition and
+scheduler-managed orchestration.
 
 ## Choose the right level
 
@@ -48,7 +49,8 @@ orchestrator = Agent(
 )
 ```
 
-This is the simplest public composition path when the delegated unit should look like a functional tool.
+This is the simplest public composition path when the delegated unit should look
+like a functional tool.
 
 ## Scheduler-managed orchestration
 
@@ -56,21 +58,24 @@ This is the simplest public composition path when the delegated unit should look
 from agiwo.scheduler import Scheduler
 
 async with Scheduler() as scheduler:
-    result = await scheduler.run(
-        orchestrator,
+    route = await scheduler.route_root_input(
         "Research two competing approaches and compare them.",
+        agent=orchestrator,
+        persistent=False,
     )
+    result = await scheduler.wait_for(route.state_id)
     print(result.response)
 ```
 
 For longer-lived roots:
 
 ```python
-state_id = await scheduler.submit(
-    orchestrator,
+route = await scheduler.route_root_input(
     "Manage the research pipeline",
+    agent=orchestrator,
     persistent=True,
 )
+state_id = route.state_id
 
 await scheduler.wait_for(state_id)
 await scheduler.enqueue_input(state_id, "Now focus on pricing.")
@@ -78,13 +83,15 @@ await scheduler.enqueue_input(state_id, "Now focus on pricing.")
 
 ## Scheduler runtime tools
 
-Agents running under the scheduler automatically get orchestration tools such as:
+Agents running under the scheduler automatically get orchestration tools such
+as:
 
 - `spawn_agent`
 - `sleep_and_wait`
 - `query_spawned_agent`
 - `cancel_agent`
 - `list_agents`
+- `retrospect_tool_result`
 
 These are runtime-owned tools. You do not register them manually on the agent.
 
@@ -92,7 +99,8 @@ These are runtime-owned tools. You do not register them manually on the agent.
 
 ### Specialist delegation
 
-One orchestrator delegates bounded work to specialist agents via `Agent.as_tool()`.
+One orchestrator delegates bounded work to specialist agents via
+`Agent.as_tool()`.
 
 ### Persistent supervisor
 
@@ -100,4 +108,5 @@ One root stays alive and coordinates work over time through scheduler tools.
 
 ### Fan-out and synthesis
 
-Multiple worker agents gather or analyze in parallel, then another run synthesizes the results.
+Multiple worker agents gather or analyze in parallel, then another run
+synthesizes the results.

--- a/website/src/content/docs/docs/guides/multi-agent.mdx
+++ b/website/src/content/docs/docs/guides/multi-agent.mdx
@@ -86,7 +86,8 @@ await scheduler.enqueue_input(state_id, "Now focus on pricing.")
 Agents running under the scheduler automatically get orchestration tools such
 as:
 
-- `spawn_agent`
+- `spawn_child_agent`
+- `fork_child_agent`
 - `sleep_and_wait`
 - `query_spawned_agent`
 - `cancel_agent`

--- a/website/src/content/docs/docs/guides/storage.mdx
+++ b/website/src/content/docs/docs/guides/storage.mdx
@@ -1,34 +1,44 @@
 ---
 title: Storage
-description: Configure run persistence and trace collection for observability and operator workflows.
+description: Configure run-log persistence and trace collection for observability and operator workflows.
 ---
 
 # Storage and Observability
 
 Agiwo separates runtime storage into two independent concerns:
 
-- run and step persistence
+- run-log persistence
 - trace collection
 
-## Run and step storage
+## Run log storage
 
-Run-step storage records inputs, outputs, steps, token usage, and status transitions.
+Run-log storage records canonical runtime facts as append-only `RunLog` entries.
 
 ```python
-from agiwo.agent import RunStepStorageConfig
-from agiwo.agent.storage.factory import create_run_step_storage
+from agiwo.agent import RunLogStorageConfig
+from agiwo.agent.storage.factory import create_run_log_storage
 
-storage = create_run_step_storage(
-    RunStepStorageConfig(
+storage = create_run_log_storage(
+    RunLogStorageConfig(
         storage_type="sqlite",
         config={"db_path": "runs.db"},
     )
 )
 ```
 
-## Trace Storage
+Stored facts include:
 
-Trace storage records span-style execution facts for debugging and observability.
+- `RunStarted`, `RunFinished`, `RunFailed`, `TerminationDecided`
+- `LLMCallStarted`, `LLMCallCompleted`
+- committed user, assistant, and tool steps
+- runtime decisions such as compaction, retrospect, rollback, and hook failures
+
+Replay/query helpers such as `list_step_views(...)` and `list_run_views(...)`
+are rebuilt from the stored `RunLog`.
+
+## Trace storage
+
+Trace storage persists trace snapshots built from committed run-log facts.
 
 ```python
 from agiwo.agent import TraceStorageConfig
@@ -49,7 +59,7 @@ from agiwo.agent import (
     AgentConfig,
     AgentOptions,
     AgentStorageOptions,
-    RunStepStorageConfig,
+    RunLogStorageConfig,
     TraceStorageConfig,
 )
 
@@ -59,7 +69,7 @@ config = AgentConfig(
     system_prompt="Use tools only when useful.",
     options=AgentOptions(
         storage=AgentStorageOptions(
-            run_step_storage=RunStepStorageConfig(
+            run_log_storage=RunLogStorageConfig(
                 storage_type="sqlite",
                 config={"db_path": "runs.db"},
             ),
@@ -81,9 +91,10 @@ config = AgentConfig(
 
 ## What this enables
 
-- inspect prior runs and steps
-- calculate token and cost metrics
+- inspect replayable run and step views
+- calculate token and cost metrics from committed facts
 - query traces by agent, session, or time range
 - support Console views for sessions, scheduler state, and traces
 
-The Console owns session storage and projections separately; the SDK itself does not expose a standalone session storage abstraction.
+The Console owns session storage and projections separately; the SDK itself does
+not expose a standalone session storage abstraction.

--- a/website/src/content/docs/docs/guides/streaming.mdx
+++ b/website/src/content/docs/docs/guides/streaming.mdx
@@ -5,7 +5,9 @@ description: Use Agiwo's shared streaming pipeline across Agent and Scheduler ex
 
 # Streaming
 
-Agiwo is streaming-first. `run()`, `run_stream()`, `start()`, and scheduler streaming all use the same underlying runtime pipeline.
+Agiwo is streaming-first. All LLM responses flow through the same streaming
+pipeline, whether you use `run()`, `run_stream()`, `start()`, or scheduler
+`route_root_input()`.
 
 ## Use `run_stream()` for the simple path
 
@@ -27,18 +29,41 @@ async for event in handle.stream():
 result = await handle.wait()
 ```
 
-This is the right path when you need explicit waiting or cancellation.
-
 ## Stream from the scheduler
 
 ```python
 from agiwo.scheduler import Scheduler
 
 async with Scheduler() as scheduler:
-    async for event in scheduler.stream("Research topic X", agent=agent):
+    route = await scheduler.route_root_input(
+        "Research topic X",
+        agent=agent,
+        persistent=False,
+    )
+    assert route.stream is not None
+
+    async for event in route.stream:
         if event.type == "step_delta" and event.delta.content:
             print(event.delta.content, end="", flush=True)
 ```
+
+For an existing root:
+
+```python
+route = await scheduler.route_root_input(
+    "Continue the analysis",
+    agent=agent,
+    state_id=existing_state_id,
+)
+assert route.stream is not None
+
+async for event in route.stream:
+    process(event)
+```
+
+Only one live stream subscriber is allowed per root `state_id`. If you steer a
+currently `RUNNING` root, `RouteResult.stream` is `None` because the existing
+subscriber keeps consuming that root's stream.
 
 ## Event shapes
 
@@ -47,7 +72,14 @@ async with Scheduler() as scheduler:
 - `run_started`
 - `step_delta`
 - `step_completed`
+- `messages_rebuilt`
+- `compaction_applied`
+- `compaction_failed`
+- `retrospect_applied`
+- `termination_decided`
+- `run_rolled_back`
 - `run_completed`
 - `run_failed`
 
-This means you can build one streaming consumer that works across direct agent runs and scheduler-managed runs.
+This lets one stream consumer work across direct agent runs and
+scheduler-managed runs.

--- a/website/src/content/docs/docs/reference/api/scheduler.mdx
+++ b/website/src/content/docs/docs/reference/api/scheduler.mdx
@@ -1,6 +1,6 @@
 ---
 title: Scheduler API
-description: Reference for Scheduler lifecycle, orchestration methods, control methods, and state semantics.
+description: Reference for Scheduler lifecycle, routing methods, control methods, and state semantics.
 ---
 
 # Scheduler API
@@ -23,25 +23,20 @@ await scheduler.stop()
 
 ## Core methods
 
-### `run(...)`
-
-Submit one root and wait for the final `RunOutput`.
-
-### `submit(...)`
-
-Create and start a root immediately, returning `state_id`.
-
 ### `enqueue_input(...)`
 
 Queue the next input for a persistent root that is `IDLE` or `FAILED`.
 
 ### `route_root_input(...)`
 
-High-level integration entry point used by Console and channels. It decides whether the correct action is submit, enqueue, or steer.
+Canonical integration entry point used by Console and channels. It decides
+whether the correct action is:
 
-### `stream(...)`
+- `submitted`
+- `enqueued`
+- `steered`
 
-Consume `AgentStreamItem` values for a root run.
+The returned `RouteResult.stream` is the root stream for that routed turn.
 
 ### `wait_for(...)`
 
@@ -60,6 +55,14 @@ Wait until a state settles to `IDLE`, `COMPLETED`, or `FAILED`.
 - `list_states(...)`
 - `list_events(...)`
 - `get_stats(...)`
+- `get_registered_agent(...)`
+
+## Stream semantics
+
+- `route_root_input()` exposes stream consumption through `RouteResult.stream`
+- only one live stream subscriber is allowed per root `state_id`
+- `RouteResult.stream` is `None` only for `steered + RUNNING`, where the
+  existing subscriber keeps consuming the live stream
 
 ## State storage backends
 
@@ -68,3 +71,10 @@ Wait until a state settles to `IDLE`, `COMPLETED`, or `FAILED`.
 - `memory`
 - `sqlite`
 - `mongodb`
+
+## Route stream modes
+
+`RouteStreamMode` currently supports:
+
+- `RUN_END`
+- `UNTIL_SETTLED`


### PR DESCRIPTION
## Summary
- replace the ambiguous scheduler `spawn_agent` runtime tool with explicit `spawn_child_agent` and `fork_child_agent`
- expose `allowed_tools` on regular child spawning and keep fork spawning conflict-free
- normalize empty bash stdin handling and update scheduler/runtime docs and tests

## Verification
- `uv run pytest tests/scheduler/test_tools.py -v`
- `uv run pytest tests/scheduler/test_scheduler.py -v`
- `uv run pytest tests/scheduler/test_models.py -v`
- `uv run pytest tests/agent/test_definition_contracts.py -v`
- `uv run pytest tests/tool/test_bash_tool.py -v`
- `uv run python scripts/lint.py ci`
- pre-push: `uv run pytest tests/ -v --tb=short` and console tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced separate `spawn_child_agent` and `fork_child_agent` tools for distinct child agent creation modes.
  * Added `route_root_input()` API with `RouteStreamMode` configuration for scheduling workflows.

* **API Changes**
  * Deprecated `Scheduler.run()`, `submit()`, and `stream()` methods; use `route_root_input()` with `wait_for()` instead.
  * Redesigned hooks system from `AgentHooks` to phase-based `HookRegistry`.
  * Shifted storage model from run-step persistence to run-log storage.

* **Bug Fixes**
  * Fixed empty string stdin parameter handling in bash tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->