### PR TITLE
Fix traces list horizontal overflow

### DIFF
--- a/console/web/src/app/traces/page.tsx
+++ b/console/web/src/app/traces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, Suspense, useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -24,6 +25,41 @@ const TRACE_STATUS_FILTERS = [
   { label: "Running", value: "running" },
   { label: "Unset", value: "unset" },
 ];
+
+const TRACE_ROW_GRID =
+  "xl:grid-cols-[7rem_minmax(0,2fr)_8.5rem_8.5rem_6rem_6rem_7rem_5rem_6rem_8rem]";
+
+function compactIdentifier(value: string, head = 8, tail = 4) {
+  if (value.length <= head + tail + 3) {
+    return value;
+  }
+  return `${value.slice(0, head)}...${value.slice(-tail)}`;
+}
+
+function TraceListCell({
+  label,
+  children,
+  align = "left",
+}: {
+  label: string;
+  children: ReactNode;
+  align?: "left" | "center" | "right";
+}) {
+  return (
+    <div
+      className={[
+        "min-w-0",
+        align === "center" ? "xl:text-center" : "",
+        align === "right" ? "xl:text-right" : "",
+      ].join(" ")}
+    >
+      <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-zinc-600 xl:sr-only">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
 
 function TracesPageContent() {
   const router = useRouter();
@@ -206,107 +242,117 @@ function TracesPageContent() {
       ) : traces.length === 0 ? (
         <EmptyStateMessage>No traces found</EmptyStateMessage>
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-zinc-800">
-          <table className="w-full text-sm">
-            <thead className="bg-zinc-900 text-zinc-400 text-xs uppercase tracking-wide">
-              <tr>
-                <th className="text-left px-4 py-3">Trace</th>
-                <th className="text-left px-4 py-3">Input / Output</th>
-                <th className="text-left px-4 py-3">Session</th>
-                <th className="text-left px-4 py-3">Agent</th>
-                <th className="text-center px-4 py-3">Status</th>
-                <th className="text-right px-4 py-3">Cost</th>
-                <th className="text-right px-4 py-3">Tokens</th>
-                <th className="text-right px-4 py-3">Calls</th>
-                <th className="text-right px-4 py-3">Duration</th>
-                <th className="text-right px-4 py-3">Started</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-800">
-              {traces.map((t) => (
-                <tr
-                  key={t.trace_id}
-                  className="hover:bg-zinc-900/50 transition-colors"
-                >
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <Link
-                        href={`/traces/${t.trace_id}`}
-                        className="font-mono text-xs text-zinc-200 transition-colors hover:text-white"
-                      >
-                        {t.trace_id.slice(0, 12)}
-                      </Link>
-                      <CopyButton
-                        value={t.trace_id}
-                        label="Copy"
-                        className="h-5 px-1.5"
-                      />
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 min-w-[20rem] max-w-md">
+        <div className="overflow-hidden rounded-lg border border-zinc-800">
+          <div
+            className={`hidden ${TRACE_ROW_GRID} gap-3 bg-zinc-900 px-4 py-3 text-xs uppercase tracking-wide text-zinc-400 xl:grid`}
+          >
+            <div>Trace</div>
+            <div>Input / Output</div>
+            <div>Session</div>
+            <div>Agent</div>
+            <div className="text-center">Status</div>
+            <div className="text-right">Cost</div>
+            <div className="text-right">Tokens</div>
+            <div className="text-right">Calls</div>
+            <div className="text-right">Duration</div>
+            <div className="text-right">Started</div>
+          </div>
+
+          <div className="divide-y divide-zinc-800">
+            {traces.map((t) => (
+              <article
+                key={t.trace_id}
+                className={`grid gap-3 px-4 py-4 text-sm transition-colors hover:bg-zinc-900/50 sm:grid-cols-2 xl:grid ${TRACE_ROW_GRID} xl:items-center xl:py-3`}
+              >
+                <TraceListCell label="Trace">
+                  <div className="flex min-w-0 items-center gap-2">
                     <Link
                       href={`/traces/${t.trace_id}`}
-                      className="block text-zinc-200 transition-colors hover:text-white"
+                      title={t.trace_id}
+                      className="font-mono text-xs text-zinc-200 transition-colors hover:text-white"
                     >
-                      <span className="line-clamp-2">
-                        {t.input_query || "Trace detail"}
-                      </span>
-                      {t.final_output ? (
-                        <span className="mt-1 block truncate text-xs text-zinc-500">
-                          {t.final_output}
-                        </span>
-                      ) : null}
+                      {compactIdentifier(t.trace_id, 10, 4)}
                     </Link>
-                  </td>
-                  <td className="px-4 py-3 text-zinc-400">
-                    {t.session_id ? (
-                      <Link
-                        href={`/sessions/${t.session_id}`}
-                        className="transition-colors hover:text-zinc-200"
-                      >
-                        <MonoText truncate className="max-w-[9rem]">
-                          {t.session_id}
-                        </MonoText>
-                      </Link>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-zinc-400">
-                    {t.agent_id ? (
-                      <MonoText truncate className="max-w-[9rem]">
-                        {t.agent_id}
-                      </MonoText>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <TraceStatusBadge status={t.status} />
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-200">
-                    {formatUsd(t.total_token_cost)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    <div>{formatTokenCount(t.total_tokens)}</div>
-                    <div className="text-[11px] text-zinc-500">
-                      {formatTokenCount(t.total_input_tokens)} in / {formatTokenCount(t.total_output_tokens)} out
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    <div>{t.total_llm_calls} llm</div>
-                    <div className="text-[11px] text-zinc-500">{t.total_tool_calls} tools</div>
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-400">
-                    {formatRoundedMs(t.duration_ms)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-xs text-zinc-500">
+                    <CopyButton
+                      value={t.trace_id}
+                      label="Copy"
+                      className="h-5 px-1.5"
+                    />
+                  </div>
+                </TraceListCell>
+
+                <TraceListCell label="Input / Output">
+                  <Link
+                    href={`/traces/${t.trace_id}`}
+                    className="block min-w-0 text-zinc-200 transition-colors hover:text-white"
+                  >
+                    <span className="line-clamp-2">
+                      {t.input_query || "Trace detail"}
+                    </span>
+                    {t.final_output ? (
+                      <span className="mt-1 block truncate text-xs text-zinc-500">
+                        {t.final_output}
+                      </span>
+                    ) : null}
+                  </Link>
+                </TraceListCell>
+
+                <TraceListCell label="Session">
+                  {t.session_id ? (
+                    <Link
+                      href={`/sessions/${t.session_id}`}
+                      title={t.session_id}
+                      className="inline-flex max-w-full transition-colors hover:text-zinc-200"
+                    >
+                      <MonoText>{compactIdentifier(t.session_id)}</MonoText>
+                    </Link>
+                  ) : (
+                    <span className="text-zinc-500">-</span>
+                  )}
+                </TraceListCell>
+
+                <TraceListCell label="Agent">
+                  {t.agent_id ? (
+                    <MonoText title={t.agent_id}>
+                      {compactIdentifier(t.agent_id)}
+                    </MonoText>
+                  ) : (
+                    <span className="text-zinc-500">-</span>
+                  )}
+                </TraceListCell>
+
+                <TraceListCell label="Status" align="center">
+                  <TraceStatusBadge status={t.status} />
+                </TraceListCell>
+
+                <TraceListCell label="Cost" align="right">
+                  <span className="text-zinc-200">{formatUsd(t.total_token_cost)}</span>
+                </TraceListCell>
+
+                <TraceListCell label="Tokens" align="right">
+                  <div className="text-zinc-400">{formatTokenCount(t.total_tokens)}</div>
+                  <div className="text-[11px] text-zinc-500">
+                    {formatTokenCount(t.total_input_tokens)} in / {formatTokenCount(t.total_output_tokens)} out
+                  </div>
+                </TraceListCell>
+
+                <TraceListCell label="Calls" align="right">
+                  <div className="text-zinc-400">{t.total_llm_calls} llm</div>
+                  <div className="text-[11px] text-zinc-500">{t.total_tool_calls} tools</div>
+                </TraceListCell>
+
+                <TraceListCell label="Duration" align="right">
+                  <span className="text-zinc-400">{formatRoundedMs(t.duration_ms)}</span>
+                </TraceListCell>
+
+                <TraceListCell label="Started" align="right">
+                  <span className="text-xs text-zinc-500">
                     {formatLocalDateTime(t.start_time)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </span>
+                </TraceListCell>
+              </article>
+            ))}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- replace the traces table with a responsive row-list layout that avoids horizontal scrolling
- shorten trace, session, and agent identifiers while preserving full values in links, titles, and copy actions
- keep dense metrics visible across desktop and narrow viewports

## Verification
- npm run lint
- npm test
- npm run build
- uv run python scripts/lint.py ci (pre-commit/pre-push)
- uv run pytest tests/ -v --tb=short (pre-push)
- rebuilt and redeployed Docker Console with scripts/update_redeploy_console_docker.sh --no-pull
- verified Docker /traces layout at 1440, 1024, 768, and 390 px with no horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned traces list into a responsive grid for improved mobile and large-screen readability.
  * Added per-item labels on mobile and clearer column alignment for easier scanning.
  * Improved identifier display with compact formatting plus hover tooltips showing full IDs for better visibility and copy confidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->