### PR TITLE
Add observability design and settle scheduler interruptions

### DIFF
--- a/agiwo/scheduler/runner_completion.py
+++ b/agiwo/scheduler/runner_completion.py
@@ -11,6 +11,7 @@ from agiwo.scheduler.models import AgentState, SchedulerEventType
 from agiwo.scheduler.runner_output import (
     build_last_run_result,
     is_failed_output,
+    is_interrupted_output,
     is_normal_completion,
     is_periodic_wake,
     is_sleeping_output,
@@ -58,6 +59,8 @@ class RunnerCompletionHandler:
             handled = await self._handle_shutdown_requested(state, text)
         elif is_failed_output(output):
             handled = await self._handle_failed_output(state, output, text)
+        elif is_interrupted_output(output):
+            handled = await self._handle_interrupted_output(state, output, text)
         elif is_sleeping_output(output):
             handled = await self._handle_sleeping(state, text)
         elif is_periodic_wake(action):
@@ -141,6 +144,39 @@ class RunnerCompletionHandler:
                     summary=text,
                     error=reason,
                 )
+            )
+        )
+        if state.is_child:
+            await self._ctx.emit_event_to_parent(
+                state,
+                SchedulerEventType.CHILD_FAILED,
+                {"reason": reason},
+            )
+        return True
+
+    async def _handle_interrupted_output(
+        self,
+        state: AgentState,
+        output: RunOutput,
+        text: str | None,
+    ) -> bool:
+        reason = output.termination_reason.value
+        last_run_result = build_last_run_result(
+            termination_reason=output.termination_reason,
+            run_id=output.run_id,
+            summary=text,
+        )
+        if state.is_root and state.is_persistent:
+            await self._ctx.save_state(
+                state.with_idle(result_summary=text or reason).with_updates(
+                    last_run_result=last_run_result
+                )
+            )
+            return True
+
+        await self._ctx.save_state(
+            state.with_failed(text or reason).with_updates(
+                last_run_result=last_run_result
             )
         )
         if state.is_child:

--- a/agiwo/scheduler/runner_output.py
+++ b/agiwo/scheduler/runner_output.py
@@ -12,6 +12,15 @@ _FAILED_TERMINATIONS = frozenset(
         TerminationReason.TIMEOUT,
     }
 )
+_INTERRUPTED_TERMINATIONS = frozenset(
+    {
+        TerminationReason.MAX_STEPS,
+        TerminationReason.MAX_OUTPUT_TOKENS,
+        TerminationReason.MAX_INPUT_TOKENS_PER_CALL,
+        TerminationReason.MAX_RUN_COST,
+        TerminationReason.TOOL_LIMIT,
+    }
+)
 
 
 def build_last_run_result(
@@ -31,6 +40,12 @@ def build_last_run_result(
 
 def is_failed_output(output: RunOutput) -> bool:
     return any(output.termination_reason is reason for reason in _FAILED_TERMINATIONS)
+
+
+def is_interrupted_output(output: RunOutput) -> bool:
+    return any(
+        output.termination_reason is reason for reason in _INTERRUPTED_TERMINATIONS
+    )
 
 
 def is_sleeping_output(output: RunOutput) -> bool:
@@ -58,6 +73,7 @@ def is_normal_completion(action: DispatchAction, output: RunOutput) -> bool:
 __all__ = [
     "build_last_run_result",
     "is_failed_output",
+    "is_interrupted_output",
     "is_normal_completion",
     "is_periodic_wake",
     "is_sleeping_output",

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -34,6 +34,7 @@ from agiwo.scheduler.models import (
 from agiwo.scheduler.formatting import build_wake_message
 from agiwo.scheduler.engine import Scheduler
 from agiwo.scheduler.store.memory import InMemoryAgentStateStorage
+from agiwo.tool import BaseTool, ToolContext, ToolResult
 
 
 _TEST_CLEANUP_WAIT_FIRST = 0.1
@@ -197,6 +198,33 @@ def _tool_call(
         ),
         StreamChunk(finish_reason="tool_calls"),
     ]
+
+
+class NoopTool(BaseTool):
+    @property
+    def name(self) -> str:
+        return "noop"
+
+    @property
+    def description(self) -> str:
+        return "Return a static result."
+
+    def get_parameters(self) -> dict:
+        return {"type": "object", "properties": {}, "additionalProperties": False}
+
+    async def execute(
+        self,
+        parameters: dict,
+        context: ToolContext,
+        abort_signal: AbortSignal | None = None,
+    ) -> ToolResult:
+        del context, abort_signal
+        return ToolResult.success(
+            tool_name=self.name,
+            tool_call_id="",
+            input_args=parameters,
+            content="ok",
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1140,6 +1168,61 @@ class TestSchedulerStream:
         assert items
         assert isinstance(items[-1], RunCompletedEvent)
         assert items[-1].response == "Second answer"
+
+    @pytest.mark.asyncio
+    async def test_persistent_root_max_steps_stream_settles_and_can_continue(self):
+        async with Scheduler(_fast_config()) as scheduler:
+            model = MockModel(
+                [
+                    _tool_call("noop"),
+                    _simple_completion("Continued answer"),
+                ]
+            )
+            agent = _make_agent(
+                name="stream-max-steps",
+                model=model,
+                id="stream-max-steps",
+                tools=[NoopTool()],
+                options=AgentOptions(
+                    max_steps=1,
+                    enable_termination_summary=False,
+                ),
+            )
+
+            first = await scheduler.route_root_input(
+                "first",
+                agent=agent,
+                session_id="sess-max-steps",
+                timeout=_TEST_RUN_TIMEOUT,
+                persistent=True,
+                stream_mode=RouteStreamMode.UNTIL_SETTLED,
+            )
+            first_items = [item async for item in first.stream]
+            state = await scheduler.get_state("stream-max-steps")
+
+            assert state is not None
+            assert state.status == AgentStateStatus.IDLE
+            assert state.last_run_result is not None
+            assert (
+                state.last_run_result.termination_reason == TerminationReason.MAX_STEPS
+            )
+            assert isinstance(first_items[-1], RunCompletedEvent)
+            assert first_items[-1].termination_reason == TerminationReason.MAX_STEPS
+
+            second = await scheduler.route_root_input(
+                "continue",
+                agent=agent,
+                state_id="stream-max-steps",
+                timeout=_TEST_RUN_TIMEOUT,
+                persistent=True,
+                stream_mode=RouteStreamMode.UNTIL_SETTLED,
+            )
+            second_items = [item async for item in second.stream]
+
+        assert second_items
+        assert isinstance(second_items[-1], RunCompletedEvent)
+        assert second_items[-1].response == "Continued answer"
+        assert second_items[-1].termination_reason == TerminationReason.COMPLETED
 
     @pytest.mark.asyncio
     async def test_stream_rejects_second_subscriber_for_same_root(self):


### PR DESCRIPTION
## Summary
- add the mainline/debug observability design doc
- classify resource-limit terminations as interrupted scheduler outputs
- settle persistent roots back to idle after interrupted runs while preserving last_run_result
- add regression coverage for persistent max-steps streams continuing after settlement

## Tests
- uv run pytest tests/scheduler/test_scheduler.py -k max_steps_stream_settles -v
- uv run python scripts/lint.py ci
- uv run pytest tests/ -v --tb=short
- uv run python scripts/check.py console-tests