### PR TITLE
Improve console step display

### DIFF
--- a/console/web/src/app/sessions/[id]/page.test.tsx
+++ b/console/web/src/app/sessions/[id]/page.test.tsx
@@ -9,6 +9,8 @@ const apiMocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "sess-1" }),
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/lib/api", async () => {

--- a/console/web/src/app/sessions/[id]/page.tsx
+++ b/console/web/src/app/sessions/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Workflow } from "lucide-react";
 import { BackHeader } from "@/components/back-header";
 import { MetricCard } from "@/components/metric-card";
@@ -12,6 +12,7 @@ import { ConversationEventList } from "@/components/session-detail/conversation-
 import { MilestoneBoard } from "@/components/session-detail/milestone-board";
 import { SessionObservabilityPanel } from "@/components/session-detail/session-observability-panel";
 import { SessionStepCard } from "@/components/session-detail/session-step-card";
+import { contentText } from "@/components/step-content-preview";
 import {
   useSessionDetailResource,
   useSessionRunsPage,
@@ -33,12 +34,37 @@ import {
 import { getSchedulerRunResultView } from "@/lib/scheduler-run-result";
 import { formatLocalDateTime } from "@/lib/time";
 
+type StepRoleFilter = "all" | "user" | "assistant" | "tool";
+
+function stepMatchesSearch(step: { content: unknown; content_for_user: string | null; name: string | null; role: string; sequence: number }, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    step.role,
+    String(step.sequence),
+    step.name ?? "",
+    step.content_for_user ?? "",
+    contentText(step.content) ?? "",
+    JSON.stringify(step.content ?? ""),
+  ]
+    .join("\n")
+    .toLowerCase();
+  return haystack.includes(query.toLowerCase());
+}
+
 export default function SessionDetailPage() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const sessionId = params.id as string;
-  const [viewMode, setViewMode] = useState<"mainline" | "debug">("mainline");
+  const [viewMode, setViewMode] = useState<"mainline" | "debug">(
+    searchParams.get("view") === "debug" ? "debug" : "mainline",
+  );
   const [runsOffset, setRunsOffset] = useState(0);
   const [runsPageSize, setRunsPageSize] = useState(50);
+  const [stepRoleFilter, setStepRoleFilter] = useState<StepRoleFilter>("all");
+  const [stepSearch, setStepSearch] = useState("");
   const debugActive = viewMode === "debug";
   const detailState = useSessionDetailResource(sessionId);
   const runsState = useSessionRunsPage(
@@ -72,6 +98,26 @@ export default function SessionDetailPage() {
       })),
     [runs],
   );
+  const filteredSteps = useMemo(
+    () =>
+      steps.filter((step) => {
+        if (stepRoleFilter !== "all" && step.role !== stepRoleFilter) {
+          return false;
+        }
+        return stepMatchesSearch(step, stepSearch.trim());
+      }),
+    [stepRoleFilter, stepSearch, steps],
+  );
+  const updateViewMode = (nextViewMode: "mainline" | "debug") => {
+    setViewMode(nextViewMode);
+    const next = new URLSearchParams(searchParams.toString());
+    if (nextViewMode === "debug") {
+      next.set("view", "debug");
+    } else {
+      next.delete("view");
+    }
+    router.replace(`/sessions/${sessionId}${next.toString() ? `?${next}` : ""}`);
+  };
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -165,7 +211,7 @@ export default function SessionDetailPage() {
             <button
               type="button"
               aria-pressed={viewMode === "mainline"}
-              onClick={() => setViewMode("mainline")}
+              onClick={() => updateViewMode("mainline")}
               className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
                 viewMode === "mainline"
                   ? "border-accent bg-panel-strong text-foreground"
@@ -177,7 +223,7 @@ export default function SessionDetailPage() {
             <button
               type="button"
               aria-pressed={viewMode === "debug"}
-              onClick={() => setViewMode("debug")}
+              onClick={() => updateViewMode("debug")}
               className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
                 viewMode === "debug"
                   ? "border-accent bg-panel-strong text-foreground"
@@ -314,8 +360,13 @@ export default function SessionDetailPage() {
                 </EmptyStateMessage>
               ) : (
                 <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-sm font-medium text-zinc-300">Steps</h2>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h2 className="text-sm font-medium text-zinc-300">Steps</h2>
+                      <p className="text-xs text-zinc-500">
+                        Showing {filteredSteps.length} of {steps.length}
+                      </p>
+                    </div>
                     {stepsState.hasMore && (
                       <button
                         type="button"
@@ -327,7 +378,40 @@ export default function SessionDetailPage() {
                       </button>
                     )}
                   </div>
-                  {steps.map((step) => (
+                  <div className="grid gap-3 rounded-lg border border-zinc-800 bg-zinc-900 p-3 md:grid-cols-[1fr_auto]">
+                    <label className="space-y-1">
+                      <span className="text-xs uppercase tracking-wide text-zinc-500">Search steps</span>
+                      <input
+                        value={stepSearch}
+                        onChange={(event) => setStepSearch(event.target.value)}
+                        placeholder="tool name, content, sequence"
+                        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600"
+                      />
+                    </label>
+                    <div className="flex items-end gap-1">
+                      {(["all", "user", "assistant", "tool"] as StepRoleFilter[]).map((role) => (
+                        <button
+                          key={role}
+                          type="button"
+                          aria-pressed={stepRoleFilter === role}
+                          onClick={() => setStepRoleFilter(role)}
+                          className={`rounded-full border px-3 py-1.5 text-xs capitalize transition-colors ${
+                            stepRoleFilter === role
+                              ? "border-accent bg-panel-strong text-foreground"
+                              : "border-line text-ink-muted hover:border-line-strong hover:text-foreground"
+                          }`}
+                        >
+                          {role}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  {filteredSteps.length === 0 ? (
+                    <EmptyStateMessage className="text-zinc-500 text-center py-8">
+                      No steps match the current filters
+                    </EmptyStateMessage>
+                  ) : null}
+                  {filteredSteps.map((step) => (
                     <SessionStepCard key={step.id} step={step} />
                   ))}
                 </div>

--- a/console/web/src/app/sessions/page.tsx
+++ b/console/web/src/app/sessions/page.tsx
@@ -110,16 +110,15 @@ export default function SessionsPage() {
       ) : (
         <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 divide-y divide-zinc-800 overflow-hidden">
           {sessions.map((s) => (
-            <Link
+            <div
               key={s.session_id}
-              href={`/sessions/${s.session_id}`}
               className={cn(
-                "group block px-5 py-4 transition-colors duration-150",
+                "grid gap-4 px-5 py-4 transition-colors duration-150 md:grid-cols-[1fr_auto]",
                 "hover:bg-zinc-800/50"
               )}
             >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 min-w-0">
+              <Link href={`/sessions/${s.session_id}`} className="min-w-0">
+                <div className="min-w-0">
                   <div className="text-sm text-zinc-200">
                     <UserInputCompact
                       input={s.last_user_input}
@@ -135,30 +134,31 @@ export default function SessionsPage() {
                     </p>
                   )}
                 </div>
-                <div className="text-right shrink-0 space-y-1.5">
-                  <div className="flex items-center justify-end gap-2">
+              </Link>
+              <div className="flex shrink-0 items-start justify-between gap-3 md:justify-end">
+                <div className="space-y-1.5 text-left md:text-right">
+                  <div className="flex flex-wrap items-center gap-2 md:justify-end">
                     <PillBadge variant="default">{s.run_count} runs</PillBadge>
-                    <MonoText truncate className="max-w-[120px]">{s.agent_id || "unknown"}</MonoText>
+                    <PillBadge variant="pending">{s.step_count} steps</PillBadge>
                   </div>
-                  <div className="flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={(e) => handleDelete(s.session_id, e)}
-                      className={cn(
-                        "p-1.5 rounded-md text-zinc-500 hover:text-red-400 hover:bg-red-900/20",
-                        "transition-colors duration-150"
-                      )}
-                      aria-label={`Delete session ${s.session_id.slice(0, 8)}`}
-                    >
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
-                    <p className="text-[11px] text-zinc-500">
-                      {formatRelativeTime(s.updated_at)}
-                    </p>
-                  </div>
+                  <MonoText truncate className="block max-w-[180px]">{s.agent_id || "unknown"}</MonoText>
+                  <p className="text-[11px] text-zinc-500">
+                    {formatRelativeTime(s.updated_at)}
+                  </p>
                 </div>
+                <button
+                  type="button"
+                  onClick={(e) => handleDelete(s.session_id, e)}
+                  className={cn(
+                    "rounded-md p-1.5 text-zinc-500 transition-colors duration-150",
+                    "hover:bg-red-900/20 hover:text-red-400"
+                  )}
+                  aria-label={`Delete session ${s.session_id.slice(0, 8)}`}
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
               </div>
-            </Link>
+            </div>
           ))}
         </div>
       )}

--- a/console/web/src/app/traces/[id]/page.test.tsx
+++ b/console/web/src/app/traces/[id]/page.test.tsx
@@ -7,6 +7,8 @@ const apiMocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "trace-1" }),
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/lib/api", async () => {

--- a/console/web/src/app/traces/[id]/page.tsx
+++ b/console/web/src/app/traces/[id]/page.tsx
@@ -12,6 +12,7 @@ import { SectionCard } from "@/components/section-card";
 import { ErrorStateMessage, FullPageMessage } from "@/components/state-message";
 import { TokenMetricsBadges } from "@/components/token-metrics-badges";
 import { TokenSummaryCards } from "@/components/token-summary-cards";
+import { TraceDiagnostics } from "@/components/trace-detail/trace-diagnostics";
 import { TraceLlmCalls } from "@/components/trace-detail/trace-llm-calls";
 import { TraceLoopTimeline } from "@/components/trace-detail/trace-loop-timeline";
 import { TraceMainlineEvents } from "@/components/trace-detail/trace-mainline-events";
@@ -485,6 +486,7 @@ export default function TraceDetailPage() {
         </div>
       ) : (
         <>
+          <TraceDiagnostics trace={trace} />
           <TraceLlmCalls llmCalls={trace.llm_calls} />
           <TraceRuntimeDecisions decisions={trace.runtime_decisions} />
           <TraceLoopTimeline events={trace.timeline_events} />

--- a/console/web/src/app/traces/[id]/page.tsx
+++ b/console/web/src/app/traces/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Activity, Clock, Cpu, Flag, GitBranch, Wrench, Zap } from "lucide-react";
 import { BackHeader } from "@/components/back-header";
 import { JsonDisclosure } from "@/components/json-disclosure";
@@ -18,8 +18,13 @@ import { TraceMainlineEvents } from "@/components/trace-detail/trace-mainline-ev
 import { TraceReviewCycles } from "@/components/trace-detail/trace-review-cycles";
 import { TraceRuntimeDecisions } from "@/components/trace-detail/trace-runtime-decisions";
 import { TraceStatusBadge } from "@/components/trace-status-badge";
+import {
+  StepContentPreview,
+  StructuredValuePreview,
+  ToolCallPreviewList,
+} from "@/components/step-content-preview";
 import { getTrace } from "@/lib/api";
-import type { TraceDetail, SpanResponse } from "@/lib/api";
+import type { ToolCallPayload, TraceDetail, SpanResponse } from "@/lib/api";
 import { latestAlignment, latestObjective } from "@/lib/insights";
 import {
   formatDurationMs,
@@ -92,8 +97,61 @@ function TraceInsightRail({ trace }: TraceInsightRailProps) {
           </span>
         </div>
       </div>
+      {trace.final_output ? (
+        <div className="rounded-xl border border-line bg-panel px-4 py-3 lg:col-span-4">
+          <div className="mb-2 text-xs uppercase tracking-wide text-ink-faint">
+            Final Output Preview
+          </div>
+          <p className="line-clamp-3 text-sm leading-6 text-foreground">
+            {trace.final_output}
+          </p>
+        </div>
+      ) : null}
     </div>
   );
+}
+
+function SpanDetailPreview({ span }: { span: SpanResponse }) {
+  if (span.kind === "llm_call" && span.llm_details) {
+    const toolCalls: ToolCallPayload[] = Array.isArray(
+      span.llm_details.response_tool_calls,
+    )
+      ? (span.llm_details.response_tool_calls as ToolCallPayload[])
+      : [];
+    return (
+      <div className="space-y-3 rounded-lg border border-line bg-panel px-3 py-3">
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Response</div>
+          <StepContentPreview
+            value={span.llm_details.response_content}
+            emptyLabel="No assistant response content"
+          />
+        </div>
+        {toolCalls.length > 0 ? <ToolCallPreviewList toolCalls={toolCalls} /> : null}
+      </div>
+    );
+  }
+
+  if (span.kind === "tool_call" && span.tool_details) {
+    const output =
+      span.tool_details.content_for_user ??
+      span.tool_details.output ??
+      span.tool_details.error;
+    return (
+      <div className="space-y-3 rounded-lg border border-line bg-panel px-3 py-3">
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
+          <StructuredValuePreview value={span.tool_details.input_args ?? {}} />
+        </div>
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
+          <StepContentPreview value={output} emptyLabel="No tool result content" />
+        </div>
+      </div>
+    );
+  }
+
+  return null;
 }
 
 /**
@@ -218,6 +276,8 @@ function SpanRow({
             </div>
           )}
 
+          <SpanDetailPreview span={span} />
+
           {span.llm_details && (
             <JsonDisclosure label="LLM Details" value={span.llm_details} />
           )}
@@ -251,12 +311,16 @@ function SpanRow({
  */
 export default function TraceDetailPage() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const traceId = params.id as string;
   const [trace, setTrace] = useState<TraceDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedSpans, setExpandedSpans] = useState<Set<string>>(new Set());
-  const [viewMode, setViewMode] = useState<"mainline" | "debug">("mainline");
+  const [viewMode, setViewMode] = useState<"mainline" | "debug">(
+    searchParams.get("view") === "debug" ? "debug" : "mainline",
+  );
 
   useEffect(() => {
     getTrace(traceId)
@@ -278,6 +342,17 @@ export default function TraceDetailPage() {
       else next.add(spanId);
       return next;
     });
+  };
+
+  const updateViewMode = (nextViewMode: "mainline" | "debug") => {
+    setViewMode(nextViewMode);
+    const next = new URLSearchParams(searchParams.toString());
+    if (nextViewMode === "debug") {
+      next.set("view", "debug");
+    } else {
+      next.delete("view");
+    }
+    router.replace(`/traces/${traceId}${next.toString() ? `?${next}` : ""}`);
   };
 
   if (loading) {
@@ -370,7 +445,7 @@ export default function TraceDetailPage() {
         <button
           type="button"
           aria-pressed={viewMode === "mainline"}
-          onClick={() => setViewMode("mainline")}
+          onClick={() => updateViewMode("mainline")}
           className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
             viewMode === "mainline"
               ? "border-accent bg-panel-strong text-foreground"
@@ -382,7 +457,7 @@ export default function TraceDetailPage() {
         <button
           type="button"
           aria-pressed={viewMode === "debug"}
-          onClick={() => setViewMode("debug")}
+          onClick={() => updateViewMode("debug")}
           className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
             viewMode === "debug"
               ? "border-accent bg-panel-strong text-foreground"

--- a/console/web/src/app/traces/page.tsx
+++ b/console/web/src/app/traces/page.tsx
@@ -8,12 +8,14 @@ import {
   ErrorStateMessage,
   TextStateMessage,
 } from "@/components/state-message";
+import { CopyButton } from "@/components/copy-button";
+import { MonoText } from "@/components/mono-text";
 import { PaginationControls } from "@/components/pagination-controls";
 import { TraceStatusBadge } from "@/components/trace-status-badge";
 import { listTraces } from "@/lib/api";
 import type { TraceListItem } from "@/lib/api";
 import { formatTokenCount, formatUsd } from "@/lib/metrics";
-import { formatRoundedMs } from "@/lib/time";
+import { formatLocalDateTime, formatRoundedMs } from "@/lib/time";
 
 const TRACE_STATUS_FILTERS = [
   { label: "All", value: "" },
@@ -208,17 +210,16 @@ function TracesPageContent() {
           <table className="w-full text-sm">
             <thead className="bg-zinc-900 text-zinc-400 text-xs uppercase tracking-wide">
               <tr>
-                <th className="text-left px-4 py-3">Input</th>
+                <th className="text-left px-4 py-3">Trace</th>
+                <th className="text-left px-4 py-3">Input / Output</th>
+                <th className="text-left px-4 py-3">Session</th>
                 <th className="text-left px-4 py-3">Agent</th>
                 <th className="text-center px-4 py-3">Status</th>
                 <th className="text-right px-4 py-3">Cost</th>
-                <th className="text-right px-4 py-3">Input</th>
-                <th className="text-right px-4 py-3">Output</th>
-                <th className="text-right px-4 py-3">Total</th>
-                <th className="text-right px-4 py-3">Cache R/C</th>
-                <th className="text-right px-4 py-3">LLM</th>
-                <th className="text-right px-4 py-3">Tools</th>
+                <th className="text-right px-4 py-3">Tokens</th>
+                <th className="text-right px-4 py-3">Calls</th>
                 <th className="text-right px-4 py-3">Duration</th>
+                <th className="text-right px-4 py-3">Started</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-800">
@@ -227,16 +228,58 @@ function TracesPageContent() {
                   key={t.trace_id}
                   className="hover:bg-zinc-900/50 transition-colors"
                 >
-                  <td className="px-4 py-3 max-w-xs">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={`/traces/${t.trace_id}`}
+                        className="font-mono text-xs text-zinc-200 transition-colors hover:text-white"
+                      >
+                        {t.trace_id.slice(0, 12)}
+                      </Link>
+                      <CopyButton
+                        value={t.trace_id}
+                        label="Copy"
+                        className="h-5 px-1.5"
+                      />
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 min-w-[20rem] max-w-md">
                     <Link
                       href={`/traces/${t.trace_id}`}
-                      className="text-zinc-200 hover:text-white block"
+                      className="block text-zinc-200 transition-colors hover:text-white"
                     >
-                      {t.input_query || t.trace_id.slice(0, 12)}
+                      <span className="line-clamp-2">
+                        {t.input_query || "Trace detail"}
+                      </span>
+                      {t.final_output ? (
+                        <span className="mt-1 block truncate text-xs text-zinc-500">
+                          {t.final_output}
+                        </span>
+                      ) : null}
                     </Link>
                   </td>
                   <td className="px-4 py-3 text-zinc-400">
-                    {t.agent_id || "-"}
+                    {t.session_id ? (
+                      <Link
+                        href={`/sessions/${t.session_id}`}
+                        className="transition-colors hover:text-zinc-200"
+                      >
+                        <MonoText truncate className="max-w-[9rem]">
+                          {t.session_id}
+                        </MonoText>
+                      </Link>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">
+                    {t.agent_id ? (
+                      <MonoText truncate className="max-w-[9rem]">
+                        {t.agent_id}
+                      </MonoText>
+                    ) : (
+                      "-"
+                    )}
                   </td>
                   <td className="px-4 py-3 text-center">
                     <TraceStatusBadge status={t.status} />
@@ -245,25 +288,20 @@ function TracesPageContent() {
                     {formatUsd(t.total_token_cost)}
                   </td>
                   <td className="px-4 py-3 text-right text-zinc-400">
-                    {formatTokenCount(t.total_input_tokens)}
+                    <div>{formatTokenCount(t.total_tokens)}</div>
+                    <div className="text-[11px] text-zinc-500">
+                      {formatTokenCount(t.total_input_tokens)} in / {formatTokenCount(t.total_output_tokens)} out
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-right text-zinc-400">
-                    {formatTokenCount(t.total_output_tokens)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    {formatTokenCount(t.total_tokens)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-500">
-                    {formatTokenCount(t.total_cache_read_tokens)} / {formatTokenCount(t.total_cache_creation_tokens)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    {t.total_llm_calls}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    {t.total_tool_calls}
+                    <div>{t.total_llm_calls} llm</div>
+                    <div className="text-[11px] text-zinc-500">{t.total_tool_calls} tools</div>
                   </td>
                   <td className="px-4 py-3 text-right text-zinc-400">
                     {formatRoundedMs(t.duration_ms)}
+                  </td>
+                  <td className="px-4 py-3 text-right text-xs text-zinc-500">
+                    {formatLocalDateTime(t.start_time)}
                   </td>
                 </tr>
               ))}

--- a/console/web/src/components/copy-button.tsx
+++ b/console/web/src/components/copy-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export function CopyButton({
+  value,
+  label = "Copy",
+  className,
+}: {
+  value: string;
+  label?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copyValue = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copyValue}
+      className={cn(
+        "inline-flex h-6 items-center gap-1 rounded border border-line px-1.5 text-[11px] text-ink-faint transition-colors hover:border-line-strong hover:text-foreground",
+        className,
+      )}
+      aria-label={`${label}: ${value}`}
+      title={label}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      <span>{copied ? "Copied" : label}</span>
+    </button>
+  );
+}
+
+export default CopyButton;

--- a/console/web/src/components/json-disclosure.test.tsx
+++ b/console/web/src/components/json-disclosure.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { JsonDisclosure } from "./json-disclosure";
+
+describe("JsonDisclosure", () => {
+  test("copies the serialized JSON without expanding first", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<JsonDisclosure label="Raw step JSON" value={{ role: "assistant" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Raw step JSON" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('{\n  "role": "assistant"\n}');
+    });
+    expect(screen.getByText("Copied")).toBeInTheDocument();
+  });
+});

--- a/console/web/src/components/json-disclosure.tsx
+++ b/console/web/src/components/json-disclosure.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -50,29 +50,55 @@ export function JsonDisclosure({
   contentClassName,
 }: JsonDisclosureProps) {
   const [expanded, setExpanded] = useState(false);
-  const serialized = useMemo(
-    () => (expanded ? JSON.stringify(value, null, 2) : null),
-    [expanded, value],
-  );
+  const [copied, setCopied] = useState(false);
+  const serialized = useMemo(() => JSON.stringify(value, null, 2), [value]);
+  const copyLabel = label.toLowerCase().includes("json")
+    ? `Copy ${label}`
+    : `Copy ${label} JSON`;
+
+  const copyJson = async () => {
+    if (!serialized) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(serialized);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      setCopied(false);
+    }
+  };
 
   return (
     <div className={cn("rounded-xl border border-line bg-panel-muted", className)}>
-      <button
-        type="button"
-        aria-expanded={expanded}
-        onClick={() => {
-          setExpanded((current) => !current);
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-ink-muted transition-colors hover:text-foreground"
-      >
-        {expanded ? (
-          <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-        )}
-        <span className="font-medium">{label}</span>
-        <span className="ml-auto text-[11px] text-ink-faint">{summarizeValue(value)}</span>
-      </button>
+      <div className="flex items-center gap-1 px-3 py-2 text-xs text-ink-muted">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => {
+            setExpanded((current) => !current);
+          }}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left transition-colors hover:text-foreground"
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+          )}
+          <span className="font-medium">{label}</span>
+          <span className="ml-auto text-[11px] text-ink-faint">{summarizeValue(value)}</span>
+        </button>
+        <button
+          type="button"
+          onClick={copyJson}
+          className="inline-flex h-6 items-center gap-1 rounded border border-line px-1.5 text-[11px] text-ink-faint transition-colors hover:border-line-strong hover:text-foreground"
+          aria-label={copyLabel}
+          title={copyLabel}
+        >
+          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          <span>{copied ? "Copied" : "Copy"}</span>
+        </button>
+      </div>
       {expanded && (
         <pre
           className={cn(

--- a/console/web/src/components/session-detail/conversation-event-list.tsx
+++ b/console/web/src/components/session-detail/conversation-event-list.tsx
@@ -74,40 +74,42 @@ export function ConversationEventList({
           No conversation events for the selected filter.
         </div>
       ) : (
-        filteredEvents.map((event) => (
-          <details
-            key={event.id}
-            className={`rounded-xl border px-3 py-3 ${eventCardClass(event)}`}
-          >
-            <summary className="cursor-pointer list-none">
-              <div className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">
-                    {event.title}
-                  </span>
-                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                    {event.kind}
-                  </span>
-                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                    {event.priority}
-                  </span>
-                  <span className="text-xs text-ink-muted">
-                    seq {event.sequence ?? "-"}
-                  </span>
+        <div className="relative space-y-3 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
+          {filteredEvents.map((event) => (
+            <details
+              key={event.id}
+              className={`group relative ml-10 rounded-xl border px-3 py-3 ${eventCardClass(event)}`}
+            >
+              <summary className="cursor-pointer list-none">
+                <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel font-mono text-[11px] text-ink-muted">
+                  {event.sequence ?? "-"}
                 </div>
-                <p className="text-sm text-foreground">{event.summary}</p>
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">
+                      {event.title}
+                    </span>
+                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
+                      {event.kind}
+                    </span>
+                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
+                      {event.priority}
+                    </span>
+                  </div>
+                  <p className="text-sm text-foreground">{event.summary}</p>
+                </div>
+              </summary>
+              <div className="mt-3">
+                <JsonDisclosure
+                  label="Details"
+                  value={event.details}
+                  className="bg-panel"
+                  contentClassName="bg-panel"
+                />
               </div>
-            </summary>
-            <div className="mt-3">
-              <JsonDisclosure
-                label="Details"
-                value={event.details}
-                className="bg-panel"
-                contentClassName="bg-panel"
-              />
-            </div>
-          </details>
-        ))
+            </details>
+          ))}
+        </div>
       )}
     </SectionCard>
   );

--- a/console/web/src/components/session-detail/session-step-card.test.tsx
+++ b/console/web/src/components/session-detail/session-step-card.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { StepResponse } from "@/lib/api";
+
+import { SessionStepCard } from "./session-step-card";
+
+function buildStep(partial: Partial<StepResponse>): StepResponse {
+  return {
+    id: "step-1",
+    session_id: "session-1",
+    run_id: "run-1",
+    sequence: 3,
+    role: "assistant",
+    agent_id: "agent-1",
+    content: null,
+    content_for_user: null,
+    reasoning_content: null,
+    user_input: null,
+    tool_calls: null,
+    tool_call_id: null,
+    name: null,
+    metrics: null,
+    created_at: null,
+    parent_run_id: null,
+    depth: 0,
+    ...partial,
+  };
+}
+
+describe("SessionStepCard", () => {
+  test("shows assistant message content before raw JSON", () => {
+    render(
+      <SessionStepCard
+        step={buildStep({
+          content: [{ type: "text", text: "Assistant visible answer" }],
+          content_for_user: "User-facing answer",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("User-facing answer")).toBeInTheDocument();
+    expect(screen.getByText("Raw step JSON")).toBeInTheDocument();
+  });
+
+  test("shows tool result content and tool call arguments semantically", () => {
+    render(
+      <SessionStepCard
+        step={buildStep({
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: '{"query":"agiwo console"}',
+              },
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("web_search")).toBeInTheDocument();
+    expect(screen.getAllByText(/agiwo console/).length).toBeGreaterThan(0);
+
+    render(
+      <SessionStepCard
+        step={buildStep({
+          id: "tool-step",
+          role: "tool",
+          sequence: 4,
+          name: "web_search",
+          content: { status: "ok", result: "Search result body" },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("result")).toBeInTheDocument();
+    expect(screen.getByText("Search result body")).toBeInTheDocument();
+  });
+});

--- a/console/web/src/components/session-detail/session-step-card.tsx
+++ b/console/web/src/components/session-detail/session-step-card.tsx
@@ -1,34 +1,17 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { Bot, ChevronDown, ChevronRight, User, Wrench } from "lucide-react";
+import { Bot, User, Wrench } from "lucide-react";
 
+import {
+  RawJsonBlock,
+  StepContentPreview,
+  ToolCallPreviewList,
+  contentText,
+} from "@/components/step-content-preview";
 import { TokenMetricsBadges } from "@/components/token-metrics-badges";
 import { UserInputDetail } from "@/components/user-input-detail";
-import type { StepResponse, ToolCallPayload } from "@/lib/api";
+import type { StepResponse } from "@/lib/api";
 import { parseGenericMetrics } from "@/lib/metrics";
-
-function StepCardOriginalToggle({ content }: { content: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const toggle = useCallback(() => setExpanded((prev) => !prev), []);
-  return (
-    <div className="mt-1">
-      <button
-        type="button"
-        onClick={toggle}
-        className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
-      >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        {expanded ? "Hide original result" : "View original result"}
-      </button>
-      {expanded && (
-        <div className="mt-1 max-h-64 overflow-auto rounded bg-zinc-800/50 px-3 py-2 text-xs text-zinc-400 whitespace-pre-wrap">
-          {content}
-        </div>
-      )}
-    </div>
-  );
-}
 
 export function SessionStepCard({ step }: { step: StepResponse }) {
   const isUser = step.role === "user";
@@ -36,17 +19,18 @@ export function SessionStepCard({ step }: { step: StepResponse }) {
   const isTool = step.role === "tool";
   const metrics = parseGenericMetrics(step.metrics ?? undefined);
 
-  const getToolLabel = (toolCall: ToolCallPayload): string =>
-    toolCall.function?.name || "tool_call";
-  const getToolArgs = (toolCall: ToolCallPayload): string =>
-    toolCall.function?.arguments || JSON.stringify(toolCall);
-
   const hasStructuredUserInput =
     isUser && step.user_input !== null && step.user_input !== undefined;
   const hasCondensed = isTool && typeof step.condensed_content === "string";
-  const displayContent = hasCondensed ? step.condensed_content : step.content;
-  const originalContent =
-    hasCondensed && typeof step.content === "string" ? step.content : null;
+  const assistantContent =
+    step.content_for_user ?? contentText(step.content) ?? step.content;
+  const toolContent = step.condensed_content ?? step.content_for_user ?? step.content;
+  const displayContent = isAssistant
+    ? assistantContent
+    : isTool
+      ? toolContent
+      : step.content;
+  const originalContent = hasCondensed ? step.content : null;
 
   return (
     <div
@@ -83,30 +67,25 @@ export function SessionStepCard({ step }: { step: StepResponse }) {
         </div>
       )}
 
-      {!hasStructuredUserInput && Boolean(displayContent) && (
-        <div className="max-h-96 overflow-auto">
-          <div className="text-sm whitespace-pre-wrap break-words">
-            {typeof displayContent === "string"
-              ? displayContent
-              : JSON.stringify(displayContent, null, 2)}
-          </div>
-        </div>
+      {!hasStructuredUserInput && (
+        <StepContentPreview
+          value={displayContent}
+          emptyLabel={
+            isAssistant
+              ? "No assistant message content"
+              : isTool
+                ? "No tool result content"
+                : "No step content"
+          }
+        />
       )}
 
-      {originalContent && <StepCardOriginalToggle content={originalContent} />}
+      {originalContent !== null && originalContent !== undefined && (
+        <RawJsonBlock className="mt-3" label="Original result" value={originalContent} />
+      )}
 
       {step.tool_calls && step.tool_calls.length > 0 && (
-        <div className="mt-2 space-y-1">
-          {step.tool_calls.map((toolCall, index) => (
-            <div
-              key={index}
-              className="max-h-48 overflow-auto rounded bg-zinc-800/50 px-3 py-2 font-mono text-xs"
-            >
-              <span className="text-amber-400">{getToolLabel(toolCall)}</span>
-              <span className="ml-2 text-zinc-500">{getToolArgs(toolCall)}</span>
-            </div>
-          ))}
-        </div>
+        <ToolCallPreviewList toolCalls={step.tool_calls} />
       )}
 
       {step.metrics && (
@@ -119,6 +98,8 @@ export function SessionStepCard({ step }: { step: StepResponse }) {
           />
         </div>
       )}
+
+      <RawJsonBlock className="mt-3" label="Raw step JSON" value={step} />
     </div>
   );
 }

--- a/console/web/src/components/step-content-preview.tsx
+++ b/console/web/src/components/step-content-preview.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { Wrench } from "lucide-react";
+
+import { JsonDisclosure } from "@/components/json-disclosure";
+import type { ToolCallPayload } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function stringifyPretty(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (typeof value === "string") {
+    const parsed = tryParseJson(value);
+    if (parsed !== null) {
+      return JSON.stringify(parsed, null, 2);
+    }
+    return value;
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+export function contentText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.trim().length > 0 ? value : null;
+  }
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) =>
+        item && typeof item === "object" && "text" in item && typeof item.text === "string"
+          ? item.text
+          : "",
+      )
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join("\n") : null;
+  }
+  return null;
+}
+
+function compactText(value: string, maxLength = 220): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function inlineValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (typeof value === "string") {
+    return compactText(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return "[]";
+    }
+    if (value.every((item) => ["string", "number", "boolean"].includes(typeof item))) {
+      return compactText(value.join(", "));
+    }
+    return `${value.length} items`;
+  }
+  if (typeof value === "object") {
+    return `${Object.keys(value).length} fields`;
+  }
+  return String(value);
+}
+
+export function StructuredValuePreview({
+  value,
+  className,
+}: {
+  value: unknown;
+  className?: string;
+}) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <div className="text-sm text-ink-faint">Empty list</div>;
+    }
+    return (
+      <div className={cn("space-y-2 text-sm", className)}>
+        {value.slice(0, 6).map((item, index) => (
+          <div key={index} className="rounded-md bg-panel-muted px-3 py-2 text-ink-soft break-words">
+            {inlineValue(item)}
+          </div>
+        ))}
+        {value.length > 6 ? (
+          <div className="text-xs text-ink-faint">{value.length - 6} more items in raw JSON</div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!value || typeof value !== "object") {
+    return (
+      <div className={cn("text-sm leading-6 text-ink-soft whitespace-pre-wrap break-words", className)}>
+        {inlineValue(value)}
+      </div>
+    );
+  }
+
+  const entries = Object.entries(value).filter(([, item]) => item !== null && item !== undefined);
+  if (entries.length === 0) {
+    return <div className="text-sm text-ink-faint">Empty object</div>;
+  }
+
+  return (
+    <dl className={cn("grid gap-2 text-sm", className)}>
+      {entries.slice(0, 8).map(([key, item]) => (
+        <div key={key} className="grid gap-1 rounded-md bg-panel-muted px-3 py-2 sm:grid-cols-[9rem_1fr]">
+          <dt className="font-mono text-xs text-ink-faint">{key}</dt>
+          <dd className="min-w-0 text-ink-soft break-words">{inlineValue(item)}</dd>
+        </div>
+      ))}
+      {entries.length > 8 ? (
+        <div className="text-xs text-ink-faint">{entries.length - 8} more fields in raw JSON</div>
+      ) : null}
+    </dl>
+  );
+}
+
+export function StepContentPreview({
+  value,
+  emptyLabel,
+}: {
+  value: unknown;
+  emptyLabel: string;
+}) {
+  const text = contentText(value);
+  if (text) {
+    return (
+      <div className="max-h-96 overflow-auto text-sm leading-6 text-ink-soft whitespace-pre-wrap break-words">
+        {text}
+      </div>
+    );
+  }
+
+  if (value !== null && value !== undefined) {
+    return (
+      <div className="max-h-96 overflow-auto">
+        <StructuredValuePreview value={value} />
+      </div>
+    );
+  }
+
+  return <div className="text-sm text-ink-faint">{emptyLabel}</div>;
+}
+
+export function ToolCallPreviewList({ toolCalls }: { toolCalls: ToolCallPayload[] }) {
+  if (toolCalls.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {toolCalls.map((toolCall, index) => {
+        const toolName = toolCall.function?.name || "tool_call";
+        const args = toolCall.function?.arguments ?? toolCall;
+        return (
+          <details key={`${toolName}-${toolCall.id ?? index}`} className="rounded-lg border border-line bg-panel-muted">
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs">
+              <Wrench className="h-3.5 w-3.5 text-warning" />
+              <span className="font-medium text-ink-soft">{toolName}</span>
+              {toolCall.id ? (
+                <span className="font-mono text-[11px] text-ink-faint">{toolCall.id}</span>
+              ) : null}
+              <span className="ml-auto max-w-72 truncate font-mono text-[11px] text-ink-faint">
+                {compactText(stringifyPretty(args), 160)}
+              </span>
+            </summary>
+            <pre className="max-h-56 overflow-auto border-t border-line px-3 py-2 font-mono text-xs text-ink-muted whitespace-pre-wrap break-words">
+              {stringifyPretty(args)}
+            </pre>
+          </details>
+        );
+      })}
+    </div>
+  );
+}
+
+export function RawJsonBlock({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: unknown;
+  className?: string;
+}) {
+  return <JsonDisclosure className={className} label={label} value={value} />;
+}

--- a/console/web/src/components/trace-detail/trace-diagnostics.test.tsx
+++ b/console/web/src/components/trace-detail/trace-diagnostics.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { TraceDetail } from "@/lib/api";
+
+import { TraceDiagnostics } from "./trace-diagnostics";
+
+function buildTrace(): TraceDetail {
+  return {
+    trace_id: "trace-1",
+    agent_id: "agent-1",
+    session_id: "session-1",
+    user_id: null,
+    start_time: "2026-04-27T10:00:00Z",
+    end_time: "2026-04-27T10:00:12Z",
+    duration_ms: 12000,
+    status: "ok",
+    root_span_id: "root",
+    total_tokens: 95000,
+    total_input_tokens: 70000,
+    total_output_tokens: 25000,
+    total_token_cost: 0.12,
+    total_llm_calls: 1,
+    total_tool_calls: 1,
+    total_cache_read_tokens: 0,
+    total_cache_creation_tokens: 0,
+    max_depth: 1,
+    input_query: "diagnose",
+    final_output: "done",
+    runtime_decisions: [
+      {
+        kind: "step_back",
+        sequence: 6,
+        run_id: "run-1",
+        agent_id: "agent-1",
+        created_at: "2026-04-27T10:00:11Z",
+        summary: "2 results condensed after checkpoint seq 4",
+        details: { affected_count: 2 },
+      },
+    ],
+    timeline_events: [],
+    mainline_events: [],
+    review_cycles: [],
+    llm_calls: [],
+    spans: [
+      {
+        span_id: "llm-1",
+        trace_id: "trace-1",
+        parent_span_id: null,
+        kind: "llm_call",
+        name: "gpt-5.4",
+        start_time: "2026-04-27T10:00:00Z",
+        end_time: "2026-04-27T10:00:02Z",
+        duration_ms: 2000,
+        status: "ok",
+        error_message: null,
+        depth: 1,
+        attributes: { sequence: 2 },
+        input_preview: null,
+        output_preview: "I will inspect the file.",
+        metrics: { "tokens.total": 90000 },
+        llm_details: {
+          messages: [
+            { role: "system", content: "You are an agent." },
+            { role: "user", content: "Find the bug." },
+          ],
+          tools: [{ name: "read_file" }],
+          response_content: "I will inspect the file.",
+          response_tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: { name: "read_file", arguments: '{"path":"app.py"}' },
+            },
+          ],
+          finish_reason: "tool_calls",
+        },
+        tool_details: null,
+        run_id: "run-1",
+        step_id: "step-2",
+      },
+      {
+        span_id: "tool-1",
+        trace_id: "trace-1",
+        parent_span_id: null,
+        kind: "tool_call",
+        name: "read_file",
+        start_time: "2026-04-27T10:00:02Z",
+        end_time: "2026-04-27T10:00:12Z",
+        duration_ms: 10000,
+        status: "error",
+        error_message: "file missing",
+        depth: 1,
+        attributes: { sequence: 3, tool_call_id: "call-1" },
+        input_preview: null,
+        output_preview: "file missing",
+        metrics: {},
+        llm_details: null,
+        tool_details: {
+          tool_name: "read_file",
+          tool_call_id: "call-1",
+          input_args: { path: "app.py" },
+          output: "file missing",
+          error: "file missing",
+          status: "error",
+        },
+        run_id: "run-1",
+        step_id: "step-3",
+      },
+    ],
+  };
+}
+
+describe("TraceDiagnostics", () => {
+  test("renders risk signals, paired tool transactions, and LLM prompt messages", () => {
+    render(<TraceDiagnostics trace={buildTrace()} />);
+
+    expect(screen.getByText("Diagnostic Summary")).toBeInTheDocument();
+    expect(screen.getByText(/errored span/)).toBeInTheDocument();
+    expect(screen.getByText(/high token usage/)).toBeInTheDocument();
+    expect(screen.getByText("Execution Chain")).toBeInTheDocument();
+    expect(screen.getByText("Tool Transactions")).toBeInTheDocument();
+    expect(screen.getByText("LLM Call Inspector")).toBeInTheDocument();
+    expect(screen.getByText("Find the bug.")).toBeInTheDocument();
+    expect(screen.getAllByText("read_file").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("file missing").length).toBeGreaterThan(0);
+  });
+});

--- a/console/web/src/components/trace-detail/trace-diagnostics.tsx
+++ b/console/web/src/components/trace-detail/trace-diagnostics.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import { AlertTriangle, Bot, Clock, GitBranch, Wrench, Zap } from "lucide-react";
+
+import { JsonDisclosure } from "@/components/json-disclosure";
+import { MonoText } from "@/components/mono-text";
+import { SectionCard } from "@/components/section-card";
+import {
+  StepContentPreview,
+  StructuredValuePreview,
+  ToolCallPreviewList,
+  contentText,
+  stringifyPretty,
+} from "@/components/step-content-preview";
+import type { SpanResponse, ToolCallPayload, TraceDetail } from "@/lib/api";
+import { formatDurationMs, formatTokenCount } from "@/lib/metrics";
+import { formatLocalDateTime } from "@/lib/time";
+
+type RecordValue = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordValue {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function compact(value: unknown, maxLength = 180): string {
+  const text =
+    typeof value === "string" ? value : contentText(value) ?? stringifyPretty(value);
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function spanSequence(span: SpanResponse): number | null {
+  return numberValue(span.attributes.sequence);
+}
+
+function llmSpans(trace: TraceDetail): SpanResponse[] {
+  return trace.spans.filter((span) => span.kind === "llm_call" && span.llm_details);
+}
+
+function toolSpans(trace: TraceDetail): SpanResponse[] {
+  return trace.spans.filter((span) => span.kind === "tool_call" && span.tool_details);
+}
+
+function toolCallId(span: SpanResponse): string | null {
+  return stringValue(span.tool_details?.tool_call_id) ?? stringValue(span.attributes.tool_call_id);
+}
+
+function toolName(span: SpanResponse): string {
+  return stringValue(span.tool_details?.tool_name) ?? span.name;
+}
+
+function responseToolCalls(span: SpanResponse): ToolCallPayload[] {
+  const calls = span.llm_details?.response_tool_calls;
+  return Array.isArray(calls) ? (calls as ToolCallPayload[]) : [];
+}
+
+function traceRiskSignals(trace: TraceDetail): string[] {
+  const signals: string[] = [];
+  const spans = trace.spans;
+  const errors = spans.filter((span) => span.status === "error" || span.error_message);
+  if (errors.length > 0) {
+    signals.push(`${errors.length} errored span${errors.length === 1 ? "" : "s"}`);
+  }
+
+  const slowest = [...spans]
+    .filter((span) => span.duration_ms !== null)
+    .sort((a, b) => (b.duration_ms ?? 0) - (a.duration_ms ?? 0))[0];
+  if (slowest && (slowest.duration_ms ?? 0) >= 10_000) {
+    signals.push(`slow span ${slowest.name} took ${formatDurationMs(slowest.duration_ms ?? 0)}`);
+  }
+
+  const stepBacks = trace.runtime_decisions.filter((decision) => decision.kind === "step_back");
+  if (stepBacks.length > 0) {
+    signals.push(`${stepBacks.length} step-back decision${stepBacks.length === 1 ? "" : "s"}`);
+  }
+
+  const compactionFailures = trace.runtime_decisions.filter(
+    (decision) => decision.kind === "compaction_failed",
+  );
+  if (compactionFailures.length > 0) {
+    signals.push(`${compactionFailures.length} compaction failure${compactionFailures.length === 1 ? "" : "s"}`);
+  }
+
+  const abnormalFinishes = llmSpans(trace).filter((span) => {
+    const finishReason = stringValue(span.llm_details?.finish_reason);
+    return finishReason && !["stop", "tool_calls", "end_turn", "complete"].includes(finishReason);
+  });
+  if (abnormalFinishes.length > 0) {
+    signals.push(`${abnormalFinishes.length} abnormal LLM finish reason${abnormalFinishes.length === 1 ? "" : "s"}`);
+  }
+
+  const toolFingerprints = new Map<string, number>();
+  for (const span of toolSpans(trace)) {
+    const key = `${toolName(span)}:${compact(span.tool_details?.input_args ?? {}, 120)}`;
+    toolFingerprints.set(key, (toolFingerprints.get(key) ?? 0) + 1);
+  }
+  const repeatedTools = [...toolFingerprints.values()].filter((count) => count > 1).length;
+  if (repeatedTools > 0) {
+    signals.push(`${repeatedTools} repeated tool argument pattern${repeatedTools === 1 ? "" : "s"}`);
+  }
+
+  if (trace.total_tokens > 80_000) {
+    signals.push(`high token usage ${formatTokenCount(trace.total_tokens)}`);
+  }
+
+  return signals;
+}
+
+function DiagnosticsOverview({ trace }: { trace: TraceDetail }) {
+  const risks = traceRiskSignals(trace);
+  const slowest = [...trace.spans]
+    .filter((span) => span.duration_ms !== null)
+    .sort((a, b) => (b.duration_ms ?? 0) - (a.duration_ms ?? 0))[0];
+  const mostExpensive = [...llmSpans(trace)]
+    .sort(
+      (a, b) =>
+        (numberValue(b.metrics["tokens.total"]) ?? 0) -
+        (numberValue(a.metrics["tokens.total"]) ?? 0),
+    )[0];
+
+  return (
+    <SectionCard title="Diagnostic Summary" bodyClassName="grid gap-3 px-4 py-4 lg:grid-cols-3">
+      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Risk Signals
+        </div>
+        {risks.length === 0 ? (
+          <p className="text-sm text-ink-muted">No obvious rule-based risks detected.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {risks.map((risk) => (
+              <span
+                key={risk}
+                className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200"
+              >
+                {risk}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
+          <Clock className="h-3.5 w-3.5" />
+          Bottleneck
+        </div>
+        <p className="text-sm text-foreground">
+          {slowest
+            ? `${slowest.name} (${formatDurationMs(slowest.duration_ms ?? 0)})`
+            : "No timed spans"}
+        </p>
+      </div>
+      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
+          <Zap className="h-3.5 w-3.5" />
+          Heaviest LLM Call
+        </div>
+        <p className="text-sm text-foreground">
+          {mostExpensive
+            ? `${mostExpensive.name} (${formatTokenCount(numberValue(mostExpensive.metrics["tokens.total"]) ?? 0)} tokens)`
+            : "No LLM calls"}
+        </p>
+      </div>
+    </SectionCard>
+  );
+}
+
+function messageRole(message: unknown): string {
+  if (isRecord(message)) {
+    return stringValue(message.role) ?? stringValue(message.type) ?? "message";
+  }
+  return "message";
+}
+
+function messageContent(message: unknown): unknown {
+  if (isRecord(message)) {
+    return message.content ?? message.text ?? message;
+  }
+  return message;
+}
+
+function LlmCallInspector({ trace }: { trace: TraceDetail }) {
+  const spans = llmSpans(trace);
+  return (
+    <SectionCard title="LLM Call Inspector" bodyClassName="space-y-3 px-4 py-4">
+      {spans.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
+          No LLM call details recorded for this trace.
+        </div>
+      ) : (
+        spans.map((span, index) => {
+          const details = span.llm_details ?? {};
+          const messages = Array.isArray(details.messages) ? details.messages : [];
+          const tools = Array.isArray(details.tools) ? details.tools : [];
+          const calls = responseToolCalls(span);
+          return (
+            <details key={span.span_id} className="rounded-xl border border-line bg-panel px-3 py-3">
+              <summary className="cursor-pointer list-none">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Bot className="h-4 w-4 text-success" />
+                  <span className="text-sm font-medium text-foreground">
+                    {span.name || `LLM call ${index + 1}`}
+                  </span>
+                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                    seq {spanSequence(span) ?? "-"}
+                  </span>
+                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                    {messages.length} messages
+                  </span>
+                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                    {tools.length} tools available
+                  </span>
+                  {stringValue(details.finish_reason) ? (
+                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
+                      {stringValue(details.finish_reason)}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-2 text-sm text-ink-muted">
+                  {compact(details.response_content ?? span.output_preview ?? "No response preview")}
+                </p>
+              </summary>
+              <div className="mt-3 space-y-4">
+                <div>
+                  <div className="mb-2 text-xs uppercase tracking-wide text-ink-faint">
+                    Prompt Messages
+                  </div>
+                  <div className="space-y-2">
+                    {messages.slice(0, 20).map((message, messageIndex) => (
+                      <div
+                        key={messageIndex}
+                        className="rounded-lg border border-line bg-panel-muted px-3 py-2"
+                      >
+                        <div className="mb-1 text-[11px] uppercase tracking-wide text-ink-faint">
+                          {messageRole(message)}
+                        </div>
+                        <StepContentPreview
+                          value={messageContent(message)}
+                          emptyLabel="Empty message"
+                        />
+                      </div>
+                    ))}
+                    {messages.length > 20 ? (
+                      <p className="text-xs text-ink-faint">
+                        {messages.length - 20} more messages in raw details.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+                <div>
+                  <div className="mb-2 text-xs uppercase tracking-wide text-ink-faint">
+                    Model Response
+                  </div>
+                  <StepContentPreview
+                    value={details.response_content}
+                    emptyLabel="No assistant response content"
+                  />
+                  {calls.length > 0 ? <ToolCallPreviewList toolCalls={calls} /> : null}
+                </div>
+                <JsonDisclosure
+                  label="Raw LLM details JSON"
+                  value={details}
+                  className="bg-panel"
+                  contentClassName="bg-panel"
+                />
+              </div>
+            </details>
+          );
+        })
+      )}
+    </SectionCard>
+  );
+}
+
+function ToolTransactions({ trace }: { trace: TraceDetail }) {
+  const toolsByCallId = new Map<string, SpanResponse>();
+  for (const span of toolSpans(trace)) {
+    const id = toolCallId(span);
+    if (id) {
+      toolsByCallId.set(id, span);
+    }
+  }
+
+  const transactions = llmSpans(trace).flatMap((llmSpan) =>
+    responseToolCalls(llmSpan).map((call) => ({
+      llmSpan,
+      call,
+      toolSpan: call.id ? toolsByCallId.get(call.id) ?? null : null,
+    })),
+  );
+  const unmatchedTools = toolSpans(trace).filter((span) => {
+    const id = toolCallId(span);
+    return !id || !transactions.some((item) => item.call.id === id);
+  });
+
+  return (
+    <SectionCard title="Tool Transactions" bodyClassName="space-y-3 px-4 py-4">
+      {transactions.length === 0 && unmatchedTools.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
+          No tool transactions recorded for this trace.
+        </div>
+      ) : null}
+      {transactions.map(({ llmSpan, call, toolSpan }, index) => {
+        const output =
+          toolSpan?.tool_details?.content_for_user ??
+          toolSpan?.tool_details?.output ??
+          toolSpan?.tool_details?.error;
+        return (
+          <div key={`${call.id ?? "call"}-${index}`} className="rounded-xl border border-line bg-panel px-3 py-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Wrench className="h-4 w-4 text-warning" />
+              <span className="text-sm font-medium text-foreground">
+                {call.function?.name ?? toolSpan?.name ?? "tool_call"}
+              </span>
+              {call.id ? <MonoText>{call.id}</MonoText> : null}
+              <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                from seq {spanSequence(llmSpan) ?? "-"}
+              </span>
+              <span
+                className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide ${
+                  toolSpan?.status === "error"
+                    ? "border-red-500/40 bg-red-500/10 text-red-200"
+                    : toolSpan
+                      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+                      : "border-amber-500/40 bg-amber-500/10 text-amber-200"
+                }`}
+              >
+                {toolSpan ? toolSpan.status : "missing result"}
+              </span>
+              {toolSpan?.duration_ms != null ? (
+                <span className="rounded-full border border-line bg-panel-muted px-2 py-1 text-[11px] text-ink-muted">
+                  {formatDurationMs(toolSpan.duration_ms)}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+              <div>
+                <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
+                <StructuredValuePreview value={call.function?.arguments ?? toolSpan?.tool_details?.input_args ?? {}} />
+              </div>
+              <div>
+                <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
+                <StepContentPreview value={output} emptyLabel="No matching tool result" />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      {unmatchedTools.map((span) => (
+        <div key={span.span_id} className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <Wrench className="h-4 w-4 text-warning" />
+            <span className="text-sm font-medium text-foreground">{toolName(span)}</span>
+            <span className="text-xs text-amber-200">Tool result without matched assistant call</span>
+          </div>
+          <StepContentPreview
+            value={span.tool_details?.output ?? span.tool_details?.error}
+            emptyLabel="No tool result content"
+          />
+        </div>
+      ))}
+    </SectionCard>
+  );
+}
+
+function ExecutionChain({ trace }: { trace: TraceDetail }) {
+  const spanEvents = trace.spans.map((span) => ({
+    id: `span:${span.span_id}`,
+    time: span.start_time,
+    sequence: spanSequence(span),
+    kind: span.kind,
+    title: span.name,
+    summary:
+      span.kind === "tool_call"
+        ? compact(span.tool_details?.output ?? span.tool_details?.error ?? span.output_preview ?? "")
+        : compact(span.output_preview ?? span.llm_details?.response_content ?? span.error_message ?? ""),
+    status: span.status,
+    duration: span.duration_ms,
+  }));
+  const decisionEvents = trace.runtime_decisions.map((decision) => ({
+    id: `decision:${decision.kind}:${decision.sequence}:${decision.run_id}`,
+    time: decision.created_at,
+    sequence: decision.sequence,
+    kind: decision.kind,
+    title: decision.kind.replaceAll("_", " "),
+    summary: decision.summary,
+    status: decision.kind.includes("failed") ? "error" : "ok",
+    duration: null,
+  }));
+  const events = [...spanEvents, ...decisionEvents].sort((a, b) => {
+    const byTime = new Date(a.time ?? 0).getTime() - new Date(b.time ?? 0).getTime();
+    if (byTime !== 0) {
+      return byTime;
+    }
+    return (a.sequence ?? 0) - (b.sequence ?? 0);
+  });
+
+  return (
+    <SectionCard title="Execution Chain" bodyClassName="space-y-2 px-4 py-4">
+      {events.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
+          No execution chain events available.
+        </div>
+      ) : (
+        <div className="relative space-y-2 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
+          {events.map((event) => (
+            <div key={event.id} className="relative ml-10 rounded-xl border border-line bg-panel px-3 py-3">
+              <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel">
+                {event.kind === "llm_call" ? (
+                  <Zap className="h-3.5 w-3.5 text-success" />
+                ) : event.kind === "tool_call" ? (
+                  <Wrench className="h-3.5 w-3.5 text-warning" />
+                ) : (
+                  <GitBranch className="h-3.5 w-3.5 text-ink-muted" />
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-foreground">{event.title}</span>
+                <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
+                  {event.kind}
+                </span>
+                <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                  seq {event.sequence ?? "-"}
+                </span>
+                {event.duration != null ? (
+                  <span className="rounded-full border border-line bg-panel-muted px-2 py-1 text-[11px] text-ink-muted">
+                    {formatDurationMs(event.duration)}
+                  </span>
+                ) : null}
+                <span className="ml-auto text-xs text-ink-muted">{formatLocalDateTime(event.time)}</span>
+              </div>
+              {event.summary ? (
+                <p className="mt-2 text-sm leading-5 text-ink-muted">{event.summary}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+export function TraceDiagnostics({ trace }: { trace: TraceDetail }) {
+  return (
+    <div className="space-y-6">
+      <DiagnosticsOverview trace={trace} />
+      <ExecutionChain trace={trace} />
+      <ToolTransactions trace={trace} />
+      <LlmCallInspector trace={trace} />
+    </div>
+  );
+}
+
+export default TraceDiagnostics;

--- a/console/web/src/components/trace-detail/trace-loop-timeline.test.tsx
+++ b/console/web/src/components/trace-detail/trace-loop-timeline.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { TraceTimelineEvent } from "@/lib/api";
+
+import { TraceLoopTimeline } from "./trace-loop-timeline";
+
+describe("TraceLoopTimeline", () => {
+  test("renders LLM and tool details as readable content before raw JSON", () => {
+    const events: TraceTimelineEvent[] = [
+      {
+        kind: "llm_call",
+        timestamp: "2026-04-25T12:00:00Z",
+        sequence: 1,
+        run_id: "run-1",
+        agent_id: "agent-1",
+        span_id: "span-llm",
+        step_id: "step-llm",
+        title: "LLM Call",
+        summary: "gpt-4.1 · tool_calls",
+        status: "ok",
+        details: {
+          finish_reason: "tool_calls",
+          messages: [{ role: "user", content: "Find docs" }],
+          response_content: "I will search the docs.",
+          response_tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: '{"query":"docs"}',
+              },
+            },
+          ],
+        },
+      },
+      {
+        kind: "tool_call",
+        timestamp: "2026-04-25T12:00:01Z",
+        sequence: 2,
+        run_id: "run-1",
+        agent_id: "agent-1",
+        span_id: "span-tool",
+        step_id: "step-tool",
+        title: "Tool Call: web_search",
+        summary: "completed",
+        status: "ok",
+        details: {
+          tool_name: "web_search",
+          tool_call_id: "call-1",
+          input_args: { query: "docs" },
+          output: "Search result body",
+          status: "completed",
+        },
+      },
+    ];
+
+    render(<TraceLoopTimeline events={events} />);
+
+    fireEvent.click(screen.getByText("LLM Call"));
+    expect(screen.getByText("I will search the docs.")).toBeInTheDocument();
+    expect(screen.getAllByText("web_search").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Raw details JSON")).toHaveLength(2);
+
+    fireEvent.click(screen.getByText("Tool Call: web_search"));
+    expect(screen.getByText("Arguments")).toBeInTheDocument();
+    expect(screen.getByText("Search result body")).toBeInTheDocument();
+    expect(screen.getAllByText("Raw details JSON")).toHaveLength(2);
+  });
+});

--- a/console/web/src/components/trace-detail/trace-loop-timeline.tsx
+++ b/console/web/src/components/trace-detail/trace-loop-timeline.tsx
@@ -3,7 +3,13 @@
 import { JsonDisclosure } from "@/components/json-disclosure";
 import { MonoText } from "@/components/mono-text";
 import { SectionCard } from "@/components/section-card";
-import type { TraceTimelineEvent } from "@/lib/api";
+import {
+  StepContentPreview,
+  StructuredValuePreview,
+  ToolCallPreviewList,
+  contentText,
+} from "@/components/step-content-preview";
+import type { ToolCallPayload, TraceTimelineEvent } from "@/lib/api";
 import { formatLocalDateTime } from "@/lib/time";
 
 function timelineStatusBadgeClass(status: string): string {
@@ -14,6 +20,99 @@ function timelineStatusBadgeClass(status: string): string {
     return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
   }
   return "border-line bg-panel-muted text-ink-muted";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function detailChips(event: TraceTimelineEvent): string[] {
+  const details = event.details;
+  if (event.kind === "llm_call") {
+    return [
+      typeof details.finish_reason === "string" ? details.finish_reason : "",
+      Array.isArray(details.messages) ? `${details.messages.length} messages` : "",
+      Array.isArray(details.response_tool_calls)
+        ? `${details.response_tool_calls.length} tool calls`
+        : "",
+    ].filter(Boolean);
+  }
+  if (event.kind === "tool_call") {
+    return [
+      typeof details.tool_name === "string" ? details.tool_name : "",
+      typeof details.tool_call_id === "string" ? details.tool_call_id : "",
+      typeof details.status === "string" ? details.status : "",
+    ].filter(Boolean);
+  }
+  if (event.kind === "review_checkpoint") {
+    return [
+      typeof details.trigger_reason === "string" ? details.trigger_reason : "",
+      typeof details.steps_since_last_review === "number"
+        ? `${details.steps_since_last_review} steps`
+        : "",
+      typeof details.active_milestone === "string" ? details.active_milestone : "",
+    ].filter(Boolean);
+  }
+  if (event.kind === "runtime_decision" || event.kind === "review_result") {
+    return [
+      typeof details.kind === "string" ? details.kind : "",
+      typeof details.experience === "string" ? details.experience : "",
+      typeof details.affected_count === "number" ? `${details.affected_count} affected` : "",
+    ].filter(Boolean);
+  }
+  return [];
+}
+
+function TimelineDetailPreview({ event }: { event: TraceTimelineEvent }) {
+  const details = event.details;
+
+  if (event.kind === "llm_call") {
+    const response = details.response_content;
+    const toolCalls: ToolCallPayload[] = Array.isArray(details.response_tool_calls)
+      ? (details.response_tool_calls as ToolCallPayload[])
+      : [];
+    return (
+      <div className="space-y-3">
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Response</div>
+          <StepContentPreview value={response} emptyLabel="No assistant response content" />
+        </div>
+        {toolCalls.length > 0 ? <ToolCallPreviewList toolCalls={toolCalls} /> : null}
+      </div>
+    );
+  }
+
+  if (event.kind === "tool_call") {
+    const preferredOutput = details.content_for_user ?? details.output ?? details.error;
+    return (
+      <div className="space-y-3">
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
+          <StructuredValuePreview value={details.input_args ?? {}} />
+        </div>
+        <div>
+          <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
+          <StepContentPreview value={preferredOutput} emptyLabel="No tool result content" />
+        </div>
+      </div>
+    );
+  }
+
+  if (event.kind === "milestone_update" && Array.isArray(details.milestones)) {
+    return (
+      <div className="space-y-2">
+        {details.milestones.slice(0, 6).map((milestone, index) => (
+          <div key={index} className="rounded-md bg-panel-muted px-3 py-2 text-sm text-ink-soft">
+            {isRecord(milestone) && typeof milestone.description === "string"
+              ? milestone.description
+              : contentText(milestone) ?? `Milestone ${index + 1}`}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <StructuredValuePreview value={details} />;
 }
 
 export function TraceLoopTimeline({
@@ -49,6 +148,18 @@ export function TraceLoopTimeline({
                   ) : null}
                 </div>
                 <p className="text-sm text-foreground">{event.summary}</p>
+                {detailChips(event).length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {detailChips(event).map((item, chipIndex) => (
+                      <span
+                        key={`${event.kind}-${event.sequence ?? "na"}-${chipIndex}`}
+                        className="rounded-full border border-line bg-panel-muted px-2 py-1 text-[11px] text-ink-muted"
+                      >
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
                 <div className="flex flex-wrap gap-3 text-xs text-ink-muted">
                   {event.run_id && (
                     <span>
@@ -65,9 +176,10 @@ export function TraceLoopTimeline({
                 </div>
               </div>
             </summary>
-            <div className="mt-3">
+            <div className="mt-3 space-y-3">
+              <TimelineDetailPreview event={event} />
               <JsonDisclosure
-                label="Details"
+                label="Raw details JSON"
                 value={event.details}
                 className="bg-panel"
                 contentClassName="bg-panel"

--- a/console/web/src/components/trace-detail/trace-mainline-events.tsx
+++ b/console/web/src/components/trace-detail/trace-mainline-events.tsx
@@ -56,14 +56,18 @@ export function TraceMainlineEvents({
           No mainline narrative available for this trace.
         </div>
       ) : (
-        events.map((event) => {
+        <div className="relative space-y-3 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
+          {events.map((event) => {
           const previewItems = eventPreviewItems(event);
           return (
             <details
               key={event.id}
-              className="rounded-xl border border-line bg-panel px-3 py-3"
+              className="relative ml-10 rounded-xl border border-line bg-panel px-3 py-3"
             >
               <summary className="cursor-pointer list-none">
+                <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel font-mono text-[11px] text-ink-muted">
+                  {event.sequence ?? "-"}
+                </div>
                 <div className="space-y-2">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium text-foreground">
@@ -117,7 +121,8 @@ export function TraceMainlineEvents({
               </div>
             </details>
           );
-        })
+        })}
+        </div>
       )}
     </SectionCard>
   );


### PR DESCRIPTION
## Summary
- Render assistant messages, tool calls, and tool results as readable step previews by default
- Keep raw step/details JSON behind collapsible sections with one-click copy
- Add focused tests for JSON copy, session step rendering, and trace timeline previews

## Verification
- npm run lint
- npm test
- npm run build
- pre-commit lint gate
- pre-push full gate