### PR TITLE
fix: prevent concurrent PTY cleanup hangs

### DIFF
--- a/agiwo/tool/builtin/bash_tool/local_executor.py
+++ b/agiwo/tool/builtin/bash_tool/local_executor.py
@@ -342,9 +342,13 @@ class LocalExecutor(Sandbox):
                 exit_code=1,
             )
         finally:
-            # Wait for the reader to finish before cleaning up
+            # `process.wait()` can finish before the PTY reader observes EOF.
+            # If we wait on `process_done` unconditionally, short-lived PTY
+            # commands can hang forever during cleanup.
+            if not process_done.is_set():
+                loop.remove_reader(master_fd)
+                process_done.set()
             await process_done.wait()
-            loop.remove_reader(master_fd)
             try:
                 os.close(master_fd)
             except OSError:

--- a/agiwo/tool/builtin/bash_tool/local_executor.py
+++ b/agiwo/tool/builtin/bash_tool/local_executor.py
@@ -348,7 +348,6 @@ class LocalExecutor(Sandbox):
             if not process_done.is_set():
                 loop.remove_reader(master_fd)
                 process_done.set()
-            await process_done.wait()
             try:
                 os.close(master_fd)
             except OSError:

--- a/docs/superpowers/plans/2026-04-23-feishu-ack-reaction-repair.md
+++ b/docs/superpowers/plans/2026-04-23-feishu-ack-reaction-repair.md
@@ -1,0 +1,350 @@
+# Feishu ACK Reaction Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Feishu message ACKs reliable by switching the default reaction to a safe emoji and extending the ACK fallback chain from reaction to reply to create-message.
+
+**Architecture:** Keep ACK ownership inside `FeishuDeliveryService` and avoid adding new abstractions. Fix the unsafe default in `ConsoleConfig`, drive the ACK ladder with focused regression tests, and redeploy the managed `agiwo-console` container from the current source tree while preserving the existing data directory and host-network setup.
+
+**Tech Stack:** Python 3.10+, FastAPI Console backend, Feishu channel, httpx, pytest, Docker, `scripts/deploy_console.sh`
+
+---
+
+## File Structure
+
+- Modify: `console/server/config.py`
+  Change the default Feishu ACK reaction from `Typing` to `OnIt`.
+- Modify: `console/server/channels/feishu/delivery_service.py`
+  Keep `send_ack()` as the ACK owner and extend it to try reaction, then reply, then create-message.
+- Modify: `console/tests/test_feishu_service_components.py`
+  Add regression tests for the three ACK branches.
+- Modify: `console/tests/test_config_env.py`
+  Add coverage for the new default ACK reaction value.
+- Create: `/tmp/agiwo-console-redeploy.env`
+  Export the current container environment into a temporary env file for replacement deployment.
+
+## Task 1: Lock In the ACK Contract With Tests
+
+**Files:**
+- Modify: `console/tests/test_feishu_service_components.py`
+- Modify: `console/tests/test_config_env.py`
+
+- [ ] **Step 1: Add a failing config-default test**
+
+```python
+def test_console_config_uses_safe_default_feishu_ack_reaction() -> None:
+    config = ConsoleConfig()
+
+    assert config.channels.feishu.ack_reaction_emoji == "OnIt"
+```
+
+- [ ] **Step 2: Add a failing ACK reaction-success test**
+
+```python
+@pytest.mark.asyncio
+async def test_delivery_service_send_ack_stops_after_reaction_success() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(),
+        reply_text=AsyncMock(),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_not_called()
+    api.create_text_message.assert_not_called()
+```
+
+- [ ] **Step 3: Add a failing ACK reply-fallback test**
+
+```python
+@pytest.mark.asyncio
+async def test_delivery_service_send_ack_falls_back_to_reply_text() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(side_effect=RuntimeError("reaction failed")),
+        reply_text=AsyncMock(),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_awaited_once_with("msg-1", "收到，正在处理。")
+    api.create_text_message.assert_not_called()
+```
+
+- [ ] **Step 4: Add a failing ACK create-message fallback test**
+
+```python
+@pytest.mark.asyncio
+async def test_delivery_service_send_ack_falls_back_to_create_message() -> None:
+    api = SimpleNamespace(
+        add_message_reaction=AsyncMock(side_effect=RuntimeError("reaction failed")),
+        reply_text=AsyncMock(side_effect=RuntimeError("reply failed")),
+        create_text_message=AsyncMock(),
+    )
+    delivery = FeishuDeliveryService(
+        api=api,
+        config=ConsoleConfig(),
+        truncate_for_log=lambda text: text,
+    )
+
+    await delivery.send_ack(_inbound_message())
+
+    api.add_message_reaction.assert_awaited_once_with("msg-1", "OnIt")
+    api.reply_text.assert_awaited_once_with("msg-1", "收到，正在处理。")
+    api.create_text_message.assert_awaited_once_with("chat-1", "收到，正在处理。")
+```
+
+- [ ] **Step 5: Run the focused tests to verify they fail**
+
+Run: `uv run pytest console/tests/test_feishu_service_components.py console/tests/test_config_env.py -k "ack or safe_default_feishu_ack_reaction" -v`
+
+Expected: FAIL because `ConsoleConfig` still defaults to `Typing` and `FeishuDeliveryService.send_ack()` currently stops after `reply_text()` failure.
+
+- [ ] **Step 6: Commit the red test slice**
+
+```bash
+git add console/tests/test_feishu_service_components.py console/tests/test_config_env.py
+git commit -m "test: cover feishu ack fallback ladder"
+```
+
+## Task 2: Implement the Safe Default and ACK Ladder
+
+**Files:**
+- Modify: `console/server/config.py`
+- Modify: `console/server/channels/feishu/delivery_service.py`
+- Test: `console/tests/test_feishu_service_components.py`
+- Test: `console/tests/test_config_env.py`
+
+- [ ] **Step 1: Change the default ACK reaction in config**
+
+```python
+class FeishuConfig(BaseModel):
+    enabled: bool = False
+    channel_instance_id: str = "feishu-main"
+    api_base_url: str = "https://open.feishu.cn"
+    app_id: str = ""
+    app_secret: str = ""
+    verification_token: str = ""
+    encrypt_key: str = ""
+    sdk_log_level: Literal["debug", "info", "warn", "error"] = "info"
+    bot_open_id: str = ""
+    default_agent_name: str = ""
+    whitelist_open_ids: list[str] = Field(default_factory=list)
+    debounce_ms: int = 3000
+    max_batch_window_ms: int = 15000
+    scheduler_wait_timeout: int = 900
+    ack_reaction_emoji: str = "OnIt"
+    ack_fallback_text: str = "收到，正在处理。"
+```
+
+- [ ] **Step 2: Extend `send_ack()` to a three-step ladder**
+
+```python
+    async def send_ack(self, inbound: InboundMessage) -> None:
+        try:
+            await self._api.add_message_reaction(
+                inbound.message_id,
+                self._config.feishu_ack_reaction_emoji,
+            )
+            logger.info(
+                "feishu_ack_sent",
+                channel="feishu",
+                mode="reaction",
+                chat_type=inbound.chat_type,
+                chat_id=inbound.chat_id,
+                message_id=inbound.message_id,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "feishu_ack_reaction_failed",
+                message_id=inbound.message_id,
+                error=str(exc),
+            )
+
+        try:
+            await self._api.reply_text(
+                inbound.message_id,
+                self._config.feishu_ack_fallback_text,
+            )
+            logger.info(
+                "feishu_ack_sent",
+                channel="feishu",
+                mode="reply_fallback",
+                chat_type=inbound.chat_type,
+                chat_id=inbound.chat_id,
+                message_id=inbound.message_id,
+                text=self._truncate_for_log(self._config.feishu_ack_fallback_text),
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "feishu_ack_fallback_failed",
+                message_id=inbound.message_id,
+                error=str(exc),
+            )
+
+        try:
+            await self._api.create_text_message(
+                inbound.chat_id,
+                self._config.feishu_ack_fallback_text,
+            )
+            logger.info(
+                "feishu_ack_sent",
+                channel="feishu",
+                mode="create_message_fallback",
+                chat_type=inbound.chat_type,
+                chat_id=inbound.chat_id,
+                message_id=inbound.message_id,
+                text=self._truncate_for_log(self._config.feishu_ack_fallback_text),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "feishu_ack_create_message_failed",
+                message_id=inbound.message_id,
+                chat_id=inbound.chat_id,
+                error=str(exc),
+            )
+```
+
+- [ ] **Step 3: Run the focused tests again**
+
+Run: `uv run pytest console/tests/test_feishu_service_components.py console/tests/test_config_env.py -k "ack or safe_default_feishu_ack_reaction" -v`
+
+Expected: PASS for the new config default assertion and all three ACK ladder cases.
+
+- [ ] **Step 4: Run the full Feishu component test file**
+
+Run: `uv run pytest console/tests/test_feishu_service_components.py -v`
+
+Expected: PASS, confirming the ACK changes do not break command routing, group reply fallback, or attachment/message parsing coverage.
+
+- [ ] **Step 5: Commit the implementation slice**
+
+```bash
+git add console/server/config.py console/server/channels/feishu/delivery_service.py console/tests/test_feishu_service_components.py console/tests/test_config_env.py
+git commit -m "fix: harden feishu ack delivery"
+```
+
+## Task 3: Run Required Backend Checks
+
+**Files:**
+- Modify: none
+- Test: `console/tests/test_feishu_service_components.py`
+- Test: `console/tests/test_config_env.py`
+
+- [ ] **Step 1: Run the repo lint gate required for Python changes**
+
+Run: `uv run python scripts/lint.py ci`
+
+Expected: PASS. If this fails because of unrelated pre-existing syntax errors outside the Feishu slice, capture the failing file path and keep it in the work log before moving on.
+
+- [ ] **Step 2: Run the console backend test gate**
+
+Run: `uv run python scripts/check.py console-tests`
+
+Expected: PASS for the console backend suite, including the Feishu channel tests.
+
+- [ ] **Step 3: Record the verification outcome**
+
+No repo files change in this task. Keep the test output in the work log and do not create a verification-only commit here.
+
+## Task 4: Redeploy the Managed Console Container
+
+**Files:**
+- Create: `/tmp/agiwo-console-redeploy.env`
+- Modify: none
+
+- [ ] **Step 1: Export the current container environment to a temporary env file**
+
+Run:
+
+```bash
+docker inspect agiwo-console --format '{{range .Config.Env}}{{println .}}{{end}}' \
+  | python - <<'PY'
+import sys
+from pathlib import Path
+
+keep = []
+for raw in sys.stdin:
+    line = raw.strip()
+    if not line or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    if key.startswith(("PATH", "LANG", "HOME", "PYTHON_", "PIP_", "GPG_KEY", "NEXT_TELEMETRY_DISABLED", "NPM_CONFIG_UPDATE_NOTIFIER")):
+        continue
+    keep.append(f"{key}={value}")
+
+path = Path("/tmp/agiwo-console-redeploy.env")
+path.write_text("\\n".join(keep) + "\\n", encoding="utf-8")
+print(path)
+PY
+```
+
+Expected: prints `/tmp/agiwo-console-redeploy.env` and creates a reusable env file containing the current Console and provider settings.
+
+- [ ] **Step 2: Rebuild and replace the managed container from the current source tree**
+
+Run:
+
+```bash
+scripts/deploy_console.sh \
+  --env-file /tmp/agiwo-console-redeploy.env \
+  --data-dir /home/hongv/.agiwo-console-data \
+  --name agiwo-console \
+  --image agiwo-console:local \
+  --network-mode host \
+  --mount /home/hongv/workspace/agiwo:agiwo-repo
+```
+
+Expected: image rebuild completes, the existing `agiwo-console` container is replaced, and the script prints `deployment complete`.
+
+- [ ] **Step 3: Verify container health and the ACK runtime config**
+
+Run:
+
+```bash
+docker inspect agiwo-console --format '{{.State.Health.Status}}'
+curl -fsS http://127.0.0.1:8422/api/health
+docker inspect agiwo-console --format '{{range .Config.Env}}{{println .}}{{end}}' | rg 'AGIWO_CONSOLE_CHANNELS__FEISHU__ACK_REACTION_EMOJI'
+```
+
+Expected:
+
+- `healthy`
+- `{"status":"ok","service":"agiwo-console"}`
+- `AGIWO_CONSOLE_CHANNELS__FEISHU__ACK_REACTION_EMOJI=OnIt` unless the operator intentionally overrides it in the env file
+
+- [ ] **Step 4: Verify the new code is inside the running container**
+
+Run:
+
+```bash
+docker exec agiwo-console python - <<'PY'
+from server.config import ConsoleConfig
+print(ConsoleConfig().channels.feishu.ack_reaction_emoji)
+PY
+```
+
+Expected: prints `OnIt`.
+
+- [ ] **Step 5: Commit the deployment helper command updates if any repo files changed**
+
+```bash
+git status --short
+```
+
+Expected: no new repo changes from deployment. If the working tree is clean for this slice, no deployment commit is needed.

--- a/docs/superpowers/plans/2026-04-23-feishu-ack-reaction-repair.md
+++ b/docs/superpowers/plans/2026-04-23-feishu-ack-reaction-repair.md
@@ -20,8 +20,8 @@
   Add regression tests for the three ACK branches.
 - Modify: `console/tests/test_config_env.py`
   Add coverage for the new default ACK reaction value.
-- Create: `/tmp/agiwo-console-redeploy.env`
-  Export the current container environment into a temporary env file for replacement deployment.
+- Create: a secure temporary env file (for example `${ENV_FILE}` created via `mktemp`)
+  Export the current container environment into a temporary env file for replacement deployment, then remove it after verification.
 
 ## Task 1: Lock In the ACK Contract With Tests
 
@@ -154,10 +154,13 @@ class FeishuConfig(BaseModel):
 
 ```python
     async def send_ack(self, inbound: InboundMessage) -> None:
+        reaction_emoji = self._config.channels.feishu.ack_reaction_emoji
+        fallback_text = self._config.channels.feishu.ack_fallback_text
+
         try:
             await self._api.add_message_reaction(
                 inbound.message_id,
-                self._config.feishu_ack_reaction_emoji,
+                reaction_emoji,
             )
             logger.info(
                 "feishu_ack_sent",
@@ -178,7 +181,7 @@ class FeishuConfig(BaseModel):
         try:
             await self._api.reply_text(
                 inbound.message_id,
-                self._config.feishu_ack_fallback_text,
+                fallback_text,
             )
             logger.info(
                 "feishu_ack_sent",
@@ -187,7 +190,7 @@ class FeishuConfig(BaseModel):
                 chat_type=inbound.chat_type,
                 chat_id=inbound.chat_id,
                 message_id=inbound.message_id,
-                text=self._truncate_for_log(self._config.feishu_ack_fallback_text),
+                text=self._truncate_for_log(fallback_text),
             )
             return
         except Exception as exc:  # noqa: BLE001
@@ -200,7 +203,7 @@ class FeishuConfig(BaseModel):
         try:
             await self._api.create_text_message(
                 inbound.chat_id,
-                self._config.feishu_ack_fallback_text,
+                fallback_text,
             )
             logger.info(
                 "feishu_ack_sent",
@@ -209,7 +212,7 @@ class FeishuConfig(BaseModel):
                 chat_type=inbound.chat_type,
                 chat_id=inbound.chat_id,
                 message_id=inbound.message_id,
-                text=self._truncate_for_log(self._config.feishu_ack_fallback_text),
+                text=self._truncate_for_log(fallback_text),
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -265,7 +268,7 @@ No repo files change in this task. Keep the test output in the work log and do n
 ## Task 4: Redeploy the Managed Console Container
 
 **Files:**
-- Create: `/tmp/agiwo-console-redeploy.env`
+- Create: a secure temporary env file (for example `${ENV_FILE}`)
 - Modify: none
 
 - [ ] **Step 1: Export the current container environment to a temporary env file**
@@ -273,8 +276,13 @@ No repo files change in this task. Keep the test output in the work log and do n
 Run:
 
 ```bash
+: "${ENV_FILE:=$(mktemp /tmp/agiwo-console-redeploy.XXXXXX.env)}"
+chmod 600 "${ENV_FILE}"
+export ENV_FILE
+
 docker inspect agiwo-console --format '{{range .Config.Env}}{{println .}}{{end}}' \
   | python - <<'PY'
+import os
 import sys
 from pathlib import Path
 
@@ -288,38 +296,46 @@ for raw in sys.stdin:
         continue
     keep.append(f"{key}={value}")
 
-path = Path("/tmp/agiwo-console-redeploy.env")
+path = Path(os.environ["ENV_FILE"])
 path.write_text("\\n".join(keep) + "\\n", encoding="utf-8")
-print(path)
+path.chmod(0o600)
+print(f"{path}  # secure temp file; remove it after Step 4")
 PY
 ```
 
-Expected: prints `/tmp/agiwo-console-redeploy.env` and creates a reusable env file containing the current Console and provider settings.
+Expected: prints the concrete `${ENV_FILE}` path, keeps the file at mode `600`, and creates a reusable env file containing the current Console and provider settings.
 
 - [ ] **Step 2: Rebuild and replace the managed container from the current source tree**
 
 Run:
 
 ```bash
+: "${ENV_FILE:?Run Step 1 first to create ENV_FILE}"
+DATA_DIR="${DATA_DIR:-$HOME/.agiwo-console-data}"
+HOST_REPO_PATH="${HOST_REPO_PATH:-$(pwd)}"
+CONSOLE_NAME="${CONSOLE_NAME:-agiwo-console}"
+CONSOLE_IMAGE="${CONSOLE_IMAGE:-agiwo-console:local}"
+
 scripts/deploy_console.sh \
-  --env-file /tmp/agiwo-console-redeploy.env \
-  --data-dir /home/hongv/.agiwo-console-data \
-  --name agiwo-console \
-  --image agiwo-console:local \
+  --env-file "${ENV_FILE}" \
+  --data-dir "${DATA_DIR}" \
+  --name "${CONSOLE_NAME}" \
+  --image "${CONSOLE_IMAGE}" \
   --network-mode host \
-  --mount /home/hongv/workspace/agiwo:agiwo-repo
+  --mount "${HOST_REPO_PATH}:agiwo-repo"
 ```
 
-Expected: image rebuild completes, the existing `agiwo-console` container is replaced, and the script prints `deployment complete`.
+Expected: image rebuild completes, the existing `${CONSOLE_NAME}` container is replaced, and the script prints `deployment complete`. Defaults are `${HOME}/.agiwo-console-data` for `DATA_DIR`, the current repo for `HOST_REPO_PATH`, `agiwo-console` for `CONSOLE_NAME`, and `agiwo-console:local` for `CONSOLE_IMAGE`.
 
 - [ ] **Step 3: Verify container health and the ACK runtime config**
 
 Run:
 
 ```bash
-docker inspect agiwo-console --format '{{.State.Health.Status}}'
+: "${CONSOLE_NAME:=agiwo-console}"
+docker inspect "${CONSOLE_NAME}" --format '{{.State.Health.Status}}'
 curl -fsS http://127.0.0.1:8422/api/health
-docker inspect agiwo-console --format '{{range .Config.Env}}{{println .}}{{end}}' | rg 'AGIWO_CONSOLE_CHANNELS__FEISHU__ACK_REACTION_EMOJI'
+docker inspect "${CONSOLE_NAME}" --format '{{range .Config.Env}}{{println .}}{{end}}' | rg 'AGIWO_CONSOLE_CHANNELS__FEISHU__ACK_REACTION_EMOJI'
 ```
 
 Expected:
@@ -333,7 +349,8 @@ Expected:
 Run:
 
 ```bash
-docker exec agiwo-console python - <<'PY'
+: "${CONSOLE_NAME:=agiwo-console}"
+docker exec "${CONSOLE_NAME}" python - <<'PY'
 from server.config import ConsoleConfig
 print(ConsoleConfig().channels.feishu.ack_reaction_emoji)
 PY
@@ -341,7 +358,18 @@ PY
 
 Expected: prints `OnIt`.
 
-- [ ] **Step 5: Commit the deployment helper command updates if any repo files changed**
+- [ ] **Step 5: Remove the temporary env file after verification**
+
+Run:
+
+```bash
+: "${ENV_FILE:?Run Step 1 first to create ENV_FILE}"
+rm -f "${ENV_FILE}"
+```
+
+Expected: the secure temp file from Step 1 is deleted after deployment and verification complete.
+
+- [ ] **Step 6: Commit the deployment helper command updates if any repo files changed**
 
 ```bash
 git status --short

--- a/docs/superpowers/plans/2026-04-23-runtime-tool-surface-hardening.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-tool-surface-hardening.md
@@ -1,0 +1,551 @@
+# Runtime Tool Surface Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the ambiguous `spawn_agent` runtime tool with explicit `spawn_child_agent` and `fork_child_agent`, expose `allowed_tools` for regular child spawning, and normalize empty bash stdin so `stdin: ""` no longer falsely requires PTY mode.
+
+**Architecture:** Keep the internal scheduler primitive on `SpawnChildRequest` plus its existing `fork` flag and harden the public tool surface instead of rewriting the scheduler core. Split runtime-tool entrypoints into two concrete tools, wire `allowed_tools` through the existing child override path, and fix bash stdin normalization in the parser so the execution layer only sees meaningful stdin values.
+
+**Tech Stack:** Python 3.10+, pytest, scheduler runtime tools, bash builtin tool, Markdown docs
+
+---
+
+## File Structure
+
+- Modify: `agiwo/tool/builtin/bash_tool/parameter_parser.py`
+  Normalize empty-string stdin before execution.
+- Modify: `agiwo/tool/builtin/bash_tool/tool.py`
+  Keep runtime checks aligned with the new stdin normalization behavior.
+- Modify: `agiwo/scheduler/runtime_tools.py`
+  Remove `SpawnAgentTool`, add `SpawnChildAgentTool` and `ForkChildAgentTool`, and expose `allowed_tools` on the regular spawn tool.
+- Modify: `agiwo/scheduler/runner.py`
+  Rename the excluded runtime tool for non-fork children and update fork-related comments.
+- Modify: `agiwo/scheduler/formatting.py`
+  Update fork notices to refer to `fork_child_agent` instead of `spawn_agent`.
+- Modify: `tests/tool/test_bash_tool.py`
+  Cover empty-stdin normalization and keep the non-empty stdin rejection test.
+- Modify: `tests/scheduler/test_tools.py`
+  Replace `SpawnAgentTool` coverage with `SpawnChildAgentTool` and `ForkChildAgentTool`, and add `allowed_tools` assertions.
+- Modify: `tests/scheduler/test_scheduler.py`
+  Update runtime-tool presence assertions and fork/non-fork inheritance checks for the new tool names.
+- Modify: `tests/scheduler/test_models.py`
+  Update fork notice expectations.
+- Modify: `AGENTS.md`
+  Replace public runtime-tool references and child inheritance wording.
+- Modify: `docs/guides/multi-agent.md`
+  Document the new tool names and semantics.
+- Modify: `website/src/content/docs/docs/guides/multi-agent.mdx`
+  Mirror the doc-site version of the multi-agent guide update.
+- Modify: `docs/concepts/scheduler.md`
+  Update the runtime tool table and child-agent orchestration wording.
+- Modify: `docs/concepts/agent.md`
+  Update the system-tool description for scheduler-owned runtime tools.
+- Modify: `website/src/content/docs/docs/concepts/tool.mdx`
+  Update scheduler runtime tool examples.
+
+## Task 1: Harden Bash Empty Stdin Handling
+
+**Files:**
+- Modify: `tests/tool/test_bash_tool.py`
+- Modify: `agiwo/tool/builtin/bash_tool/parameter_parser.py`
+- Modify: `agiwo/tool/builtin/bash_tool/tool.py`
+
+- [ ] **Step 1: Add a failing test for empty stdin normalization**
+
+```python
+async def test_empty_stdin_does_not_require_pty(self, bash_tool, mock_context):
+    result = await bash_tool.execute(
+        {"command": "echo hi", "stdin": "", "tool_call_id": "tc_005d"},
+        mock_context,
+    )
+
+    assert result.output["ok"] is True
+    call = bash_tool.config.sandbox.execute_calls[-1]
+    assert call["stdin"] is None
+```
+
+- [ ] **Step 2: Run the focused bash test file to verify the new case fails**
+
+Run: `uv run pytest tests/tool/test_bash_tool.py -v`
+
+Expected: FAIL on `test_empty_stdin_does_not_require_pty` because `stdin=""` is currently treated as present input and the tool returns `stdin requires pty=true`.
+
+- [ ] **Step 3: Normalize empty-string stdin in the parser**
+
+```python
+def parse_stdin(self, parameters: dict[str, Any]) -> str | None | ParseError:
+    """Return parsed stdin value, None, or a ParseError."""
+    stdin_value = parameters.get("stdin")
+    if stdin_value is None:
+        return None
+    if not isinstance(stdin_value, str):
+        return ParseError("stdin must be a string")
+    if stdin_value == "":
+        return None
+    return stdin_value
+```
+
+- [ ] **Step 4: Keep the execution guard strict for non-empty stdin**
+
+```python
+if background and stdin is not None:
+    return self._formatter.error(
+        parameters,
+        "stdin is only supported for foreground PTY execution",
+        tool_call_id=tool_call_id,
+    )
+if stdin is not None and not use_pty:
+    return self._formatter.error(
+        parameters, "stdin requires pty=true", tool_call_id=tool_call_id
+    )
+```
+
+Use the existing logic in `agiwo/tool/builtin/bash_tool/tool.py` unchanged unless lint or type cleanup is required. The point is to verify that parser normalization, not execution relaxation, fixes the false-positive failure.
+
+- [ ] **Step 5: Re-run the bash tests**
+
+Run: `uv run pytest tests/tool/test_bash_tool.py -v`
+
+Expected: PASS, including the existing `test_stdin_requires_pty` case for non-empty stdin and the new empty-stdin normalization case.
+
+- [ ] **Step 6: Commit the bash hardening slice**
+
+```bash
+git add tests/tool/test_bash_tool.py agiwo/tool/builtin/bash_tool/parameter_parser.py agiwo/tool/builtin/bash_tool/tool.py
+git commit -m "fix: normalize empty bash stdin"
+```
+
+## Task 2: Split Runtime Tool Entry Points
+
+**Files:**
+- Modify: `tests/scheduler/test_tools.py`
+- Modify: `agiwo/scheduler/runtime_tools.py`
+
+- [ ] **Step 1: Replace the old spawn-tool imports and add new test classes**
+
+```python
+from agiwo.scheduler.runtime_tools import (
+    CancelAgentTool,
+    ForkChildAgentTool,
+    ListAgentsTool,
+    QuerySpawnedAgentTool,
+    RetrospectToolResultTool,
+    SleepAndWaitTool,
+    SpawnChildAgentTool,
+)
+
+
+class TestSpawnChildAgentTool:
+    """Coverage for the regular child-spawn runtime tool."""
+
+
+class TestForkChildAgentTool:
+    """Coverage for the fork child-spawn runtime tool."""
+```
+
+- [ ] **Step 2: Add failing tests for `allowed_tools` passthrough and fork-tool schema**
+
+```python
+@pytest.mark.asyncio
+async def test_spawn_child_passes_allowed_tools(self, store, control, context):
+    await _register_parent(store)
+    tool = SpawnChildAgentTool(control)
+
+    tool_result = await tool.execute(
+        {
+            "task": "Research topic A",
+            "allowed_tools": [],
+            "child_id": "restricted-child",
+            "tool_call_id": "tc-1",
+        },
+        context,
+    )
+
+    assert tool_result.is_success
+    state = await store.get_state("restricted-child")
+    assert state is not None
+    assert state.config_overrides["allowed_tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_fork_child_sets_fork_without_custom_overrides(
+    self, store, control, context
+):
+    await _register_parent(store)
+    tool = ForkChildAgentTool(control)
+
+    tool_result = await tool.execute(
+        {"task": "Continue analysis", "child_id": "fork-child", "tool_call_id": "tc-1"},
+        context,
+    )
+
+    assert tool_result.is_success
+    state = await store.get_state("fork-child")
+    assert state is not None
+    assert state.config_overrides.get("fork") is True
+    assert state.config_overrides.get("instruction") is None
+    assert state.config_overrides.get("allowed_tools") is None
+    assert state.config_overrides.get("allowed_skills") is None
+```
+
+- [ ] **Step 3: Run the scheduler tool tests to verify the new cases fail**
+
+Run: `uv run pytest tests/scheduler/test_tools.py -v`
+
+Expected: FAIL because `SpawnChildAgentTool` and `ForkChildAgentTool` do not exist yet and because `SpawnAgentTool` is still the active runtime tool implementation.
+
+- [ ] **Step 4: Replace `SpawnAgentTool` with two concrete tools**
+
+```python
+class SpawnChildAgentTool(BaseTool):
+    name = "spawn_child_agent"
+    description = """Spawn a child agent to handle an independent sub-task asynchronously.
+Use this when you want a fresh child agent with optional instruction, tool restrictions,
+or skill restrictions. The child agent cannot spawn further child agents."""
+
+    def get_parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Brief, complete task for the child agent.",
+                },
+                "instruction": {
+                    "type": "string",
+                    "description": "Optional child-specific execution guidance.",
+                },
+                "child_id": {
+                    "type": "string",
+                    "description": "Optional explicit child agent id.",
+                },
+                "allowed_tools": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional explicit functional tool list for the child.",
+                },
+                "allowed_skills": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional explicit skill list for the child.",
+                },
+            },
+            "required": ["task"],
+        }
+
+    async def execute(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+        abort_signal: AbortSignal | None = None,
+    ) -> ToolResult:
+        del abort_signal
+        start_time = time.time()
+        parent_agent_id = context.agent_id
+        task = parameters.get("task", "")
+        state = await self._port.spawn_child(
+            SpawnChildRequest(
+                parent_agent_id=parent_agent_id,
+                session_id=context.session_id,
+                task=task,
+                instruction=parameters.get("instruction"),
+                custom_child_id=parameters.get("child_id"),
+                allowed_tools=parameters.get("allowed_tools"),
+                allowed_skills=parameters.get("allowed_skills"),
+                fork=False,
+            )
+        )
+        return ToolResult.success(
+            tool_name=self.name,
+            tool_call_id=context.tool_call_id,
+            input_args={"task": task, "child_id": state.id},
+            content=f"Spawned child agent '{state.id}' for task: {task}",
+            output={"child_id": state.id, "status": "pending"},
+            start_time=start_time,
+        )
+
+
+class ForkChildAgentTool(BaseTool):
+    name = "fork_child_agent"
+    description = """Fork the current agent into a child agent that inherits the parent
+conversation context. Use this when the child should continue from the parent's context
+instead of starting fresh. The child agent cannot spawn further child agents."""
+
+    def get_parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "child_id": {
+                    "type": "string",
+                    "description": "Optional explicit child agent id.",
+                },
+                "task": {
+                    "type": "string",
+                    "description": "Brief task for the forked child to continue from the parent's context.",
+                },
+            },
+            "required": ["task"],
+        }
+
+    async def execute(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+        abort_signal: AbortSignal | None = None,
+    ) -> ToolResult:
+        del abort_signal
+        start_time = time.time()
+        parent_agent_id = context.agent_id
+        task = parameters.get("task", "")
+        state = await self._port.spawn_child(
+            SpawnChildRequest(
+                parent_agent_id=parent_agent_id,
+                session_id=context.session_id,
+                task=task,
+                custom_child_id=parameters.get("child_id"),
+                fork=True,
+            )
+        )
+        return ToolResult.success(
+            tool_name=self.name,
+            tool_call_id=context.tool_call_id,
+            input_args={"task": task, "child_id": state.id},
+            content=f"Spawned fork child agent '{state.id}' for task: {task}",
+            output={"child_id": state.id, "status": "pending"},
+            start_time=start_time,
+        )
+```
+
+Keep the existing `context.depth > 0` denial in both tools so child agents still cannot create further child agents.
+
+- [ ] **Step 5: Update the tests to use the new tool classes and names**
+
+```python
+tool = SpawnChildAgentTool(control)
+assert "Spawned child agent" in tool_result.content
+
+tool = ForkChildAgentTool(control)
+assert state.config_overrides.get("fork") is True
+```
+
+Delete or rewrite tests that currently exercise `fork=True` on the old `SpawnAgentTool`. The new contract is two distinct tools, so no test should call a single tool with a `fork` flag anymore.
+
+- [ ] **Step 6: Re-run the scheduler tool test file**
+
+Run: `uv run pytest tests/scheduler/test_tools.py -v`
+
+Expected: PASS, including the new `allowed_tools` persistence coverage and the fork-child coverage under the new tool name.
+
+- [ ] **Step 7: Commit the runtime-tool split**
+
+```bash
+git add tests/scheduler/test_tools.py agiwo/scheduler/runtime_tools.py
+git commit -m "refactor: split child spawn runtime tools"
+```
+
+## Task 3: Wire New Tool Names Through Scheduler Runtime Behavior
+
+**Files:**
+- Modify: `tests/scheduler/test_scheduler.py`
+- Modify: `tests/scheduler/test_models.py`
+- Modify: `agiwo/scheduler/runner.py`
+- Modify: `agiwo/scheduler/formatting.py`
+
+- [ ] **Step 1: Add failing assertions for runtime-tool visibility**
+
+```python
+assert "spawn_child_agent" in tool_names
+assert "fork_child_agent" in tool_names
+assert "spawn_agent" not in tool_names
+```
+
+Update both root-agent and child-agent visibility tests in `tests/scheduler/test_scheduler.py`, including the fork-child inheritance assertions that currently mention `spawn_agent`.
+
+- [ ] **Step 2: Run the scheduler runtime test files to verify name-based failures**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py tests/scheduler/test_models.py -v`
+
+Expected: FAIL because the scheduler still excludes `spawn_agent` by name, the fork notice still says `Do NOT use spawn_agent`, and runtime tool expectations still reference the removed name.
+
+- [ ] **Step 3: Rename the excluded non-fork tool and fork notice text**
+
+```python
+_CHILD_EXCLUDED_SYSTEM_TOOLS: frozenset[str] = frozenset({"spawn_child_agent"})
+```
+
+```python
+_FORK_NOTICE = _system_notice(
+    "You are a forked child agent. Your conversation history has been "
+    "inherited from the parent agent. Do NOT use fork_child_agent or "
+    "spawn_child_agent — child agents cannot spawn further child agents. "
+    "Complete the following task directly."
+)
+```
+
+Preserve the existing runtime behavior:
+
+- non-fork children exclude the regular spawn tool
+- fork children still inherit all system tools for prompt/KV alignment
+- gate checks still prevent child agents from actually spawning children
+
+- [ ] **Step 4: Update scheduler runtime tests to the new names**
+
+```python
+parent_has_spawn = "spawn_child_agent" in parent_tool_names
+child_has_spawn = "spawn_child_agent" in child_tool_names
+assert "fork_child_agent" in child_tool_names
+assert "spawn_agent" not in child_tool_names
+```
+
+Also update `tests/scheduler/test_models.py` string assertions so they match the new fork notice text.
+
+- [ ] **Step 5: Re-run the scheduler runtime tests**
+
+Run: `uv run pytest tests/scheduler/test_scheduler.py tests/scheduler/test_models.py -v`
+
+Expected: PASS, with root and fork-child tool visibility aligned to the new public runtime-tool surface.
+
+- [ ] **Step 6: Commit the scheduler runtime naming updates**
+
+```bash
+git add tests/scheduler/test_scheduler.py tests/scheduler/test_models.py agiwo/scheduler/runner.py agiwo/scheduler/formatting.py
+git commit -m "refactor: align scheduler runtime with child tool split"
+```
+
+## Task 4: Update Specs, Guides, and Repo Contract Docs
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/guides/multi-agent.md`
+- Modify: `website/src/content/docs/docs/guides/multi-agent.mdx`
+- Modify: `docs/concepts/scheduler.md`
+- Modify: `docs/concepts/agent.md`
+- Modify: `website/src/content/docs/docs/concepts/tool.mdx`
+
+- [ ] **Step 1: Add failing doc grep checks locally**
+
+Run:
+
+```bash
+rg -n "\bspawn_agent\b" AGENTS.md docs/guides/multi-agent.md website/src/content/docs/docs/guides/multi-agent.mdx docs/concepts/scheduler.md docs/concepts/agent.md website/src/content/docs/docs/concepts/tool.mdx
+```
+
+Expected: matches are found in all of these files because the docs still describe the removed tool name.
+
+- [ ] **Step 2: Update `AGENTS.md` to describe the new runtime tool names**
+
+```md
+- Scheduler runtime tools（`spawn_child_agent`、`fork_child_agent`、`sleep_and_wait` 等）通过 `runtime_agent.inject_system_tools` 注入，不混入 `tools`（extra_tools），不受 `allowed_tools` 约束。
+- 子 Agent 的 system_tools 由 `SchedulerRunner` 从父 Agent 的 `system_tools` 派生；非 fork 模式排除 `spawn_child_agent`，fork 模式继承全部（gate 检查仍阻止实际继续派生 child）。
+```
+
+- [ ] **Step 3: Update the multi-agent and concepts docs**
+
+Use replacements of this shape:
+
+```md
+- `spawn_child_agent`: create a fresh child agent for an independent sub-task
+- `fork_child_agent`: fork the current agent into a child that inherits parent context
+```
+
+```md
+Scheduler tools such as `spawn_child_agent`, `fork_child_agent`, and `sleep_and_wait`
+are runtime-owned system tools. They are not registered manually on the agent.
+```
+
+Make the same semantic update in both repository docs and website docs so the published site does not drift from repo documentation.
+
+- [ ] **Step 4: Re-run the doc grep check and the repo lint gate**
+
+Run:
+
+```bash
+rg -n "\bspawn_agent\b" AGENTS.md docs/guides/multi-agent.md website/src/content/docs/docs/guides/multi-agent.mdx docs/concepts/scheduler.md docs/concepts/agent.md website/src/content/docs/docs/concepts/tool.mdx
+uv run python scripts/lint.py ci
+```
+
+Expected:
+
+- the `rg` command returns no matches in the targeted files
+- the lint gate passes
+
+- [ ] **Step 5: Commit the documentation sweep**
+
+```bash
+git add AGENTS.md docs/guides/multi-agent.md website/src/content/docs/docs/guides/multi-agent.mdx docs/concepts/scheduler.md docs/concepts/agent.md website/src/content/docs/docs/concepts/tool.mdx
+git commit -m "docs: rename child runtime tools"
+```
+
+## Task 5: Full Regression Pass
+
+**Files:**
+- Modify: none
+- Test: `tests/tool/test_bash_tool.py`
+- Test: `tests/scheduler/test_tools.py`
+- Test: `tests/scheduler/test_scheduler.py`
+- Test: `tests/scheduler/test_models.py`
+
+- [ ] **Step 1: Run the focused regression suite**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/tool/test_bash_tool.py \
+  tests/scheduler/test_tools.py \
+  tests/scheduler/test_scheduler.py \
+  tests/scheduler/test_models.py \
+  -v
+```
+
+Expected: PASS across bash normalization, runtime tool behavior, and scheduler visibility assertions.
+
+- [ ] **Step 2: Run the repo CI-aligned lint gate one more time**
+
+Run: `uv run python scripts/lint.py ci`
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect the working tree**
+
+Run: `git status --short`
+
+Expected: only intended modified files remain. Do not touch unrelated pre-existing changes outside this plan.
+
+- [ ] **Step 4: Create the final integration commit**
+
+```bash
+git add agiwo/tool/builtin/bash_tool/parameter_parser.py \
+  agiwo/tool/builtin/bash_tool/tool.py \
+  agiwo/scheduler/runtime_tools.py \
+  agiwo/scheduler/runner.py \
+  agiwo/scheduler/formatting.py \
+  tests/tool/test_bash_tool.py \
+  tests/scheduler/test_tools.py \
+  tests/scheduler/test_scheduler.py \
+  tests/scheduler/test_models.py \
+  AGENTS.md \
+  docs/guides/multi-agent.md \
+  website/src/content/docs/docs/guides/multi-agent.mdx \
+  docs/concepts/scheduler.md \
+  docs/concepts/agent.md \
+  website/src/content/docs/docs/concepts/tool.mdx
+git commit -m "refactor: harden runtime tool surface"
+```
+
+- [ ] **Step 5: Summarize the rollout outcome**
+
+Use this structure in the handoff note:
+
+```md
+- Replaced `spawn_agent` with `spawn_child_agent` and `fork_child_agent`.
+- Exposed `allowed_tools` on regular child spawning.
+- Normalized empty bash stdin so `stdin: ""` no longer falsely requires PTY.
+- Updated scheduler runtime tests, docs, and AGENTS guidance.
+```
+
+## Self-Review
+
+- Spec coverage: this plan covers the three approved design changes: bash stdin normalization, child-runtime tool split, and doc/contract updates for the new tool names.
+- Placeholder scan: no `TBD`, `TODO`, or deferred “handle later” text remains in task steps.
+- Type consistency: the plan consistently uses `spawn_child_agent`, `fork_child_agent`, `allowed_tools`, and `SpawnChildRequest` with the existing `fork` flag across code, tests, and docs.

--- a/docs/superpowers/plans/2026-04-23-runtime-tool-surface-hardening.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-tool-surface-hardening.md
@@ -1,5 +1,10 @@
 # Runtime Tool Surface Hardening Implementation Plan
 
+> **Status:** Completed and archived.
+> Created: 2026-04-23
+> Verified against current code: 2026-04-24
+> Archival note: `stdin: ""` normalization, `SpawnChildAgentTool`, `allowed_tools`, and the `spawn_child_agent` / `fork_child_agent` split are already implemented in the current codebase. Use this plan as historical context, not as pending work.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the ambiguous `spawn_agent` runtime tool with explicit `spawn_child_agent` and `fork_child_agent`, expose `allowed_tools` for regular child spawning, and normalize empty bash stdin so `stdin: ""` no longer falsely requires PTY mode.
@@ -43,14 +48,14 @@
 - Modify: `website/src/content/docs/docs/concepts/tool.mdx`
   Update scheduler runtime tool examples.
 
-## Task 1: Harden Bash Empty Stdin Handling
+## Task 1: Verify Bash Empty Stdin Handling
 
 **Files:**
 - Modify: `tests/tool/test_bash_tool.py`
 - Modify: `agiwo/tool/builtin/bash_tool/parameter_parser.py`
 - Modify: `agiwo/tool/builtin/bash_tool/tool.py`
 
-- [ ] **Step 1: Add a failing test for empty stdin normalization**
+- [x] **Step 1: Verify the empty-stdin regression test already exists**
 
 ```python
 async def test_empty_stdin_does_not_require_pty(self, bash_tool, mock_context):
@@ -64,13 +69,13 @@ async def test_empty_stdin_does_not_require_pty(self, bash_tool, mock_context):
     assert call["stdin"] is None
 ```
 
-- [ ] **Step 2: Run the focused bash test file to verify the new case fails**
+- [x] **Step 2: Run the focused bash test file to verify the current behavior**
 
 Run: `uv run pytest tests/tool/test_bash_tool.py -v`
 
-Expected: FAIL on `test_empty_stdin_does_not_require_pty` because `stdin=""` is currently treated as present input and the tool returns `stdin requires pty=true`.
+Expected: PASS, including `test_empty_stdin_does_not_require_pty`, because `stdin=""` is already normalized to `None`.
 
-- [ ] **Step 3: Normalize empty-string stdin in the parser**
+- [x] **Step 3: Confirm the parser already normalizes empty-string stdin**
 
 ```python
 def parse_stdin(self, parameters: dict[str, Any]) -> str | None | ParseError:
@@ -85,7 +90,7 @@ def parse_stdin(self, parameters: dict[str, Any]) -> str | None | ParseError:
     return stdin_value
 ```
 
-- [ ] **Step 4: Keep the execution guard strict for non-empty stdin**
+- [x] **Step 4: Confirm the execution guard remains strict for non-empty stdin**
 
 ```python
 if background and stdin is not None:
@@ -100,13 +105,13 @@ if stdin is not None and not use_pty:
     )
 ```
 
-Use the existing logic in `agiwo/tool/builtin/bash_tool/tool.py` unchanged unless lint or type cleanup is required. The point is to verify that parser normalization, not execution relaxation, fixes the false-positive failure.
+The current implementation already uses parser normalization rather than relaxing the execution guard. Keep `agiwo/tool/builtin/bash_tool/tool.py` unchanged unless unrelated cleanup is required.
 
-- [ ] **Step 5: Re-run the bash tests**
+- [x] **Step 5: Re-run the bash tests after verification**
 
 Run: `uv run pytest tests/tool/test_bash_tool.py -v`
 
-Expected: PASS, including the existing `test_stdin_requires_pty` case for non-empty stdin and the new empty-stdin normalization case.
+Expected: PASS, including the existing `test_stdin_requires_pty` case for non-empty stdin and the empty-stdin normalization case.
 
 - [ ] **Step 6: Commit the bash hardening slice**
 
@@ -188,16 +193,44 @@ async def test_fork_child_sets_fork_without_custom_overrides(
     assert state.config_overrides.get("allowed_skills") is None
 ```
 
-- [ ] **Step 3: Run the scheduler tool tests to verify the new cases fail**
+- [x] **Step 3: Run the scheduler tool tests to verify the split-tool behavior**
 
 Run: `uv run pytest tests/scheduler/test_tools.py -v`
 
-Expected: FAIL because `SpawnChildAgentTool` and `ForkChildAgentTool` do not exist yet and because `SpawnAgentTool` is still the active runtime tool implementation.
+Expected: PASS because `SpawnChildAgentTool` and `ForkChildAgentTool` already exist and the old `SpawnAgentTool` has already been removed.
 
-- [ ] **Step 4: Replace `SpawnAgentTool` with two concrete tools**
+- [x] **Step 4: Reference the current shared-base implementation**
 
 ```python
-class SpawnChildAgentTool(BaseTool):
+class _BaseSpawnChildTool(BaseTool):
+    _fork: bool = False
+    _success_verb = "Spawned"
+
+    def __init__(self, port: SchedulerToolControl) -> None:
+        self._port = port
+        super().__init__()
+
+    async def gate(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+    ) -> ToolGateDecision:
+        del parameters
+        if context.depth > 0:
+            return ToolGateDecision.deny("Child agents cannot spawn further agents.")
+        return ToolGateDecision.allow()
+
+    async def execute(
+        self,
+        parameters: dict[str, Any],
+        context: ToolContext,
+        abort_signal: AbortSignal | None = None,
+    ) -> ToolResult:
+        del abort_signal
+        ...
+
+
+class SpawnChildAgentTool(_BaseSpawnChildTool):
     name = "spawn_child_agent"
     description = """Spawn a child agent to handle an independent sub-task asynchronously.
 Use this when you want a fresh child agent with optional instruction, tool restrictions,
@@ -215,10 +248,6 @@ or skill restrictions. The child agent cannot spawn further child agents."""
                     "type": "string",
                     "description": "Optional child-specific execution guidance.",
                 },
-                "child_id": {
-                    "type": "string",
-                    "description": "Optional explicit child agent id.",
-                },
                 "allowed_tools": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -233,52 +262,35 @@ or skill restrictions. The child agent cannot spawn further child agents."""
             "required": ["task"],
         }
 
-    async def execute(
-        self,
-        parameters: dict[str, Any],
-        context: ToolContext,
-        abort_signal: AbortSignal | None = None,
-    ) -> ToolResult:
-        del abort_signal
-        start_time = time.time()
-        parent_agent_id = context.agent_id
-        task = parameters.get("task", "")
-        state = await self._port.spawn_child(
-            SpawnChildRequest(
-                parent_agent_id=parent_agent_id,
-                session_id=context.session_id,
-                task=task,
-                instruction=parameters.get("instruction"),
-                custom_child_id=parameters.get("child_id"),
-                allowed_tools=parameters.get("allowed_tools"),
-                allowed_skills=parameters.get("allowed_skills"),
-                fork=False,
-            )
+    def _get_instruction(self, parameters: dict[str, Any]) -> str | None:
+        instruction = parameters.get("instruction")
+        return instruction if isinstance(instruction, str) else None
+
+    def _get_allowed_skills(self, parameters: dict[str, Any]) -> list[str] | None:
+        return _parse_optional_string_list(
+            parameters.get("allowed_skills"),
+            field_name="allowed_skills",
         )
-        return ToolResult.success(
-            tool_name=self.name,
-            tool_call_id=context.tool_call_id,
-            input_args={"task": task, "child_id": state.id},
-            content=f"Spawned child agent '{state.id}' for task: {task}",
-            output={"child_id": state.id, "status": "pending"},
-            start_time=start_time,
+
+    def _get_allowed_tools(self, parameters: dict[str, Any]) -> list[str] | None:
+        return _parse_optional_string_list(
+            parameters.get("allowed_tools"),
+            field_name="allowed_tools",
         )
 
 
-class ForkChildAgentTool(BaseTool):
+class ForkChildAgentTool(_BaseSpawnChildTool):
     name = "fork_child_agent"
     description = """Fork the current agent into a child agent that inherits the parent
 conversation context. Use this when the child should continue from the parent's context
 instead of starting fresh. The child agent cannot spawn further child agents."""
+    _fork = True
+    _success_verb = "Forked"
 
     def get_parameters(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
-                "child_id": {
-                    "type": "string",
-                    "description": "Optional explicit child agent id.",
-                },
                 "task": {
                     "type": "string",
                     "description": "Brief task for the forked child to continue from the parent's context.",
@@ -286,37 +298,9 @@ instead of starting fresh. The child agent cannot spawn further child agents."""
             },
             "required": ["task"],
         }
-
-    async def execute(
-        self,
-        parameters: dict[str, Any],
-        context: ToolContext,
-        abort_signal: AbortSignal | None = None,
-    ) -> ToolResult:
-        del abort_signal
-        start_time = time.time()
-        parent_agent_id = context.agent_id
-        task = parameters.get("task", "")
-        state = await self._port.spawn_child(
-            SpawnChildRequest(
-                parent_agent_id=parent_agent_id,
-                session_id=context.session_id,
-                task=task,
-                custom_child_id=parameters.get("child_id"),
-                fork=True,
-            )
-        )
-        return ToolResult.success(
-            tool_name=self.name,
-            tool_call_id=context.tool_call_id,
-            input_args={"task": task, "child_id": state.id},
-            content=f"Spawned fork child agent '{state.id}' for task: {task}",
-            output={"child_id": state.id, "status": "pending"},
-            start_time=start_time,
-        )
 ```
 
-Keep the existing `context.depth > 0` denial in both tools so child agents still cannot create further child agents.
+`_BaseSpawnChildTool` owns `__init__(port)`, `gate()`, and the shared `execute()` flow so the depth-check gate and base spawn logic stay aligned. `ForkChildAgentTool` only switches `_fork = True` and `_success_verb = "Forked"` while keeping the base plumbing intact.
 
 - [ ] **Step 5: Update the tests to use the new tool classes and names**
 

--- a/docs/superpowers/specs/2026-04-23-feishu-ack-reaction-design.md
+++ b/docs/superpowers/specs/2026-04-23-feishu-ack-reaction-design.md
@@ -1,0 +1,129 @@
+# Feishu ACK Reaction Repair
+
+**Goal:** Repair Feishu channel acknowledgements so normal inbound messages get a lightweight ACK reliably, with reaction first and text fallback only when needed.
+
+**Tech Stack:** Python 3.10+, Console Feishu channel, httpx, pytest
+
+## Context
+
+The current Feishu ACK path in `console/server/channels/feishu/delivery_service.py` is intended to:
+
+1. add a reaction to the triggering message
+2. fall back to a short text reply when reaction fails
+
+Production logs on April 23, 2026 showed both branches failing:
+
+- reaction failed with `code=99992402 field validation failed`
+- fallback reply failed with `code=230001 invalid message content`
+
+Direct API reproduction against the deployed app on April 23, 2026 clarified the reaction failure. The deployed environment sets:
+
+- `AGIWO_CONSOLE_CHANNELS__FEISHU__ACK_REACTION_EMOJI=Typing`
+
+Using the documented request body shape:
+
+- `Typing` returned `231002 The operator has no permission to react on the specific message`
+- `OnIt` succeeded on the same message
+- `SMILE` also succeeded on the same message
+
+That means the current default is not a safe ACK reaction for this bot context, even though Feishu documents `Typing` in the reaction catalog.
+
+The fallback reply failure was not reproduced with a direct minimal API call. A normal text reply and a normal create-message call both succeeded against the same chat. The safer interpretation is:
+
+- the primary root cause is the unsafe default ACK reaction
+- the fallback path is still worth hardening because it currently stops after one reply attempt
+
+## Decision
+
+Keep the current ACK product behavior:
+
+- normal inbound messages should try a lightweight reaction first
+- if reaction cannot be sent, the system should still acknowledge receipt with a short text message
+
+Do not introduce a new ACK strategy abstraction. The problem is not missing flexibility; it is an unsafe default reaction choice and an incomplete fallback chain.
+
+## Design
+
+### 1. Configuration
+
+Replace the default Feishu ACK reaction value with a documented reaction `emoji_type` that works for the deployed bot context.
+
+Recommended default:
+
+- `OnIt`
+
+Rationale:
+
+- it is listed in Feishu's documented reaction catalog
+- it matches the intended semantic of "received and working on it"
+- it preserves the lightweight ACK UX better than a generic smile or thumbs-up
+
+Existing explicit operator overrides should continue to work. The code should not silently translate arbitrary legacy aliases or maintain a hidden compatibility table. Operators who override the reaction value keep responsibility for choosing an emoji that is valid for their tenant and bot context.
+
+### 2. Delivery Flow
+
+Keep `FeishuDeliveryService.send_ack()` as the only ACK owner and make its control flow explicit:
+
+1. try `add_message_reaction(message_id, emoji_type)`
+2. if reaction fails, try `reply_text(message_id, fallback_text)`
+3. if reply fails, try `create_text_message(chat_id, fallback_text)`
+
+Logging should remain structured and make the selected ACK path obvious:
+
+- `feishu_ack_sent` with `mode=reaction`
+- `feishu_ack_sent` with `mode=reply_fallback`
+- `feishu_ack_sent` with `mode=create_message_fallback`
+- warning events for each failed step
+
+This keeps the delivery contract local to the Feishu channel layer and avoids spreading ACK retry logic into the inbound handler.
+
+### 3. API Surface
+
+No new public API is needed.
+
+Changes stay inside the existing Feishu channel boundary:
+
+- `console/server/config.py`
+- `console/server/channels/feishu/delivery_service.py`
+- tests under `console/tests/`
+
+`FeishuApiClient` does not need a new method because both fallback operations already exist.
+
+## Error Handling
+
+The ACK path should be best-effort and non-blocking:
+
+- failure to add a reaction must not stop message enqueue
+- failure to reply must not stop message enqueue
+- failure to create a fallback message must still not stop message enqueue
+
+The handler should continue to enqueue the inbound message after `send_ack()` returns, matching the current non-fatal semantics.
+
+This design intentionally does not add retries or exponential backoff. ACK is latency-sensitive and should stay simple. If all three attempts fail, logs are the observability mechanism.
+
+## Testing
+
+Add focused regression coverage in `console/tests/test_feishu_service_components.py`:
+
+1. reaction success:
+   `send_ack()` sends reaction only
+2. reaction failure, reply success:
+   `send_ack()` falls back to `reply_text()`
+3. reaction failure, reply failure:
+   `send_ack()` falls back to `create_text_message()`
+
+The tests should assert the exact call ordering so the intended ACK ladder does not regress later.
+
+## Risks
+
+The main product tradeoff is that when reaction fails, users may still see a visible fallback message. That is acceptable because visible acknowledgement is better than silent failure.
+
+There is still a possibility that a tenant-specific Feishu policy rejects both reply and create-message fallback. This design does not try to mask that case; it only guarantees the code will use all available ACK paths before giving up.
+
+## Acceptance Criteria
+
+1. The default ACK reaction value is changed from `Typing` to a reaction that succeeds for the deployed bot context.
+2. Normal inbound messages no longer fail immediately because of the default reaction config.
+3. If reaction fails, ACK falls back to text reply.
+4. If text reply fails, ACK falls back to creating a new message in the chat.
+5. The Feishu regression tests cover all three ACK branches.

--- a/tests/tool/test_bash_tool_pty_execution.py
+++ b/tests/tool/test_bash_tool_pty_execution.py
@@ -1,5 +1,6 @@
 """Integration tests for PTY execution in LocalExecutor."""
 
+import asyncio
 import time
 
 import pytest
@@ -103,3 +104,25 @@ class TestLocalExecutorPtyExecution:
                 use_pty=True,
                 timeout=0.1,
             )
+
+    @pytest.mark.asyncio
+    async def test_parallel_pty_commands_do_not_hang(self, executor):
+        """Regression test for PTY cleanup when concurrent commands finish quickly."""
+        find_result, pwd_result = await asyncio.wait_for(
+            asyncio.gather(
+                executor.execute_command(
+                    "find . -maxdepth 1 -type d | sort",
+                    use_pty=True,
+                ),
+                executor.execute_command(
+                    "pwd",
+                    use_pty=True,
+                ),
+            ),
+            timeout=2.0,
+        )
+
+        assert find_result.exit_code == 0
+        assert "." in find_result.stdout
+        assert pwd_result.exit_code == 0
+        assert str(executor.workspace_path) in pwd_result.stdout

--- a/tests/tool/test_bash_tool_pty_execution.py
+++ b/tests/tool/test_bash_tool_pty_execution.py
@@ -123,6 +123,6 @@ class TestLocalExecutorPtyExecution:
         )
 
         assert find_result.exit_code == 0
-        assert "." in find_result.stdout
+        assert find_result.stdout.splitlines()[0].strip() == "."
         assert pwd_result.exit_code == 0
         assert str(executor.workspace_path) in pwd_result.stdout


### PR DESCRIPTION
## What
Prevent short-lived PTY commands from hanging during cleanup by forcing the PTY reader to complete when the subprocess has already exited. This also adds a regression test for parallel PTY commands and includes the current superpowers planning/spec docs in the branch.

## Why
`process.wait()` can finish before the PTY reader observes EOF. Waiting on the reader unconditionally can leave concurrent fast PTY commands stuck in cleanup.

## How
Update `LocalExecutor` cleanup to stop the loop reader and mark the PTY reader as done when the process has already finished, then close the master FD. Add an async regression test covering concurrent `use_pty=True` commands that both finish quickly.

## Testing
- `uv run pytest tests/tool/test_bash_tool_pty_execution.py -v`
- `uv run python scripts/lint.py ci`
- `git push -u origin fix/bash-pty-cleanup` (triggered pre-push checks, including `uv run pytest tests/ -v --tb=short`, `uv run python scripts/check.py console-tests`, and `uv run python scripts/lint.py ci`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a deadlock issue that could occur during PTY command execution cleanup, particularly with concurrent commands.

* **Tests**
  * Added regression test for concurrent PTY command execution to prevent future hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->