### PR TITLE
fix: harden Feishu ACK delivery

### DIFF
--- a/console/server/channels/feishu/delivery_service.py
+++ b/console/server/channels/feishu/delivery_service.py
@@ -24,10 +24,13 @@ class FeishuDeliveryService:
         self._truncate_for_log = truncate_for_log
 
     async def send_ack(self, inbound: InboundMessage) -> None:
+        reaction_emoji = self._config.channels.feishu.ack_reaction_emoji
+        fallback_text = self._config.channels.feishu.ack_fallback_text
+
         try:
             await self._api.add_message_reaction(
                 inbound.message_id,
-                self._config.feishu_ack_reaction_emoji,
+                reaction_emoji,
             )
             logger.info(
                 "feishu_ack_sent",
@@ -48,7 +51,7 @@ class FeishuDeliveryService:
         try:
             await self._api.reply_text(
                 inbound.message_id,
-                self._config.feishu_ack_fallback_text,
+                fallback_text,
             )
             logger.info(
                 "feishu_ack_sent",
@@ -57,12 +60,35 @@ class FeishuDeliveryService:
                 chat_type=inbound.chat_type,
                 chat_id=inbound.chat_id,
                 message_id=inbound.message_id,
-                text=self._truncate_for_log(self._config.feishu_ack_fallback_text),
+                text=self._truncate_for_log(fallback_text),
             )
+            return
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "feishu_ack_fallback_failed",
                 message_id=inbound.message_id,
+                error=str(exc),
+            )
+
+        try:
+            await self._api.create_text_message(
+                inbound.chat_id,
+                fallback_text,
+            )
+            logger.info(
+                "feishu_ack_sent",
+                channel="feishu",
+                mode="create_message_fallback",
+                chat_type=inbound.chat_type,
+                chat_id=inbound.chat_id,
+                message_id=inbound.message_id,
+                text=self._truncate_for_log(fallback_text),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "feishu_ack_create_message_failed",
+                message_id=inbound.message_id,
+                chat_id=inbound.chat_id,
                 error=str(exc),
             )
 

--- a/console/server/config.py
+++ b/console/server/config.py
@@ -99,7 +99,7 @@ class FeishuConfig(BaseModel):
     debounce_ms: int = 3000
     max_batch_window_ms: int = 15000
     scheduler_wait_timeout: int = 900
-    ack_reaction_emoji: str = "Typing"
+    ack_reaction_emoji: str = "OnIt"
     ack_fallback_text: str = "收到，正在处理。"
 
 

--- a/console/tests/test_config_env.py
+++ b/console/tests/test_config_env.py
@@ -114,6 +114,12 @@ def test_console_config_reads_uppercase_env(monkeypatch: pytest.MonkeyPatch) -> 
     assert config.channels.feishu.enabled is True
 
 
+def test_console_config_uses_safe_default_feishu_ack_reaction() -> None:
+    config = ConsoleConfig()
+
+    assert config.channels.feishu.ack_reaction_emoji == "OnIt"
+
+
 def test_console_config_rejects_legacy_default_agent_group_env_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/console/tests/test_feishu_service_components.py
+++ b/console/tests/test_feishu_service_components.py
@@ -262,6 +262,66 @@ async def test_delivery_service_falls_back_to_create_message_for_group_reply() -
 
 
 @pytest.mark.asyncio
+async def test_delivery_service_send_ack_stops_after_reaction_success() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(),
+        reply_text=AsyncMock(),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_not_called()
+    api.create_text_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delivery_service_send_ack_falls_back_to_reply_text() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(side_effect=RuntimeError("reaction failed")),
+        reply_text=AsyncMock(),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_awaited_once_with("msg-1", "收到，正在处理。")
+    api.create_text_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delivery_service_send_ack_falls_back_to_create_message() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(side_effect=RuntimeError("reaction failed")),
+        reply_text=AsyncMock(side_effect=RuntimeError("reply failed")),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_awaited_once_with("msg-1", "收到，正在处理。")
+    api.create_text_message.assert_awaited_once_with("chat-1", "收到，正在处理。")
+
+
+@pytest.mark.asyncio
 async def test_inbound_handler_executes_commands_before_ack_or_enqueue() -> None:
     parser = SimpleNamespace(
         parse_inbound_message=AsyncMock(return_value=_inbound_message()),


### PR DESCRIPTION
## Summary
- switch the default Feishu ACK reaction from `Typing` to `OnIt`
- make `FeishuDeliveryService.send_ack()` read the nested Feishu config instead of the legacy flat fields
- extend ACK fallback from reaction-only to `reaction -> reply_text -> create_text_message`
- add regression coverage for the safe default and all ACK fallback branches

## Testing
- uv run pytest console/tests/test_feishu_service_components.py console/tests/test_config_env.py -k "ack or safe_default_feishu_ack_reaction" -v
- uv run pytest console/tests/test_feishu_service_components.py -v
- uv run python scripts/lint.py ci
- uv run python scripts/check.py console-tests
