### PR TITLE
Improve agent diagnostics UI focus

### DIFF
--- a/console/server/services/runtime/runtime_observability.py
+++ b/console/server/services/runtime/runtime_observability.py
@@ -376,6 +376,24 @@ def _summary_from_step(step: StepView) -> str:
     return _summarize_text(step.get_display_text())
 
 
+def _step_event_details(step: StepView, **extra: Any) -> dict[str, Any]:
+    stored_step = step.to_dict()
+    details = {
+        "step_id": step.id,
+        "role": step.role.value,
+        "content": step.content,
+        "content_for_user": step.content_for_user,
+        "condensed_content": step.condensed_content,
+        "user_input": stored_step.get("user_input"),
+        "tool_calls": step.tool_calls,
+        "tool_call_id": step.tool_call_id,
+        "tool_name": step.name,
+        "is_error": True if step.is_error else None,
+        **extra,
+    }
+    return {key: value for key, value in details.items() if value is not None}
+
+
 def _review_cycle_summary(cycle: ReviewCycleRecord) -> str:
     if cycle.aligned is True:
         return "Review aligned with milestone"
@@ -1474,10 +1492,7 @@ def build_conversation_events(
                     priority="primary",
                     title="User",
                     summary=_summary_from_step(step),
-                    details={
-                        "step_id": step.id,
-                        "role": step.role.value,
-                    },
+                    details=_step_event_details(step),
                 )
             )
             continue
@@ -1493,10 +1508,7 @@ def build_conversation_events(
                     priority="primary",
                     title="Assistant",
                     summary=_summary_from_step(step),
-                    details={
-                        "step_id": step.id,
-                        "role": step.role.value,
-                    },
+                    details=_step_event_details(step),
                 )
             )
             continue
@@ -1513,10 +1525,7 @@ def build_conversation_events(
                     priority="muted",
                     title="Compressed History",
                     summary=_summarize_text(step.condensed_content),
-                    details={
-                        "step_id": step.id,
-                        "tool_name": tool_name,
-                    },
+                    details=_step_event_details(step, tool_name=tool_name),
                 )
             )
             continue
@@ -1533,10 +1542,7 @@ def build_conversation_events(
                     priority="secondary",
                     title="Milestones Updated",
                     summary=summary,
-                    details={
-                        "step_id": step.id,
-                        "tool_name": tool_name,
-                    },
+                    details=_step_event_details(step, tool_name=tool_name),
                 )
             )
             continue
@@ -1552,10 +1558,7 @@ def build_conversation_events(
                     priority="muted",
                     title="Review",
                     summary=_summary_from_step(step),
-                    details={
-                        "step_id": step.id,
-                        "tool_name": tool_name,
-                    },
+                    details=_step_event_details(step, tool_name=tool_name),
                 )
             )
             continue
@@ -1570,10 +1573,7 @@ def build_conversation_events(
                 priority="secondary",
                 title=f"Tool: {tool_name}",
                 summary=_summary_from_step(step),
-                details={
-                    "step_id": step.id,
-                    "tool_name": tool_name,
-                },
+                details=_step_event_details(step, tool_name=tool_name),
             )
         )
 

--- a/console/tests/test_runtime_observability.py
+++ b/console/tests/test_runtime_observability.py
@@ -361,6 +361,16 @@ def test_build_session_milestone_board_and_conversation_events() -> None:
             sequence=2,
             role=MessageRole.ASSISTANT,
             content="I will inspect auth",
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"auth.py"}',
+                    },
+                }
+            ],
         ),
         StepView(
             id="step-tool",
@@ -385,6 +395,10 @@ def test_build_session_milestone_board_and_conversation_events() -> None:
         "milestone_event",
         "review_event",
     ]
+    assert events[0].details["content"] == "please inspect auth"
+    assert events[1].details["content"] == "I will inspect auth"
+    assert events[1].details["tool_calls"][0]["function"]["name"] == "read_file"
+    assert events[2].details["tool_name"] == "declare_milestones"
     assert events[-1].summary == "Review misaligned; 2 steps condensed"
 
 

--- a/console/web/src/app/sessions/[id]/page.tsx
+++ b/console/web/src/app/sessions/[id]/page.tsx
@@ -277,89 +277,14 @@ export default function SessionDetailPage() {
               <ConversationEventList events={detail.conversation_events} />
             </div>
           ) : (
-            <div className="space-y-6">
-              <SessionObservabilityPanel
-                sessionId={sessionId}
-                observability={detail.observability}
-              />
-
-              <div className="rounded-lg border border-zinc-800 overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-zinc-900 text-zinc-500 text-xs uppercase tracking-wide">
-                    <tr>
-                      <th className="text-left px-4 py-2.5">Run</th>
-                      <th className="text-right px-4 py-2.5">Cost</th>
-                      <th className="text-right px-4 py-2.5">Input</th>
-                      <th className="text-right px-4 py-2.5">Output</th>
-                      <th className="text-right px-4 py-2.5">Total</th>
-                      <th className="text-right px-4 py-2.5">Cache R/C</th>
-                      <th className="text-right px-4 py-2.5">Steps/Tools</th>
-                      <th className="text-right px-4 py-2.5">Duration</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-zinc-800">
-                    {runTableRows.map(({ run, metrics }) => {
-                      return (
-                        <tr key={run.id} className="hover:bg-zinc-900/50">
-                          <td className="px-4 py-2.5 text-zinc-300">
-                            <MonoText className="text-xs font-mono text-zinc-300">
-                              {run.id}
-                            </MonoText>
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-200">
-                            {formatUsd(metrics.tokenCost)}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-400">
-                            {formatTokenCount(metrics.inputTokens)}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-400">
-                            {formatTokenCount(metrics.outputTokens)}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-400">
-                            {formatTokenCount(metrics.totalTokens)}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-500">
-                            {formatTokenCount(metrics.cacheReadTokens)} / {formatTokenCount(metrics.cacheCreationTokens)}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-500">
-                            {metrics.stepCount} / {metrics.toolCallsCount}
-                          </td>
-                          <td className="px-4 py-2.5 text-right text-zinc-500">
-                            {formatDurationMs(metrics.durationMs)}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-
-              <PaginationControls
-                offset={runsOffset}
-                pageSize={runsPageSize}
-                itemCount={runs.length}
-                totalCount={runsState.total}
-                hasMore={runsState.hasMore}
-                itemLabel="runs"
-                disabled={loading}
-                onPageSizeChange={(nextPageSize) => {
-                  setRunsPageSize(nextPageSize);
-                  setRunsOffset(0);
-                }}
-                onPrevious={() => {
-                  setRunsOffset((current) => Math.max(0, current - runsPageSize));
-                }}
-                onNext={() => {
-                  setRunsOffset((current) => current + runsPageSize);
-                }}
-              />
-
-              {steps.length === 0 ? (
-                <EmptyStateMessage className="text-zinc-500 text-center py-8">
-                  No steps found
-                </EmptyStateMessage>
-              ) : (
-                <div className="space-y-3">
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+              <div className="min-w-0 space-y-3">
+                {steps.length === 0 ? (
+                  <EmptyStateMessage className="text-zinc-500 text-center py-8">
+                    No steps found
+                  </EmptyStateMessage>
+                ) : (
+                  <>
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
                       <h2 className="text-sm font-medium text-zinc-300">Steps</h2>
@@ -414,8 +339,85 @@ export default function SessionDetailPage() {
                   {filteredSteps.map((step) => (
                     <SessionStepCard key={step.id} step={step} />
                   ))}
+                  </>
+                )}
+              </div>
+
+              <aside className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+                <SessionObservabilityPanel
+                  sessionId={sessionId}
+                  observability={detail.observability}
+                  compact
+                />
+
+                <div className="rounded-2xl border border-line bg-panel">
+                  <div className="border-b border-line bg-panel-muted px-4 py-3 text-sm font-medium text-foreground">
+                    Runs
+                  </div>
+                  <div className="space-y-2 px-4 py-4">
+                    {runTableRows.length === 0 ? (
+                      <div className="rounded-xl border border-dashed border-line px-3 py-4 text-sm text-ink-muted">
+                        No runs loaded.
+                      </div>
+                    ) : (
+                      runTableRows.map(({ run, metrics }) => (
+                        <div
+                          key={run.id}
+                          className="rounded-xl border border-line bg-panel-muted px-3 py-3"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <MonoText className="truncate text-xs">{run.id.slice(0, 12)}</MonoText>
+                            <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                              {run.status}
+                            </span>
+                          </div>
+                          <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-ink-muted">
+                            <span>{metrics.stepCount} steps</span>
+                            <span>{metrics.toolCallsCount} tools</span>
+                            <span>{formatDurationMs(metrics.durationMs)}</span>
+                            <span>{formatUsd(metrics.tokenCost)}</span>
+                          </div>
+                          <details className="mt-2">
+                            <summary className="cursor-pointer list-none text-xs text-ink-faint">
+                              Token details
+                            </summary>
+                            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-ink-muted">
+                              <span>in {formatTokenCount(metrics.inputTokens)}</span>
+                              <span>out {formatTokenCount(metrics.outputTokens)}</span>
+                              <span>total {formatTokenCount(metrics.totalTokens)}</span>
+                              <span>
+                                cache {formatTokenCount(metrics.cacheReadTokens)} /{" "}
+                                {formatTokenCount(metrics.cacheCreationTokens)}
+                              </span>
+                            </div>
+                          </details>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                  <div className="border-t border-line px-3 py-3">
+                    <PaginationControls
+                      offset={runsOffset}
+                      pageSize={runsPageSize}
+                      itemCount={runs.length}
+                      totalCount={runsState.total}
+                      hasMore={runsState.hasMore}
+                      itemLabel="runs"
+                      disabled={loading}
+                      onPageSizeChange={(nextPageSize) => {
+                        setRunsPageSize(nextPageSize);
+                        setRunsOffset(0);
+                      }}
+                      onPrevious={() => {
+                        setRunsOffset((current) => Math.max(0, current - runsPageSize));
+                      }}
+                      onNext={() => {
+                        setRunsOffset((current) => current + runsPageSize);
+                      }}
+                    />
+                  </div>
                 </div>
-              )}
+              </aside>
             </div>
           )}
         </div>

--- a/console/web/src/app/traces/[id]/page.test.tsx
+++ b/console/web/src/app/traces/[id]/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
 const apiMocks = vi.hoisted(() => ({
@@ -7,8 +7,6 @@ const apiMocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "trace-1" }),
-  useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/lib/api", async () => {
@@ -22,7 +20,7 @@ vi.mock("@/lib/api", async () => {
 import TraceDetailPage from "./page";
 
 describe("TraceDetailPage", () => {
-  test("switches between mainline and debug trace views", async () => {
+  test("renders unified trace diagnostics without mainline debug split", async () => {
     apiMocks.getTrace.mockResolvedValue({
       trace_id: "trace-1",
       agent_id: "agent-1",
@@ -139,17 +137,14 @@ describe("TraceDetailPage", () => {
     render(<TraceDetailPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Run Narrative")).toBeInTheDocument();
+      expect(screen.getByText("Agent Execution Diagnostics")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Review Checkpoint")).toBeInTheDocument();
-    expect(screen.getByText("Review Cycles")).toBeInTheDocument();
-    expect(screen.queryByText("Loop Timeline")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
-
-    expect(screen.getByText("LLM Calls")).toBeInTheDocument();
-    expect(screen.getByText("Loop Timeline")).toBeInTheDocument();
-    expect(screen.getByText("Span Waterfall (0 spans)")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Mainline" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Debug" })).not.toBeInTheDocument();
+    expect(screen.getByText("fix the bug")).toBeInTheDocument();
+    expect(screen.getAllByText("2 results condensed after checkpoint seq 4").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Run Narrative")).not.toBeInTheDocument();
+    expect(screen.queryByText("Span Waterfall (0 spans)")).not.toBeInTheDocument();
   });
 });

--- a/console/web/src/app/traces/[id]/page.tsx
+++ b/console/web/src/app/traces/[id]/page.tsx
@@ -2,49 +2,19 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Activity, Clock, Cpu, Flag, GitBranch, Wrench, Zap } from "lucide-react";
+import { useParams } from "next/navigation";
+import { Activity, Flag, GitBranch } from "lucide-react";
 import { BackHeader } from "@/components/back-header";
-import { JsonDisclosure } from "@/components/json-disclosure";
 import { MetricCard } from "@/components/metric-card";
-import { MonoText } from "@/components/mono-text";
 import { SectionCard } from "@/components/section-card";
 import { ErrorStateMessage, FullPageMessage } from "@/components/state-message";
-import { TokenMetricsBadges } from "@/components/token-metrics-badges";
 import { TokenSummaryCards } from "@/components/token-summary-cards";
 import { TraceDiagnostics } from "@/components/trace-detail/trace-diagnostics";
-import { TraceLlmCalls } from "@/components/trace-detail/trace-llm-calls";
-import { TraceLoopTimeline } from "@/components/trace-detail/trace-loop-timeline";
-import { TraceMainlineEvents } from "@/components/trace-detail/trace-mainline-events";
-import { TraceReviewCycles } from "@/components/trace-detail/trace-review-cycles";
-import { TraceRuntimeDecisions } from "@/components/trace-detail/trace-runtime-decisions";
 import { TraceStatusBadge } from "@/components/trace-status-badge";
-import {
-  StepContentPreview,
-  StructuredValuePreview,
-  ToolCallPreviewList,
-} from "@/components/step-content-preview";
 import { getTrace } from "@/lib/api";
-import type { ToolCallPayload, TraceDetail, SpanResponse } from "@/lib/api";
+import type { TraceDetail } from "@/lib/api";
 import { latestAlignment, latestObjective } from "@/lib/insights";
-import {
-  formatDurationMs,
-  parseGenericMetrics,
-} from "@/lib/metrics";
-import { formatRoundedMs } from "@/lib/time";
-
-/**
- * Render a small Lucide icon representing the span `kind`.
- *
- * @param kind - The span kind; expected values: `"agent"`, `"llm_call"`, `"tool_call"`. Any other value renders the default icon.
- * @returns A JSX element for the corresponding icon: `Cpu` for `"agent"`, `Zap` for `"llm_call"`, `Wrench` for `"tool_call"`, and `Clock` for other kinds. Icons are rendered with the component's standard sizing and semantic color classes.
- */
-function KindIcon({ kind }: { kind: string }) {
-  if (kind === "agent") return <Cpu className="h-3.5 w-3.5 text-accent" />;
-  if (kind === "llm_call") return <Zap className="h-3.5 w-3.5 text-success" />;
-  if (kind === "tool_call") return <Wrench className="h-3.5 w-3.5 text-warning" />;
-  return <Clock className="h-3.5 w-3.5 text-ink-faint" />;
-}
+import { formatDurationMs } from "@/lib/metrics";
 
 interface TraceInsightRailProps {
   trace: TraceDetail;
@@ -112,216 +82,21 @@ function TraceInsightRail({ trace }: TraceInsightRailProps) {
   );
 }
 
-function SpanDetailPreview({ span }: { span: SpanResponse }) {
-  if (span.kind === "llm_call" && span.llm_details) {
-    const toolCalls: ToolCallPayload[] = Array.isArray(
-      span.llm_details.response_tool_calls,
-    )
-      ? (span.llm_details.response_tool_calls as ToolCallPayload[])
-      : [];
-    return (
-      <div className="space-y-3 rounded-lg border border-line bg-panel px-3 py-3">
-        <div>
-          <div className="mb-1 text-xs font-medium text-ink-faint">Response</div>
-          <StepContentPreview
-            value={span.llm_details.response_content}
-            emptyLabel="No assistant response content"
-          />
-        </div>
-        {toolCalls.length > 0 ? <ToolCallPreviewList toolCalls={toolCalls} /> : null}
-      </div>
-    );
-  }
-
-  if (span.kind === "tool_call" && span.tool_details) {
-    const output =
-      span.tool_details.content_for_user ??
-      span.tool_details.output ??
-      span.tool_details.error;
-    return (
-      <div className="space-y-3 rounded-lg border border-line bg-panel px-3 py-3">
-        <div>
-          <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
-          <StructuredValuePreview value={span.tool_details.input_args ?? {}} />
-        </div>
-        <div>
-          <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
-          <StepContentPreview value={output} emptyLabel="No tool result content" />
-        </div>
-      </div>
-    );
-  }
-
-  return null;
-}
-
 /**
- * Render a clickable span row in the trace waterfall with an inline duration bar and optional expandable details.
+ * Renders the Trace Detail page for a single trace, showing summary metrics,
+ * related links, and a unified execution diagnostics chain.
  *
- * The row is indented by `span.depth`, positions and sizes the bar using `traceStartMs` and `traceDurationMs`,
- * and when expanded displays span metadata, error message, metrics/LLM/tool JSON disclosures, and an output preview.
- *
- * @param span - The span object to display
- * @param traceStartMs - Trace start time in milliseconds since epoch; used to compute the span's offset within the trace
- * @param traceDurationMs - Total trace duration in milliseconds; used to compute the span bar's width and left offset
- * @param expanded - Whether the span's details panel is currently expanded
- * @param onToggle - Callback invoked when the row's expand/collapse button is clicked
- * @returns The rendered span row element
- */
-function SpanRow({
-  span,
-  traceStartMs,
-  traceDurationMs,
-  expanded,
-  onToggle,
-}: {
-  span: SpanResponse;
-  traceStartMs: number;
-  traceDurationMs: number;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  const spanMetrics = parseGenericMetrics(span.metrics);
-  const spanStartMs = span.start_time
-    ? new Date(span.start_time).getTime() - traceStartMs
-    : 0;
-  const spanDuration = span.duration_ms || 0;
-  const leftPct = traceDurationMs > 0 ? (spanStartMs / traceDurationMs) * 100 : 0;
-  const widthPct =
-    traceDurationMs > 0
-      ? Math.max((spanDuration / traceDurationMs) * 100, 0.5)
-      : 100;
-
-  const barColor =
-    span.kind === "agent"
-      ? "bg-accent"
-      : span.kind === "llm_call"
-      ? "bg-success"
-      : span.kind === "tool_call"
-      ? "bg-warning"
-      : "bg-line-strong";
-
-  return (
-    <>
-      <button
-        type="button"
-        aria-expanded={expanded}
-        aria-controls={`${span.span_id}-details`}
-        className="flex w-full items-center gap-2 border-b border-line px-4 py-2.5 text-left transition-colors hover:bg-panel-muted"
-        onClick={onToggle}
-      >
-        <div
-          className="flex items-center gap-2 shrink-0"
-          style={{ paddingLeft: `${span.depth * 20}px`, width: "280px" }}
-        >
-          <KindIcon kind={span.kind} />
-          <span className="text-sm truncate">{span.name}</span>
-          <TraceStatusBadge status={span.status} />
-        </div>
-
-        <div className="relative h-5 flex-1 overflow-hidden rounded bg-panel-muted">
-          <div
-            className={`absolute h-full rounded ${barColor} opacity-80`}
-            style={{
-              left: `${Math.min(leftPct, 99)}%`,
-              width: `${Math.min(widthPct, 100 - leftPct)}%`,
-            }}
-          />
-        </div>
-
-        <div className="w-20 shrink-0 text-right text-xs text-ink-muted">
-          {spanDuration ? `${Math.round(spanDuration)}ms` : "-"}
-        </div>
-      </button>
-
-      {expanded && (
-        <div
-          id={`${span.span_id}-details`}
-          className="space-y-2 border-b border-line bg-panel-muted px-4 py-3 text-xs"
-        >
-          <div className="grid grid-cols-2 gap-x-6 gap-y-1">
-            <div>
-              <span className="text-ink-faint">Span ID: </span>
-              <MonoText className="font-mono">
-                {span.span_id.slice(0, 12)}
-              </MonoText>
-            </div>
-            <div>
-              <span className="text-ink-faint">Kind: </span>
-              <span>{span.kind}</span>
-            </div>
-            {span.duration_ms != null && (
-              <div>
-                <span className="text-ink-faint">Duration: </span>
-                <span>{formatRoundedMs(span.duration_ms)}</span>
-              </div>
-            )}
-            {span.error_message && (
-              <div className="col-span-2">
-                <span className="text-danger">Error: </span>
-                <span className="text-danger">{span.error_message}</span>
-              </div>
-            )}
-          </div>
-
-          {Object.keys(span.metrics).length > 0 && (
-            <div>
-              <TokenMetricsBadges
-                metrics={spanMetrics}
-                showCacheRead={false}
-                showCacheCreation={false}
-                chipClassName="bg-panel-strong"
-                className="mb-2 grid grid-cols-2 sm:grid-cols-4 gap-2"
-              />
-              <JsonDisclosure label="Metrics JSON" value={span.metrics} />
-            </div>
-          )}
-
-          <SpanDetailPreview span={span} />
-
-          {span.llm_details && (
-            <JsonDisclosure label="LLM Details" value={span.llm_details} />
-          )}
-
-          {span.tool_details && (
-            <JsonDisclosure label="Tool Details" value={span.tool_details} />
-          )}
-
-          {span.output_preview && (
-            <div>
-              <p className="mb-1 text-ink-faint">Output Preview:</p>
-              <div className="max-h-48 overflow-auto rounded bg-panel px-3 py-2 whitespace-pre-wrap">
-                {span.output_preview}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-    </>
-  );
-}
-
-/**
- * Renders the Trace Detail page for a single trace, showing summary metrics, links to related session/agent,
- * the span waterfall with expandable span rows, and optional input/final output panels.
- *
- * The component reads `id` from route params, fetches the trace detail, and manages loading, error, and expanded-span state.
- * While loading it shows a full-page loading message; if the trace is not found it shows a not-found message.
+ * The component reads `id` from route params, fetches the trace detail, and
+ * manages `trace`, `loading`, and `error` state.
  *
  * @returns The React element for the trace detail page.
  */
 export default function TraceDetailPage() {
   const params = useParams();
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const traceId = params.id as string;
   const [trace, setTrace] = useState<TraceDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedSpans, setExpandedSpans] = useState<Set<string>>(new Set());
-  const [viewMode, setViewMode] = useState<"mainline" | "debug">(
-    searchParams.get("view") === "debug" ? "debug" : "mainline",
-  );
 
   useEffect(() => {
     getTrace(traceId)
@@ -336,26 +111,6 @@ export default function TraceDetailPage() {
       .finally(() => setLoading(false));
   }, [traceId]);
 
-  const toggleSpan = (spanId: string) => {
-    setExpandedSpans((prev) => {
-      const next = new Set(prev);
-      if (next.has(spanId)) next.delete(spanId);
-      else next.add(spanId);
-      return next;
-    });
-  };
-
-  const updateViewMode = (nextViewMode: "mainline" | "debug") => {
-    setViewMode(nextViewMode);
-    const next = new URLSearchParams(searchParams.toString());
-    if (nextViewMode === "debug") {
-      next.set("view", "debug");
-    } else {
-      next.delete("view");
-    }
-    router.replace(`/traces/${traceId}${next.toString() ? `?${next}` : ""}`);
-  };
-
   if (loading) {
     return <FullPageMessage>Loading trace...</FullPageMessage>;
   }
@@ -364,10 +119,6 @@ export default function TraceDetailPage() {
     return <FullPageMessage>Trace not found</FullPageMessage>;
   }
 
-  const traceStartMs = trace.start_time
-    ? new Date(trace.start_time).getTime()
-    : 0;
-  const traceDurationMs = trace.duration_ms || 1;
   const reviewEventCount = trace.timeline_events.filter((event) =>
     ["review_checkpoint", "review_result", "milestone_update"].includes(event.kind),
   ).length;
@@ -442,33 +193,6 @@ export default function TraceDetailPage() {
 
       <TraceInsightRail trace={trace} />
 
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="button"
-          aria-pressed={viewMode === "mainline"}
-          onClick={() => updateViewMode("mainline")}
-          className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
-            viewMode === "mainline"
-              ? "border-accent bg-panel-strong text-foreground"
-              : "border-line text-ink-muted hover:border-line-strong hover:text-foreground"
-          }`}
-        >
-          Mainline
-        </button>
-        <button
-          type="button"
-          aria-pressed={viewMode === "debug"}
-          onClick={() => updateViewMode("debug")}
-          className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
-            viewMode === "debug"
-              ? "border-accent bg-panel-strong text-foreground"
-              : "border-line text-ink-muted hover:border-line-strong hover:text-foreground"
-          }`}
-        >
-          Debug
-        </button>
-      </div>
-
       {trace.input_query && (
         <SectionCard className="p-4">
           <p className="mb-1 text-xs text-ink-faint">Input</p>
@@ -476,40 +200,7 @@ export default function TraceDetailPage() {
         </SectionCard>
       )}
 
-      {viewMode === "mainline" ? (
-        <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-          <TraceMainlineEvents events={trace.mainline_events} />
-          <div className="space-y-6">
-            <TraceReviewCycles cycles={trace.review_cycles} />
-            <TraceRuntimeDecisions decisions={trace.runtime_decisions} />
-          </div>
-        </div>
-      ) : (
-        <>
-          <TraceDiagnostics trace={trace} />
-          <TraceLlmCalls llmCalls={trace.llm_calls} />
-          <TraceRuntimeDecisions decisions={trace.runtime_decisions} />
-          <TraceLoopTimeline events={trace.timeline_events} />
-          <SectionCard
-            className="overflow-hidden"
-            title={`Span Waterfall (${trace.spans.length} spans)`}
-            headerClassName="border-b border-line px-4 py-3"
-          >
-            <div>
-              {trace.spans.map((span) => (
-                <SpanRow
-                  key={span.span_id}
-                  span={span}
-                  traceStartMs={traceStartMs}
-                  traceDurationMs={traceDurationMs}
-                  expanded={expandedSpans.has(span.span_id)}
-                  onToggle={() => toggleSpan(span.span_id)}
-                />
-              ))}
-            </div>
-          </SectionCard>
-        </>
-      )}
+      <TraceDiagnostics trace={trace} />
 
       {trace.final_output && (
         <SectionCard className="p-4">

--- a/console/web/src/components/session-detail/conversation-event-list.test.tsx
+++ b/console/web/src/components/session-detail/conversation-event-list.test.tsx
@@ -17,7 +17,9 @@ describe("ConversationEventList", () => {
             priority: "primary",
             title: "User",
             summary: "Please inspect auth",
-            details: {},
+            details: {
+              content: "Please inspect auth with full context",
+            },
           },
           {
             id: "evt-tool",
@@ -28,7 +30,9 @@ describe("ConversationEventList", () => {
             priority: "secondary",
             title: "Tool: web_search",
             summary: "Searched the repo",
-            details: {},
+            details: {
+              content_for_user: "Searched the repo and found auth.py",
+            },
           },
           {
             id: "evt-review",
@@ -45,17 +49,53 @@ describe("ConversationEventList", () => {
       />,
     );
 
-    expect(screen.getByText("Please inspect auth")).toBeInTheDocument();
-    expect(screen.getByText("Searched the repo")).toBeInTheDocument();
+    expect(screen.getByText("Please inspect auth with full context")).toBeInTheDocument();
+    expect(screen.getByText("Searched the repo and found auth.py")).toBeInTheDocument();
     expect(screen.queryByText("Review misaligned; 2 steps condensed")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Dialogue" }));
-    expect(screen.getByText("Please inspect auth")).toBeInTheDocument();
-    expect(screen.queryByText("Searched the repo")).not.toBeInTheDocument();
+    expect(screen.getByText("Please inspect auth with full context")).toBeInTheDocument();
+    expect(screen.queryByText("Searched the repo and found auth.py")).not.toBeInTheDocument();
     expect(screen.queryByText("Review misaligned; 2 steps condensed")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "All Events" }));
-    expect(screen.getByText("Searched the repo")).toBeInTheDocument();
+    expect(screen.getByText("Searched the repo and found auth.py")).toBeInTheDocument();
     expect(screen.getByText("Review misaligned; 2 steps condensed")).toBeInTheDocument();
+  });
+
+  test("shows assistant tool calls from event details without opening raw JSON", () => {
+    render(
+      <ConversationEventList
+        events={[
+          {
+            id: "evt-assistant",
+            session_id: "sess-1",
+            run_id: "run-1",
+            sequence: 4,
+            kind: "assistant_message",
+            priority: "primary",
+            title: "Assistant",
+            summary: "I will search",
+            details: {
+              content: "I will search the repository.",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: {
+                    name: "grep",
+                    arguments: '{"pattern":"auth"}',
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("I will search the repository.")).toBeInTheDocument();
+    expect(screen.getByText("grep")).toBeInTheDocument();
+    expect(screen.getByText("auth")).toBeInTheDocument();
   });
 });

--- a/console/web/src/components/session-detail/conversation-event-list.tsx
+++ b/console/web/src/components/session-detail/conversation-event-list.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { Bot, GitBranch, User, Wrench } from "lucide-react";
 
 import { JsonDisclosure } from "@/components/json-disclosure";
 import { SectionCard } from "@/components/section-card";
-import type { ConversationEvent } from "@/lib/api";
+import {
+  StepContentPreview,
+  ToolCallPreviewList,
+} from "@/components/step-content-preview";
+import { UserInputDetail } from "@/components/user-input-detail";
+import type { ConversationEvent, ToolCallPayload, UserInput } from "@/lib/api";
 
 type ConversationFilter = "dialogue" | "key-events" | "all";
 
@@ -32,6 +38,53 @@ function eventCardClass(event: ConversationEvent): string {
     return "border-line bg-panel-muted";
   }
   return "border-line bg-panel-muted/60";
+}
+
+function eventIcon(event: ConversationEvent) {
+  if (event.kind === "user_message") {
+    return <User className="h-3.5 w-3.5 text-blue-400" />;
+  }
+  if (event.kind === "assistant_message") {
+    return <Bot className="h-3.5 w-3.5 text-green-400" />;
+  }
+  if (event.kind.includes("tool") || event.kind.includes("milestone")) {
+    return <Wrench className="h-3.5 w-3.5 text-amber-400" />;
+  }
+  return <GitBranch className="h-3.5 w-3.5 text-ink-muted" />;
+}
+
+function firstMeaningfulContent(...values: unknown[]): unknown {
+  for (const value of values) {
+    if (typeof value === "string") {
+      if (value.trim().length > 0) {
+        return value;
+      }
+      continue;
+    }
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function eventContent(event: ConversationEvent): unknown {
+  return firstMeaningfulContent(
+    event.details.content_for_user,
+    event.details.condensed_content,
+    event.details.content,
+    event.summary,
+  );
+}
+
+function eventToolCalls(event: ConversationEvent): ToolCallPayload[] {
+  return Array.isArray(event.details.tool_calls)
+    ? (event.details.tool_calls as ToolCallPayload[])
+    : [];
+}
+
+function eventUserInput(event: ConversationEvent): UserInput | null {
+  return event.details.user_input ? (event.details.user_input as UserInput) : null;
 }
 
 export function ConversationEventList({
@@ -75,40 +128,52 @@ export function ConversationEventList({
         </div>
       ) : (
         <div className="relative space-y-3 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
-          {filteredEvents.map((event) => (
-            <details
-              key={event.id}
-              className={`group relative ml-10 rounded-xl border px-3 py-3 ${eventCardClass(event)}`}
-            >
-              <summary className="cursor-pointer list-none">
+          {filteredEvents.map((event) => {
+            const toolCalls = eventToolCalls(event);
+            const userInput = eventUserInput(event);
+            const content = eventContent(event);
+            return (
+              <div
+                key={event.id}
+                className={`relative ml-10 rounded-xl border px-3 py-3 ${eventCardClass(event)}`}
+              >
                 <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel font-mono text-[11px] text-ink-muted">
-                  {event.sequence ?? "-"}
+                  {eventIcon(event)}
                 </div>
-                <div className="space-y-2">
+                <div className="space-y-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium text-foreground">
                       {event.title}
                     </span>
-                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                      {event.kind}
-                    </span>
-                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                      {event.priority}
-                    </span>
+                    {event.sequence !== null ? (
+                      <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+                        #{event.sequence}
+                      </span>
+                    ) : null}
                   </div>
-                  <p className="text-sm text-foreground">{event.summary}</p>
+                  {event.kind === "user_message" && userInput ? (
+                    <UserInputDetail input={userInput} maxTextLength={2000} />
+                  ) : (
+                    <StepContentPreview value={content} emptyLabel="No event content" />
+                  )}
+                  {toolCalls.length > 0 ? (
+                    <ToolCallPreviewList toolCalls={toolCalls} />
+                  ) : null}
+                  <div className="flex flex-wrap gap-2 text-[11px] text-ink-faint">
+                    <span>{event.kind}</span>
+                    <span>{event.priority}</span>
+                    {event.run_id ? <span>run {event.run_id}</span> : null}
+                  </div>
                 </div>
-              </summary>
-              <div className="mt-3">
                 <JsonDisclosure
-                  label="Details"
+                  label="Raw event JSON"
                   value={event.details}
-                  className="bg-panel"
+                  className="mt-3 bg-panel"
                   contentClassName="bg-panel"
                 />
               </div>
-            </details>
-          ))}
+            );
+          })}
         </div>
       )}
     </SectionCard>

--- a/console/web/src/components/session-detail/session-observability-panel.tsx
+++ b/console/web/src/components/session-detail/session-observability-panel.tsx
@@ -146,13 +146,19 @@ function DecisionCard({ event }: { event: RuntimeDecisionEvent }) {
   );
 }
 
+interface SessionObservabilityPanelProps {
+  sessionId: string;
+  observability: SessionObservability | null;
+  compact?: boolean;
+  className?: string;
+}
+
 export function SessionObservabilityPanel({
   sessionId,
   observability,
-}: {
-  sessionId: string;
-  observability: SessionObservability | null;
-}) {
+  compact = false,
+  className,
+}: SessionObservabilityPanelProps) {
   const recentTraces = observability?.recent_traces ?? [];
   const decisionEvents = observability?.decision_events ?? [];
   const latestTrace = recentTraces[0] ?? null;
@@ -160,6 +166,7 @@ export function SessionObservabilityPanel({
   return (
     <SectionCard
       title="Observability"
+      className={className}
       action={
         <Link
           href={`/traces?session_id=${sessionId}`}
@@ -169,10 +176,14 @@ export function SessionObservabilityPanel({
           <ArrowRight className="h-3 w-3" />
         </Link>
       }
-      bodyClassName="grid gap-4 px-4 py-4 lg:grid-cols-[1.15fr_0.85fr]"
+      bodyClassName={
+        compact
+          ? "space-y-4 px-4 py-4"
+          : "grid gap-4 px-4 py-4 lg:grid-cols-[1.15fr_0.85fr]"
+      }
     >
       <div className="space-y-4">
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className={compact ? "grid gap-2" : "grid gap-3 md:grid-cols-3"}>
           <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
             <div className="text-[11px] uppercase tracking-wide text-ink-faint">Recent Traces</div>
             <div className="mt-2 text-lg font-semibold text-foreground">{recentTraces.length}</div>

--- a/console/web/src/components/session-detail/session-step-card.tsx
+++ b/console/web/src/components/session-detail/session-step-card.tsx
@@ -34,7 +34,7 @@ export function SessionStepCard({ step }: { step: StepResponse }) {
 
   return (
     <div
-      className={`rounded-lg border p-4 ${
+      className={`rounded-lg border ${
         isUser
           ? "border-blue-800/50 bg-blue-950/20"
           : isTool
@@ -42,64 +42,84 @@ export function SessionStepCard({ step }: { step: StepResponse }) {
             : "border-zinc-800 bg-zinc-900"
       }`}
     >
-      <div className="mb-2 flex items-center gap-2">
-        {isUser && <User className="h-4 w-4 text-blue-400" />}
-        {isAssistant && <Bot className="h-4 w-4 text-green-400" />}
-        {isTool && <Wrench className="h-4 w-4 text-amber-400" />}
-        <span className="text-xs font-medium uppercase tracking-wide text-zinc-400">
-          {step.role}
-          {isTool && step.name && ` — ${step.name}`}
-          {step.agent_id && ` — ${step.agent_id}`}
-        </span>
-        <span className="ml-auto text-xs text-zinc-600">#{step.sequence}</span>
+      <div className="border-b border-line px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          {isUser && <User className="h-4 w-4 text-blue-400" />}
+          {isAssistant && <Bot className="h-4 w-4 text-green-400" />}
+          {isTool && <Wrench className="h-4 w-4 text-amber-400" />}
+          <span className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+            {isTool && step.name ? step.name : step.role}
+          </span>
+          <span className="ml-auto rounded-full border border-line px-2 py-0.5 text-[11px] text-zinc-500">
+            #{step.sequence}
+          </span>
+        </div>
       </div>
 
-      {step.reasoning_content && (
-        <div className="mb-2 max-h-48 overflow-auto rounded bg-zinc-800/50 px-3 py-2 text-xs text-zinc-400 whitespace-pre-wrap">
-          <span className="font-medium text-zinc-500">Thinking: </span>
-          {step.reasoning_content}
+      <div className="space-y-3 px-4 py-4">
+        {step.reasoning_content && (
+          <details className="rounded-lg border border-line bg-panel-muted">
+            <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-ink-muted">
+              Thinking
+            </summary>
+            <div className="max-h-48 overflow-auto border-t border-line px-3 py-2 text-xs text-zinc-400 whitespace-pre-wrap">
+              {step.reasoning_content}
+            </div>
+          </details>
+        )}
+
+        <div className="rounded-lg border border-line bg-panel px-3 py-3">
+          {hasStructuredUserInput ? (
+            <div className="max-h-96 overflow-auto">
+              <UserInputDetail input={step.user_input} maxTextLength={2000} />
+            </div>
+          ) : (
+            <StepContentPreview
+              value={displayContent}
+              emptyLabel={
+                isAssistant
+                  ? "No assistant message content"
+                  : isTool
+                    ? "No tool result content"
+                    : "No step content"
+              }
+            />
+          )}
         </div>
-      )}
 
-      {hasStructuredUserInput && (
-        <div className="max-h-96 overflow-auto">
-          <UserInputDetail input={step.user_input} maxTextLength={2000} />
-        </div>
-      )}
+        {step.tool_calls && step.tool_calls.length > 0 && (
+          <ToolCallPreviewList toolCalls={step.tool_calls} />
+        )}
 
-      {!hasStructuredUserInput && (
-        <StepContentPreview
-          value={displayContent}
-          emptyLabel={
-            isAssistant
-              ? "No assistant message content"
-              : isTool
-                ? "No tool result content"
-                : "No step content"
-          }
-        />
-      )}
+        {originalContent !== null && originalContent !== undefined && (
+          <RawJsonBlock label="Original result" value={originalContent} />
+        )}
 
-      {originalContent !== null && originalContent !== undefined && (
-        <RawJsonBlock className="mt-3" label="Original result" value={originalContent} />
-      )}
+        <details className="rounded-lg border border-line bg-panel-muted">
+          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-ink-muted">
+            Step details
+          </summary>
+          <div className="space-y-3 border-t border-line px-3 py-3">
+            <div className="flex flex-wrap gap-3 text-xs text-ink-muted">
+              {step.agent_id ? <span>Agent {step.agent_id}</span> : null}
+              <span>Run {step.run_id}</span>
+              {step.tool_call_id ? <span>Tool call {step.tool_call_id}</span> : null}
+              {step.created_at ? <span>{step.created_at}</span> : null}
+            </div>
+            {step.metrics && (
+              <TokenMetricsBadges
+                metrics={metrics}
+                showDuration={true}
+                showModelName={true}
+                modelName={step.metrics?.model_name ?? null}
+                chipClassName="bg-panel-strong"
+              />
+            )}
 
-      {step.tool_calls && step.tool_calls.length > 0 && (
-        <ToolCallPreviewList toolCalls={step.tool_calls} />
-      )}
-
-      {step.metrics && (
-        <div className="mt-3">
-          <TokenMetricsBadges
-            metrics={metrics}
-            showDuration={true}
-            showModelName={true}
-            modelName={step.metrics?.model_name ?? null}
-          />
-        </div>
-      )}
-
-      <RawJsonBlock className="mt-3" label="Raw step JSON" value={step} />
+            <RawJsonBlock label="Raw step JSON" value={step} />
+          </div>
+        </details>
+      </div>
     </div>
   );
 }

--- a/console/web/src/components/step-content-preview.tsx
+++ b/console/web/src/components/step-content-preview.tsx
@@ -6,12 +6,22 @@ import { JsonDisclosure } from "@/components/json-disclosure";
 import type { ToolCallPayload } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-function tryParseJson(value: string): unknown {
+const JSON_PARSE_FAILED = Symbol("json_parse_failed");
+
+function tryParseJson(value: string): unknown | typeof JSON_PARSE_FAILED {
   try {
     return JSON.parse(value);
   } catch {
-    return null;
+    return JSON_PARSE_FAILED;
   }
+}
+
+function displayValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const parsed = tryParseJson(value);
+  return parsed !== JSON_PARSE_FAILED ? parsed : value;
 }
 
 export function stringifyPretty(value: unknown): string {
@@ -20,7 +30,7 @@ export function stringifyPretty(value: unknown): string {
   }
   if (typeof value === "string") {
     const parsed = tryParseJson(value);
-    if (parsed !== null) {
+    if (parsed !== JSON_PARSE_FAILED) {
       return JSON.stringify(parsed, null, 2);
     }
     return value;
@@ -174,22 +184,29 @@ export function ToolCallPreviewList({ toolCalls }: { toolCalls: ToolCallPayload[
       {toolCalls.map((toolCall, index) => {
         const toolName = toolCall.function?.name || "tool_call";
         const args = toolCall.function?.arguments ?? toolCall;
+        const parsedArgs = displayValue(args);
         return (
-          <details key={`${toolName}-${toolCall.id ?? index}`} className="rounded-lg border border-line bg-panel-muted">
-            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs">
+          <div
+            key={`${toolName}-${toolCall.id ?? index}`}
+            className="rounded-lg border border-line bg-panel-muted"
+          >
+            <div className="flex items-center gap-2 border-b border-line px-3 py-2 text-xs">
               <Wrench className="h-3.5 w-3.5 text-warning" />
               <span className="font-medium text-ink-soft">{toolName}</span>
               {toolCall.id ? (
                 <span className="font-mono text-[11px] text-ink-faint">{toolCall.id}</span>
               ) : null}
-              <span className="ml-auto max-w-72 truncate font-mono text-[11px] text-ink-faint">
-                {compactText(stringifyPretty(args), 160)}
-              </span>
-            </summary>
-            <pre className="max-h-56 overflow-auto border-t border-line px-3 py-2 font-mono text-xs text-ink-muted whitespace-pre-wrap break-words">
-              {stringifyPretty(args)}
-            </pre>
-          </details>
+            </div>
+            <div className="px-3 py-2">
+              <StructuredValuePreview value={parsedArgs} />
+            </div>
+            <JsonDisclosure
+              label="Raw arguments"
+              value={parsedArgs}
+              className="m-2 mt-0 bg-panel"
+              contentClassName="bg-panel"
+            />
+          </div>
         );
       })}
     </div>

--- a/console/web/src/components/trace-detail/trace-diagnostics.test.tsx
+++ b/console/web/src/components/trace-detail/trace-diagnostics.test.tsx
@@ -112,15 +112,14 @@ function buildTrace(): TraceDetail {
 }
 
 describe("TraceDiagnostics", () => {
-  test("renders risk signals, paired tool transactions, and LLM prompt messages", () => {
+  test("renders risks, LLM content, tool calls, and tool results in one chain", () => {
     render(<TraceDiagnostics trace={buildTrace()} />);
 
-    expect(screen.getByText("Diagnostic Summary")).toBeInTheDocument();
+    expect(screen.getByText("Agent Execution Diagnostics")).toBeInTheDocument();
     expect(screen.getByText(/errored span/)).toBeInTheDocument();
     expect(screen.getByText(/high token usage/)).toBeInTheDocument();
-    expect(screen.getByText("Execution Chain")).toBeInTheDocument();
-    expect(screen.getByText("Tool Transactions")).toBeInTheDocument();
-    expect(screen.getByText("LLM Call Inspector")).toBeInTheDocument();
+    expect(screen.getByText("Assistant message")).toBeInTheDocument();
+    expect(screen.getByText("Prompt context (2 messages, 1 tool available)")).toBeInTheDocument();
     expect(screen.getByText("Find the bug.")).toBeInTheDocument();
     expect(screen.getAllByText("read_file").length).toBeGreaterThan(0);
     expect(screen.getAllByText("file missing").length).toBeGreaterThan(0);

--- a/console/web/src/components/trace-detail/trace-diagnostics.tsx
+++ b/console/web/src/components/trace-detail/trace-diagnostics.tsx
@@ -12,9 +12,28 @@ import {
   contentText,
   stringifyPretty,
 } from "@/components/step-content-preview";
-import type { SpanResponse, ToolCallPayload, TraceDetail } from "@/lib/api";
+import { TraceStatusBadge } from "@/components/trace-status-badge";
+import type { RuntimeDecisionEvent, SpanResponse, ToolCallPayload, TraceDetail } from "@/lib/api";
 import { formatDurationMs, formatTokenCount } from "@/lib/metrics";
 import { formatLocalDateTime } from "@/lib/time";
+
+interface SpanChainEvent {
+  id: string;
+  time: string | null;
+  sequence: number | null;
+  type: "span";
+  span: SpanResponse;
+}
+
+interface DecisionChainEvent {
+  id: string;
+  time: string | null;
+  sequence: number | null;
+  type: "decision";
+  decision: RuntimeDecisionEvent;
+}
+
+type ChainEvent = SpanChainEvent | DecisionChainEvent;
 
 type RecordValue = Record<string, unknown>;
 
@@ -52,10 +71,6 @@ function toolSpans(trace: TraceDetail): SpanResponse[] {
   return trace.spans.filter((span) => span.kind === "tool_call" && span.tool_details);
 }
 
-function toolCallId(span: SpanResponse): string | null {
-  return stringValue(span.tool_details?.tool_call_id) ?? stringValue(span.attributes.tool_call_id);
-}
-
 function toolName(span: SpanResponse): string {
   return stringValue(span.tool_details?.tool_name) ?? span.name;
 }
@@ -67,13 +82,12 @@ function responseToolCalls(span: SpanResponse): ToolCallPayload[] {
 
 function traceRiskSignals(trace: TraceDetail): string[] {
   const signals: string[] = [];
-  const spans = trace.spans;
-  const errors = spans.filter((span) => span.status === "error" || span.error_message);
+  const errors = trace.spans.filter((span) => span.status === "error" || span.error_message);
   if (errors.length > 0) {
     signals.push(`${errors.length} errored span${errors.length === 1 ? "" : "s"}`);
   }
 
-  const slowest = [...spans]
+  const slowest = [...trace.spans]
     .filter((span) => span.duration_ms !== null)
     .sort((a, b) => (b.duration_ms ?? 0) - (a.duration_ms ?? 0))[0];
   if (slowest && (slowest.duration_ms ?? 0) >= 10_000) {
@@ -117,7 +131,232 @@ function traceRiskSignals(trace: TraceDetail): string[] {
   return signals;
 }
 
-function DiagnosticsOverview({ trace }: { trace: TraceDetail }) {
+function messageRole(message: unknown): string {
+  if (isRecord(message)) {
+    return stringValue(message.role) ?? stringValue(message.type) ?? "message";
+  }
+  return "message";
+}
+
+function messageContent(message: unknown): unknown {
+  if (isRecord(message)) {
+    return message.content ?? message.text ?? message;
+  }
+  return message;
+}
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : plural;
+}
+
+function eventIcon(event: ChainEvent) {
+  if (event.type === "decision") {
+    return <GitBranch className="h-3.5 w-3.5 text-ink-muted" />;
+  }
+  if (event.span.kind === "llm_call") {
+    return <Zap className="h-3.5 w-3.5 text-success" />;
+  }
+  if (event.span.kind === "tool_call") {
+    return <Wrench className="h-3.5 w-3.5 text-warning" />;
+  }
+  return <Bot className="h-3.5 w-3.5 text-accent" />;
+}
+
+function ChainHeader({ event }: { event: ChainEvent }) {
+  const title =
+    event.type === "decision"
+      ? event.decision.kind.replaceAll("_", " ")
+      : event.span.kind === "tool_call"
+        ? toolName(event.span)
+        : event.span.name;
+  const status = event.type === "decision" ? null : event.span.status;
+  const duration = event.type === "decision" ? null : event.span.duration_ms;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm font-medium text-foreground">{title}</span>
+      {status ? <TraceStatusBadge status={status} /> : null}
+      {event.sequence !== null ? (
+        <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
+          seq {event.sequence}
+        </span>
+      ) : null}
+      {duration !== null ? (
+        <span className="rounded-full border border-line bg-panel-muted px-2 py-0.5 text-[11px] text-ink-muted">
+          {formatDurationMs(duration)}
+        </span>
+      ) : null}
+      <span className="ml-auto text-xs text-ink-faint">{formatLocalDateTime(event.time)}</span>
+    </div>
+  );
+}
+
+function LlmEventBody({ span }: { span: SpanResponse }) {
+  const details = span.llm_details ?? {};
+  const messages = Array.isArray(details.messages) ? details.messages : [];
+  const tools = Array.isArray(details.tools) ? details.tools : [];
+  const calls = responseToolCalls(span);
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="mb-1 text-xs font-medium text-ink-faint">Assistant message</div>
+        <StepContentPreview
+          value={details.response_content ?? span.output_preview}
+          emptyLabel="No assistant response content"
+        />
+      </div>
+      {calls.length > 0 ? <ToolCallPreviewList toolCalls={calls} /> : null}
+      <details className="rounded-lg border border-line bg-panel-muted">
+        <summary className="cursor-pointer list-none px-3 py-2 text-xs text-ink-muted">
+          Prompt context ({messages.length}{" "}
+          {pluralize(messages.length, "message", "messages")}, {tools.length}{" "}
+          {pluralize(tools.length, "tool", "tools")} available)
+        </summary>
+        <div className="max-h-96 space-y-2 overflow-auto border-t border-line px-3 py-3">
+          {messages.slice(0, 12).map((message, index) => (
+            <div key={index} className="rounded-lg border border-line bg-panel px-3 py-2">
+              <div className="mb-1 text-[11px] uppercase tracking-wide text-ink-faint">
+                {messageRole(message)}
+              </div>
+              <StepContentPreview value={messageContent(message)} emptyLabel="Empty message" />
+            </div>
+          ))}
+          {messages.length > 12 ? (
+            <p className="text-xs text-ink-faint">
+              {messages.length - 12} more messages in raw LLM details.
+            </p>
+          ) : null}
+        </div>
+      </details>
+      <JsonDisclosure
+        label="Raw LLM details JSON"
+        value={details}
+        className="bg-panel"
+        contentClassName="bg-panel"
+      />
+    </div>
+  );
+}
+
+function ToolEventBody({ span }: { span: SpanResponse }) {
+  const details = span.tool_details ?? {};
+  const output = details.content_for_user ?? details.output ?? details.error ?? span.output_preview;
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <div>
+        <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
+        <StructuredValuePreview value={details.input_args ?? {}} />
+      </div>
+      <div>
+        <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
+        <StepContentPreview value={output} emptyLabel="No tool result content" />
+      </div>
+      <JsonDisclosure
+        label="Raw tool details JSON"
+        value={details}
+        className="bg-panel lg:col-span-2"
+        contentClassName="bg-panel"
+      />
+    </div>
+  );
+}
+
+function DecisionBody({ decision }: { decision: RuntimeDecisionEvent }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm leading-6 text-foreground">{decision.summary}</p>
+      <div className="flex flex-wrap gap-2 text-[11px] text-ink-muted">
+        <span>run {decision.run_id}</span>
+        <span>agent {decision.agent_id}</span>
+      </div>
+      <JsonDisclosure
+        label="Decision details JSON"
+        value={decision.details}
+        className="bg-panel"
+        contentClassName="bg-panel"
+      />
+    </div>
+  );
+}
+
+function SpanFallbackBody({ span }: { span: SpanResponse }) {
+  const preview = span.output_preview ?? span.input_preview ?? span.error_message;
+  return (
+    <div className="space-y-3">
+      <StepContentPreview value={preview} emptyLabel="No span preview" />
+      {span.error_message ? (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {span.error_message}
+        </div>
+      ) : null}
+      <JsonDisclosure
+        label="Span attributes JSON"
+        value={span.attributes}
+        className="bg-panel"
+        contentClassName="bg-panel"
+      />
+    </div>
+  );
+}
+
+function ChainEventRow({ event }: { event: ChainEvent }) {
+  return (
+    <div className="relative ml-10 rounded-xl border border-line bg-panel px-3 py-3">
+      <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel">
+        {eventIcon(event)}
+      </div>
+      <div className="space-y-3">
+        <ChainHeader event={event} />
+        {event.type === "decision" ? (
+          <DecisionBody decision={event.decision} />
+        ) : event.span.kind === "llm_call" && event.span.llm_details ? (
+          <LlmEventBody span={event.span} />
+        ) : event.span.kind === "tool_call" && event.span.tool_details ? (
+          <ToolEventBody span={event.span} />
+        ) : (
+          <SpanFallbackBody span={event.span} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function buildChainEvents(trace: TraceDetail): ChainEvent[] {
+  const spanEvents = trace.spans.map((span) => ({
+    id: `span:${span.span_id}`,
+    time: span.start_time,
+    sequence: spanSequence(span),
+    type: "span" as const,
+    span,
+  }));
+  const decisionEvents = trace.runtime_decisions.map((decision) => ({
+    id: `decision:${decision.kind}:${decision.sequence}:${decision.run_id}`,
+    time: decision.created_at,
+    sequence: decision.sequence,
+    type: "decision" as const,
+    decision,
+  }));
+
+  const eventTime = (time: string | null): number => {
+    if (!time) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    const parsed = new Date(time).getTime();
+    return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+  };
+
+  return [...spanEvents, ...decisionEvents].sort((a, b) => {
+    const byTime = eventTime(a.time) - eventTime(b.time);
+    if (byTime !== 0) {
+      return byTime;
+    }
+    return (a.sequence ?? Number.MAX_SAFE_INTEGER) - (b.sequence ?? Number.MAX_SAFE_INTEGER);
+  });
+}
+
+function DiagnosticSummaryStrip({ trace }: { trace: TraceDetail }) {
   const risks = traceRiskSignals(trace);
   const slowest = [...trace.spans]
     .filter((span) => span.duration_ms !== null)
@@ -130,9 +369,9 @@ function DiagnosticsOverview({ trace }: { trace: TraceDetail }) {
     )[0];
 
   return (
-    <SectionCard title="Diagnostic Summary" bodyClassName="grid gap-3 px-4 py-4 lg:grid-cols-3">
-      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
-        <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
+    <div className="grid gap-3 border-b border-line bg-panel-muted px-4 py-3 lg:grid-cols-3">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
           <AlertTriangle className="h-3.5 w-3.5" />
           Risk Signals
         </div>
@@ -151,7 +390,7 @@ function DiagnosticsOverview({ trace }: { trace: TraceDetail }) {
           </div>
         )}
       </div>
-      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
+      <div>
         <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
           <Clock className="h-3.5 w-3.5" />
           Bottleneck
@@ -162,304 +401,51 @@ function DiagnosticsOverview({ trace }: { trace: TraceDetail }) {
             : "No timed spans"}
         </p>
       </div>
-      <div className="rounded-xl border border-line bg-panel-muted px-3 py-3">
+      <div>
         <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-ink-faint">
           <Zap className="h-3.5 w-3.5" />
           Heaviest LLM Call
         </div>
         <p className="text-sm text-foreground">
-          {mostExpensive
-            ? `${mostExpensive.name} (${formatTokenCount(numberValue(mostExpensive.metrics["tokens.total"]) ?? 0)} tokens)`
-            : "No LLM calls"}
+          {mostExpensive ? (
+            <>
+              {mostExpensive.name}{" "}
+              <MonoText>
+                {formatTokenCount(numberValue(mostExpensive.metrics["tokens.total"]) ?? 0)}
+              </MonoText>
+            </>
+          ) : (
+            "No LLM calls"
+          )}
         </p>
       </div>
-    </SectionCard>
-  );
-}
-
-function messageRole(message: unknown): string {
-  if (isRecord(message)) {
-    return stringValue(message.role) ?? stringValue(message.type) ?? "message";
-  }
-  return "message";
-}
-
-function messageContent(message: unknown): unknown {
-  if (isRecord(message)) {
-    return message.content ?? message.text ?? message;
-  }
-  return message;
-}
-
-function LlmCallInspector({ trace }: { trace: TraceDetail }) {
-  const spans = llmSpans(trace);
-  return (
-    <SectionCard title="LLM Call Inspector" bodyClassName="space-y-3 px-4 py-4">
-      {spans.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
-          No LLM call details recorded for this trace.
-        </div>
-      ) : (
-        spans.map((span, index) => {
-          const details = span.llm_details ?? {};
-          const messages = Array.isArray(details.messages) ? details.messages : [];
-          const tools = Array.isArray(details.tools) ? details.tools : [];
-          const calls = responseToolCalls(span);
-          return (
-            <details key={span.span_id} className="rounded-xl border border-line bg-panel px-3 py-3">
-              <summary className="cursor-pointer list-none">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Bot className="h-4 w-4 text-success" />
-                  <span className="text-sm font-medium text-foreground">
-                    {span.name || `LLM call ${index + 1}`}
-                  </span>
-                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
-                    seq {spanSequence(span) ?? "-"}
-                  </span>
-                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
-                    {messages.length} messages
-                  </span>
-                  <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
-                    {tools.length} tools available
-                  </span>
-                  {stringValue(details.finish_reason) ? (
-                    <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                      {stringValue(details.finish_reason)}
-                    </span>
-                  ) : null}
-                </div>
-                <p className="mt-2 text-sm text-ink-muted">
-                  {compact(details.response_content ?? span.output_preview ?? "No response preview")}
-                </p>
-              </summary>
-              <div className="mt-3 space-y-4">
-                <div>
-                  <div className="mb-2 text-xs uppercase tracking-wide text-ink-faint">
-                    Prompt Messages
-                  </div>
-                  <div className="space-y-2">
-                    {messages.slice(0, 20).map((message, messageIndex) => (
-                      <div
-                        key={messageIndex}
-                        className="rounded-lg border border-line bg-panel-muted px-3 py-2"
-                      >
-                        <div className="mb-1 text-[11px] uppercase tracking-wide text-ink-faint">
-                          {messageRole(message)}
-                        </div>
-                        <StepContentPreview
-                          value={messageContent(message)}
-                          emptyLabel="Empty message"
-                        />
-                      </div>
-                    ))}
-                    {messages.length > 20 ? (
-                      <p className="text-xs text-ink-faint">
-                        {messages.length - 20} more messages in raw details.
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-                <div>
-                  <div className="mb-2 text-xs uppercase tracking-wide text-ink-faint">
-                    Model Response
-                  </div>
-                  <StepContentPreview
-                    value={details.response_content}
-                    emptyLabel="No assistant response content"
-                  />
-                  {calls.length > 0 ? <ToolCallPreviewList toolCalls={calls} /> : null}
-                </div>
-                <JsonDisclosure
-                  label="Raw LLM details JSON"
-                  value={details}
-                  className="bg-panel"
-                  contentClassName="bg-panel"
-                />
-              </div>
-            </details>
-          );
-        })
-      )}
-    </SectionCard>
-  );
-}
-
-function ToolTransactions({ trace }: { trace: TraceDetail }) {
-  const toolsByCallId = new Map<string, SpanResponse>();
-  for (const span of toolSpans(trace)) {
-    const id = toolCallId(span);
-    if (id) {
-      toolsByCallId.set(id, span);
-    }
-  }
-
-  const transactions = llmSpans(trace).flatMap((llmSpan) =>
-    responseToolCalls(llmSpan).map((call) => ({
-      llmSpan,
-      call,
-      toolSpan: call.id ? toolsByCallId.get(call.id) ?? null : null,
-    })),
-  );
-  const unmatchedTools = toolSpans(trace).filter((span) => {
-    const id = toolCallId(span);
-    return !id || !transactions.some((item) => item.call.id === id);
-  });
-
-  return (
-    <SectionCard title="Tool Transactions" bodyClassName="space-y-3 px-4 py-4">
-      {transactions.length === 0 && unmatchedTools.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
-          No tool transactions recorded for this trace.
-        </div>
-      ) : null}
-      {transactions.map(({ llmSpan, call, toolSpan }, index) => {
-        const output =
-          toolSpan?.tool_details?.content_for_user ??
-          toolSpan?.tool_details?.output ??
-          toolSpan?.tool_details?.error;
-        return (
-          <div key={`${call.id ?? "call"}-${index}`} className="rounded-xl border border-line bg-panel px-3 py-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <Wrench className="h-4 w-4 text-warning" />
-              <span className="text-sm font-medium text-foreground">
-                {call.function?.name ?? toolSpan?.name ?? "tool_call"}
-              </span>
-              {call.id ? <MonoText>{call.id}</MonoText> : null}
-              <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
-                from seq {spanSequence(llmSpan) ?? "-"}
-              </span>
-              <span
-                className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide ${
-                  toolSpan?.status === "error"
-                    ? "border-red-500/40 bg-red-500/10 text-red-200"
-                    : toolSpan
-                      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
-                      : "border-amber-500/40 bg-amber-500/10 text-amber-200"
-                }`}
-              >
-                {toolSpan ? toolSpan.status : "missing result"}
-              </span>
-              {toolSpan?.duration_ms != null ? (
-                <span className="rounded-full border border-line bg-panel-muted px-2 py-1 text-[11px] text-ink-muted">
-                  {formatDurationMs(toolSpan.duration_ms)}
-                </span>
-              ) : null}
-            </div>
-            <div className="mt-3 grid gap-3 lg:grid-cols-2">
-              <div>
-                <div className="mb-1 text-xs font-medium text-ink-faint">Arguments</div>
-                <StructuredValuePreview value={call.function?.arguments ?? toolSpan?.tool_details?.input_args ?? {}} />
-              </div>
-              <div>
-                <div className="mb-1 text-xs font-medium text-ink-faint">Result</div>
-                <StepContentPreview value={output} emptyLabel="No matching tool result" />
-              </div>
-            </div>
-          </div>
-        );
-      })}
-      {unmatchedTools.map((span) => (
-        <div key={span.span_id} className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-3">
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <Wrench className="h-4 w-4 text-warning" />
-            <span className="text-sm font-medium text-foreground">{toolName(span)}</span>
-            <span className="text-xs text-amber-200">Tool result without matched assistant call</span>
-          </div>
-          <StepContentPreview
-            value={span.tool_details?.output ?? span.tool_details?.error}
-            emptyLabel="No tool result content"
-          />
-        </div>
-      ))}
-    </SectionCard>
-  );
-}
-
-function ExecutionChain({ trace }: { trace: TraceDetail }) {
-  const spanEvents = trace.spans.map((span) => ({
-    id: `span:${span.span_id}`,
-    time: span.start_time,
-    sequence: spanSequence(span),
-    kind: span.kind,
-    title: span.name,
-    summary:
-      span.kind === "tool_call"
-        ? compact(span.tool_details?.output ?? span.tool_details?.error ?? span.output_preview ?? "")
-        : compact(span.output_preview ?? span.llm_details?.response_content ?? span.error_message ?? ""),
-    status: span.status,
-    duration: span.duration_ms,
-  }));
-  const decisionEvents = trace.runtime_decisions.map((decision) => ({
-    id: `decision:${decision.kind}:${decision.sequence}:${decision.run_id}`,
-    time: decision.created_at,
-    sequence: decision.sequence,
-    kind: decision.kind,
-    title: decision.kind.replaceAll("_", " "),
-    summary: decision.summary,
-    status: decision.kind.includes("failed") ? "error" : "ok",
-    duration: null,
-  }));
-  const events = [...spanEvents, ...decisionEvents].sort((a, b) => {
-    const byTime = new Date(a.time ?? 0).getTime() - new Date(b.time ?? 0).getTime();
-    if (byTime !== 0) {
-      return byTime;
-    }
-    return (a.sequence ?? 0) - (b.sequence ?? 0);
-  });
-
-  return (
-    <SectionCard title="Execution Chain" bodyClassName="space-y-2 px-4 py-4">
-      {events.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
-          No execution chain events available.
-        </div>
-      ) : (
-        <div className="relative space-y-2 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
-          {events.map((event) => (
-            <div key={event.id} className="relative ml-10 rounded-xl border border-line bg-panel px-3 py-3">
-              <div className="absolute -left-10 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-line bg-panel">
-                {event.kind === "llm_call" ? (
-                  <Zap className="h-3.5 w-3.5 text-success" />
-                ) : event.kind === "tool_call" ? (
-                  <Wrench className="h-3.5 w-3.5 text-warning" />
-                ) : (
-                  <GitBranch className="h-3.5 w-3.5 text-ink-muted" />
-                )}
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm font-medium text-foreground">{event.title}</span>
-                <span className="rounded-full border border-line px-2 py-0.5 text-[11px] uppercase tracking-wide text-ink-muted">
-                  {event.kind}
-                </span>
-                <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-muted">
-                  seq {event.sequence ?? "-"}
-                </span>
-                {event.duration != null ? (
-                  <span className="rounded-full border border-line bg-panel-muted px-2 py-1 text-[11px] text-ink-muted">
-                    {formatDurationMs(event.duration)}
-                  </span>
-                ) : null}
-                <span className="ml-auto text-xs text-ink-muted">{formatLocalDateTime(event.time)}</span>
-              </div>
-              {event.summary ? (
-                <p className="mt-2 text-sm leading-5 text-ink-muted">{event.summary}</p>
-              ) : null}
-            </div>
-          ))}
-        </div>
-      )}
-    </SectionCard>
+    </div>
   );
 }
 
 export function TraceDiagnostics({ trace }: { trace: TraceDetail }) {
+  const events = buildChainEvents(trace);
+
   return (
-    <div className="space-y-6">
-      <DiagnosticsOverview trace={trace} />
-      <ExecutionChain trace={trace} />
-      <ToolTransactions trace={trace} />
-      <LlmCallInspector trace={trace} />
-    </div>
+    <SectionCard
+      title="Agent Execution Diagnostics"
+      headerClassName="border-b border-line px-4 py-3"
+    >
+      <DiagnosticSummaryStrip trace={trace} />
+      <div className="px-4 py-4">
+        {events.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-line px-4 py-6 text-sm text-ink-muted">
+            No execution chain events available.
+          </div>
+        ) : (
+          <div className="relative space-y-3 before:absolute before:left-[1.05rem] before:top-3 before:h-[calc(100%-1.5rem)] before:w-px before:bg-line">
+            {events.map((event) => (
+              <ChainEventRow key={event.id} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+    </SectionCard>
   );
 }
 


### PR DESCRIPTION
## Summary
- Make session steps and conversation events prioritize message content, tool calls, and tool results over IDs and metrics
- Move session debug observability and run details into a side panel with simplified run summaries
- Replace trace mainline/debug split with one unified agent execution diagnostics chain

## Tests
- cd console/web && npm run lint
- cd console/web && npm test
- cd console/web && npm run build
- uv run python scripts/check.py console-tests
- pre-push hook: uv run python scripts/lint.py ci, uv run pytest tests/ -v --tb=short, console tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned debug session view with responsive two-column grid layout and sticky sidebar for better space utilization.
  * Enhanced runs display with card-based metrics and collapsible token breakdowns.
  * Improved tool call visualization with parsed arguments and structured previews.
  * Added compact mode to observability panel for flexible layout options.

* **Refactor**
  * Simplified trace detail pages with unified diagnostics view, removing debug/mainline mode switching.
  * Redesigned event list from collapsible to card-based layout with better content and metadata display.
  * Restructured step cards with collapsible thinking and details sections for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->