### PR TITLE
refactor: clarify agent runtime mainline

### DIFF
--- a/agiwo/agent/compaction.py
+++ b/agiwo/agent/compaction.py
@@ -340,6 +340,17 @@ async def _compact(
         name="compact",
     )
     await commit_step(step, llm=llm_context, append_message=False)
+    completed_entries = await writer.record_llm_call_completed(
+        step=step,
+        llm=llm_context,
+    )
+    await state.session_runtime.project_run_log_entries(
+        completed_entries,
+        run_id=state.run_id,
+        agent_id=state.agent_id,
+        parent_run_id=state.parent_run_id,
+        depth=state.depth,
+    )
 
     response_content = step.content or ""
     analysis = parse_compact_response(response_content)

--- a/agiwo/agent/run_loop.py
+++ b/agiwo/agent/run_loop.py
@@ -70,18 +70,12 @@ class RunLoopOrchestrator:
         append_message: bool = True,
         track_state: bool = True,
     ) -> StepView:
+        del llm
         entries = await self.writer.commit_step(
             step,
             append_message=append_message,
             track_state=track_state,
         )
-        if llm is not None:
-            entries.extend(
-                await self.writer.record_llm_call_completed(
-                    step=step,
-                    llm=llm,
-                )
-            )
         await self._project_entries(entries)
         await self.context.hooks.on_step(step, self.context)
         return step
@@ -354,6 +348,10 @@ class RunLoopOrchestrator:
             self.runtime.abort_signal,
         )
         await self._commit_step(step, llm=llm_context)
+        entries = await self.writer.record_llm_call_completed(
+            step=step, llm=llm_context
+        )
+        await self._project_entries(entries)
         await self.context.hooks.after_llm_call(step, self.context)
         return step, llm_context
 

--- a/agiwo/agent/termination/summarizer.py
+++ b/agiwo/agent/termination/summarizer.py
@@ -70,6 +70,17 @@ async def maybe_generate_termination_summary(
         )
         step.name = "summary"
         await commit_step(step, llm=llm_context, append_message=False)
+        completed_entries = await writer.record_llm_call_completed(
+            step=step,
+            llm=llm_context,
+        )
+        await state.session_runtime.project_run_log_entries(
+            completed_entries,
+            run_id=state.run_id,
+            agent_id=state.agent_id,
+            parent_run_id=state.parent_run_id,
+            depth=state.depth,
+        )
 
         logger.info(
             "summary_generated",

--- a/tests/agent/test_compact.py
+++ b/tests/agent/test_compact.py
@@ -97,19 +97,13 @@ async def _commit_step_for_test(
     append_message: bool = True,
     track_state: bool = True,
 ) -> StepView:
+    del llm
     writer = RunStateWriter(state)
     entries = await writer.commit_step(
         step,
         append_message=append_message,
         track_state=track_state,
     )
-    if llm is not None:
-        entries.extend(
-            await writer.record_llm_call_completed(
-                step=step,
-                llm=llm,
-            )
-        )
     await state.session_runtime.project_run_log_entries(
         entries,
         run_id=state.run_id,

--- a/tests/agent/test_termination.py
+++ b/tests/agent/test_termination.py
@@ -98,19 +98,13 @@ async def _commit_step_for_test(
     append_message: bool = True,
     track_state: bool = True,
 ) -> StepView:
+    del llm
     writer = RunStateWriter(state)
     entries = await writer.commit_step(
         step,
         append_message=append_message,
         track_state=track_state,
     )
-    if llm is not None:
-        entries.extend(
-            await writer.record_llm_call_completed(
-                step=step,
-                llm=llm,
-            )
-        )
     await state.session_runtime.project_run_log_entries(
         entries,
         run_id=state.run_id,


### PR DESCRIPTION
## Summary
- move LLM completion logging out of the shared step commit path
- record completion facts explicitly in compaction, run loop, and termination summarization flows
- align compact/termination tests with the updated step commit contract

## Testing
- uv run pytest tests/agent/test_compact.py tests/agent/test_module_layout.py tests/agent/test_run_engine.py tests/agent/test_termination.py -v
- pre-push hook: uv run python scripts/lint.py ci
- pre-push hook: uv run pytest tests/ -v --tb=short
- pre-push hook: (cd console && uv run pytest tests/ -v --tb=short)