### PR TITLE
Fix introspection stream projection

### DIFF
--- a/agiwo/agent/introspect/apply.py
+++ b/agiwo/agent/introspect/apply.py
@@ -22,7 +22,13 @@ async def build_tool_step_lookup(
     start_seq: int | None = None,
     end_seq: int | None = None,
 ) -> dict[str, dict[str, Any]]:
-    lookup = dict(batch_lookup)
+    lookup = {
+        tool_call_id: info
+        for tool_call_id, info in batch_lookup.items()
+        if _sequence_in_window(
+            info.get("sequence"), start_seq=start_seq, end_seq=end_seq
+        )
+    }
     steps = await context.session_runtime.run_log_storage.list_step_views(
         session_id=context.session_id,
         start_seq=start_seq,
@@ -42,6 +48,21 @@ async def build_tool_step_lookup(
             },
         )
     return lookup
+
+
+def _sequence_in_window(
+    sequence: object,
+    *,
+    start_seq: int | None,
+    end_seq: int | None,
+) -> bool:
+    if not isinstance(sequence, int):
+        return False
+    if start_seq is not None and sequence < start_seq:
+        return False
+    if end_seq is not None and sequence > end_seq:
+        return False
+    return True
 
 
 async def apply_introspection_outcome(

--- a/agiwo/agent/introspect/apply.py
+++ b/agiwo/agent/introspect/apply.py
@@ -2,14 +2,14 @@
 
 from typing import Any
 
-from agiwo.agent.introspect.models import (
-    ContentUpdate,
-    IntrospectionCheckpoint,
-    IntrospectionOutcome,
-)
+from agiwo.agent.introspect.models import IntrospectionCheckpoint, IntrospectionOutcome
 from agiwo.agent.introspect.repair import build_context_repair_plan
 from agiwo.agent.models.step import StepView
 from agiwo.agent.runtime.context import RunContext
+from agiwo.agent.runtime.state_ops import (
+    apply_tool_message_content_updates,
+    remove_tool_call_from_messages,
+)
 from agiwo.agent.runtime.state_writer import RunStateWriter
 
 _HIDDEN_CONTEXT_REASON = "introspection_metadata"
@@ -18,10 +18,15 @@ _HIDDEN_CONTEXT_REASON = "introspection_metadata"
 async def build_tool_step_lookup(
     context: RunContext,
     batch_lookup: dict[str, dict[str, Any]],
+    *,
+    start_seq: int | None = None,
+    end_seq: int | None = None,
 ) -> dict[str, dict[str, Any]]:
     lookup = dict(batch_lookup)
     steps = await context.session_runtime.run_log_storage.list_step_views(
         session_id=context.session_id,
+        start_seq=start_seq,
+        end_seq=end_seq,
         agent_id=context.agent_id,
         include_hidden_from_context=True,
         limit=100_000,
@@ -46,6 +51,7 @@ async def apply_introspection_outcome(
     writer: RunStateWriter,
     step_lookup: dict[str, dict[str, Any]],
 ) -> None:
+    projectable_entries: list[object] = []
     previous_boundary_seq = context.ledger.introspection.last_boundary_seq
     repair_plan = build_context_repair_plan(
         context.ledger.messages,
@@ -56,22 +62,26 @@ async def apply_introspection_outcome(
     outcome.repair_plan = repair_plan
 
     if outcome.hidden_step_ids:
-        await writer.record_context_steps_hidden(
-            step_ids=outcome.hidden_step_ids,
-            reason=_HIDDEN_CONTEXT_REASON,
+        projectable_entries.extend(
+            await writer.record_context_steps_hidden(
+                step_ids=outcome.hidden_step_ids,
+                reason=_HIDDEN_CONTEXT_REASON,
+            )
         )
 
     if repair_plan is not None:
-        _apply_content_updates(context.ledger.messages, repair_plan.content_updates)
+        apply_tool_message_content_updates(context, repair_plan.content_updates)
         for update in repair_plan.content_updates:
-            await writer.record_step_condensed_content_updated(
-                step_id=update.step_id,
-                condensed_content=update.content,
+            projectable_entries.extend(
+                await writer.record_step_condensed_content_updated(
+                    step_id=update.step_id,
+                    condensed_content=update.content,
+                )
             )
 
-    _remove_review_tool_call(
-        context.ledger.messages,
-        review_tool_call_id=outcome.review_tool_call_id,
+    remove_tool_call_from_messages(
+        context,
+        tool_call_id=outcome.review_tool_call_id,
     )
 
     if outcome.aligned is True:
@@ -81,66 +91,56 @@ async def apply_introspection_outcome(
                 milestone_id=outcome.active_milestone_id or "",
             )
         )
-        await writer.record_introspection_checkpoint_recorded(
-            checkpoint_seq=outcome.boundary_seq,
-            milestone_id=outcome.active_milestone_id,
-            review_tool_call_id=outcome.review_tool_call_id,
-            review_step_id=outcome.review_step_id,
+        projectable_entries.extend(
+            await writer.record_introspection_checkpoint_recorded(
+                checkpoint_seq=outcome.boundary_seq,
+                milestone_id=outcome.active_milestone_id,
+                review_tool_call_id=outcome.review_tool_call_id,
+                review_step_id=outcome.review_step_id,
+            )
         )
 
-    await writer.record_introspection_outcome_recorded(
-        aligned=outcome.aligned,
-        mode=outcome.mode,
-        experience=outcome.experience,
-        active_milestone_id=outcome.active_milestone_id,
-        review_tool_call_id=outcome.review_tool_call_id,
-        review_step_id=outcome.review_step_id,
-        hidden_step_ids=outcome.hidden_step_ids,
-        notice_cleaned_step_ids=(
-            repair_plan.notice_cleaned_step_ids if repair_plan is not None else []
-        ),
-        condensed_step_ids=repair_plan.condensed_step_ids
-        if repair_plan is not None and outcome.mode == "step_back"
-        else [],
-        boundary_seq=outcome.boundary_seq,
-        repair_start_seq=repair_plan.start_seq if repair_plan is not None else None,
-        repair_end_seq=repair_plan.end_seq if repair_plan is not None else None,
+    projectable_entries.extend(
+        await writer.record_introspection_outcome_recorded(
+            aligned=outcome.aligned,
+            mode=outcome.mode,
+            experience=outcome.experience,
+            active_milestone_id=outcome.active_milestone_id,
+            review_tool_call_id=outcome.review_tool_call_id,
+            review_step_id=outcome.review_step_id,
+            hidden_step_ids=outcome.hidden_step_ids,
+            notice_cleaned_step_ids=(
+                repair_plan.notice_cleaned_step_ids if repair_plan is not None else []
+            ),
+            condensed_step_ids=repair_plan.condensed_step_ids
+            if repair_plan is not None and outcome.mode == "step_back"
+            else [],
+            boundary_seq=outcome.boundary_seq,
+            repair_start_seq=repair_plan.start_seq if repair_plan is not None else None,
+            repair_end_seq=repair_plan.end_seq if repair_plan is not None else None,
+        )
     )
 
     if outcome.mode == "step_back" and repair_plan is not None:
-        repair_entries = await writer.record_context_repair_applied(
-            mode="step_back",
-            affected_count=repair_plan.affected_count,
-            start_seq=repair_plan.start_seq,
-            end_seq=repair_plan.end_seq,
-            experience=repair_plan.experience,
+        projectable_entries.extend(
+            await writer.record_context_repair_applied(
+                mode="step_back",
+                affected_count=repair_plan.affected_count,
+                start_seq=repair_plan.start_seq,
+                end_seq=repair_plan.end_seq,
+                experience=repair_plan.experience,
+            )
         )
-        await context.session_runtime.project_run_log_entries(
-            repair_entries,
-            run_id=context.run_id,
-            agent_id=context.agent_id,
-            parent_run_id=context.parent_run_id,
-            depth=context.depth,
-        )
+        await writer.project_entries(projectable_entries)
         await context.hooks.after_step_back(outcome, context)
+    else:
+        await writer.project_entries(projectable_entries)
 
     context.ledger.introspection.pending_trigger = None
     context.ledger.introspection.notice_requested = False
     context.ledger.introspection.pending_milestone_switch = False
     context.ledger.introspection.review_count_since_boundary = 0
     context.ledger.introspection.last_boundary_seq = outcome.boundary_seq
-
-
-def _apply_content_updates(
-    messages: list[dict[str, Any]],
-    updates: list[ContentUpdate],
-) -> None:
-    for update in updates:
-        _replace_tool_message_content(
-            messages,
-            tool_call_id=update.tool_call_id,
-            content=update.content,
-        )
 
 
 def register_committed_tool_step(
@@ -153,69 +153,6 @@ def register_committed_tool_step(
         "id": step.id,
         "sequence": step.sequence,
     }
-
-
-def _replace_tool_message_content(
-    messages: list[dict[str, Any]],
-    *,
-    tool_call_id: str,
-    content: str,
-) -> None:
-    for message in messages:
-        if message.get("role") != "tool":
-            continue
-        if message.get("tool_call_id") != tool_call_id:
-            continue
-        message["content"] = content
-        break
-
-
-def _remove_review_tool_call(
-    messages: list[dict[str, Any]],
-    *,
-    review_tool_call_id: str | None,
-) -> None:
-    if not review_tool_call_id:
-        return
-
-    kept_messages: list[dict[str, Any]] = []
-    for message in messages:
-        if message.get("role") == "tool":
-            if message.get("tool_call_id") != review_tool_call_id:
-                kept_messages.append(message)
-            continue
-
-        if message.get("role") != "assistant":
-            kept_messages.append(message)
-            continue
-
-        tool_calls = message.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            kept_messages.append(message)
-            continue
-
-        remaining_tool_calls = [
-            tool_call
-            for tool_call in tool_calls
-            if tool_call.get("id") != review_tool_call_id
-        ]
-        if remaining_tool_calls:
-            message["tool_calls"] = remaining_tool_calls
-        else:
-            message.pop("tool_calls", None)
-        content = message.get("content")
-        if remaining_tool_calls or _has_preservable_assistant_content(content):
-            kept_messages.append(message)
-
-    messages[:] = kept_messages
-
-
-def _has_preservable_assistant_content(content: object) -> bool:
-    if isinstance(content, str):
-        return bool(content.strip())
-    if isinstance(content, (list, dict)):
-        return len(content) > 0
-    return False
 
 
 __all__ = [

--- a/agiwo/agent/introspect/apply.py
+++ b/agiwo/agent/introspect/apply.py
@@ -91,7 +91,13 @@ async def apply_introspection_outcome(
         )
 
     if repair_plan is not None:
-        apply_tool_message_content_updates(context, repair_plan.content_updates)
+        apply_tool_message_content_updates(
+            context,
+            [
+                (update.tool_call_id, update.content)
+                for update in repair_plan.content_updates
+            ],
+        )
         for update in repair_plan.content_updates:
             projectable_entries.extend(
                 await writer.record_step_condensed_content_updated(

--- a/agiwo/agent/introspect/goal.py
+++ b/agiwo/agent/introspect/goal.py
@@ -60,11 +60,37 @@ def parse_declared_milestones(output: object) -> list[Milestone]:
     return milestones
 
 
-def _active_milestone_id(milestones: list[Milestone]) -> str | None:
+def active_milestone_id_from_milestones(milestones: list[Milestone]) -> str | None:
     for milestone in milestones:
         if milestone.status == "active":
             return milestone.id
     return None
+
+
+def milestone_transition_requires_introspection(
+    *,
+    previous: list[Milestone],
+    current: list[Milestone],
+    reason: str,
+    active_milestone_id: str | None,
+) -> bool:
+    previous_active_id = active_milestone_id_from_milestones(previous)
+    current_active_id = active_milestone_id or active_milestone_id_from_milestones(
+        current
+    )
+    if previous_active_id is not None and current_active_id != previous_active_id:
+        return True
+    if reason in {"completed", "activated"}:
+        return True
+
+    previous_status_by_id = {milestone.id: milestone.status for milestone in previous}
+    for milestone in current:
+        if (
+            previous_status_by_id.get(milestone.id) != "completed"
+            and milestone.status == "completed"
+        ):
+            return True
+    return False
 
 
 def _validate_milestones(milestones: list[Milestone]) -> None:
@@ -95,9 +121,7 @@ def update_goal_milestones(
     reason: GoalUpdateReason = "declared",
 ) -> GoalUpdate:
     _validate_milestones(milestones)
-    previous_active_id = state.active_milestone_id or _active_milestone_id(
-        state.milestones
-    )
+    previous_milestones = list(state.milestones)
     existing_by_id = {milestone.id: milestone for milestone in state.milestones}
     next_by_id = dict(existing_by_id)
 
@@ -113,13 +137,13 @@ def update_goal_milestones(
         next_by_id[milestone.id] = milestone
 
     next_milestones = list(next_by_id.values())
-    if _active_milestone_id(next_milestones) is None:
+    if active_milestone_id_from_milestones(next_milestones) is None:
         for milestone in next_milestones:
             if milestone.status == "pending":
                 milestone.status = "active"
                 break
 
-    active_id = _active_milestone_id(next_milestones)
+    active_id = active_milestone_id_from_milestones(next_milestones)
     state.milestones = next_milestones
     state.active_milestone_id = active_id
     return GoalUpdate(
@@ -127,8 +151,12 @@ def update_goal_milestones(
         active_milestone_id=active_id,
         source_tool_call_id=source_tool_call_id,
         reason=reason,
-        milestone_switch=previous_active_id is not None
-        and active_id != previous_active_id,
+        milestone_switch=milestone_transition_requires_introspection(
+            previous=previous_milestones,
+            current=next_milestones,
+            reason=reason,
+            active_milestone_id=active_id,
+        ),
     )
 
 
@@ -153,7 +181,9 @@ def handle_goal_tool_result(
 
 __all__ = [
     "GoalValidationError",
+    "active_milestone_id_from_milestones",
     "handle_goal_tool_result",
+    "milestone_transition_requires_introspection",
     "parse_declared_milestones",
     "update_goal_milestones",
 ]

--- a/agiwo/agent/introspect/replay.py
+++ b/agiwo/agent/introspect/replay.py
@@ -3,11 +3,14 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from agiwo.agent.introspect.goal import (
+    active_milestone_id_from_milestones,
+    milestone_transition_requires_introspection,
+)
 from agiwo.agent.introspect.models import (
     GoalState,
     IntrospectionCheckpoint,
     IntrospectionState,
-    Milestone,
     PendingIntrospectionNotice,
 )
 from agiwo.agent.models.log import (
@@ -39,7 +42,7 @@ def build_introspect_state_from_entries(
     introspection = IntrospectionState()
     for entry in sorted(entries, key=lambda item: item.sequence):
         if isinstance(entry, GoalMilestonesUpdated):
-            if _milestone_transition_requires_introspection(
+            if milestone_transition_requires_introspection(
                 previous=goal.milestones,
                 current=entry.milestones,
                 reason=entry.reason,
@@ -48,7 +51,8 @@ def build_introspect_state_from_entries(
                 introspection.pending_milestone_switch = True
             goal.milestones = list(entry.milestones)
             goal.active_milestone_id = (
-                entry.active_milestone_id or _active_milestone_id(goal.milestones)
+                entry.active_milestone_id
+                or active_milestone_id_from_milestones(goal.milestones)
             )
             continue
         if isinstance(entry, IntrospectionCheckpointRecorded):
@@ -86,37 +90,6 @@ def build_introspect_state_from_entries(
                 introspection.review_count_since_boundary += 1
             continue
     return IntrospectReplayState(goal=goal, introspection=introspection)
-
-
-def _active_milestone_id(milestones: list[Milestone]) -> str | None:
-    for milestone in milestones:
-        if milestone.status == "active":
-            return milestone.id
-    return None
-
-
-def _milestone_transition_requires_introspection(
-    *,
-    previous: list[Milestone],
-    current: list[Milestone],
-    reason: str,
-    active_milestone_id: str | None,
-) -> bool:
-    previous_active_id = _active_milestone_id(previous)
-    current_active_id = active_milestone_id or _active_milestone_id(current)
-    if previous_active_id is not None and current_active_id != previous_active_id:
-        return True
-    if reason in {"completed", "activated"}:
-        return True
-
-    previous_status_by_id = {milestone.id: milestone.status for milestone in previous}
-    for milestone in current:
-        if (
-            previous_status_by_id.get(milestone.id) != "completed"
-            and milestone.status == "completed"
-        ):
-            return True
-    return False
 
 
 __all__ = ["IntrospectReplayState", "build_introspect_state_from_entries"]

--- a/agiwo/agent/run_tool_batch.py
+++ b/agiwo/agent/run_tool_batch.py
@@ -147,7 +147,13 @@ async def execute_tool_batch_cycle(
             terminated = True
 
     if pending_outcome is not None:
-        full_lookup = await build_tool_step_lookup(context, step_lookup)
+        previous_boundary_seq = context.ledger.introspection.last_boundary_seq
+        full_lookup = await build_tool_step_lookup(
+            context,
+            step_lookup,
+            start_seq=previous_boundary_seq + 1,
+            end_seq=pending_outcome.boundary_seq,
+        )
         await apply_introspection_outcome(
             context,
             pending_outcome,

--- a/agiwo/agent/runtime/state_ops.py
+++ b/agiwo/agent/runtime/state_ops.py
@@ -13,6 +13,7 @@ from agiwo.agent.models.run import CompactMetadata
 from agiwo.agent.models.run import TerminationReason
 from agiwo.agent.models.step import StepView
 from agiwo.agent.runtime.context import RunContext
+from agiwo.agent.introspect.models import ContentUpdate
 
 
 def replace_messages(state: RunContext, messages: Sequence[dict[str, Any]]) -> None:
@@ -26,6 +27,56 @@ def replace_messages(state: RunContext, messages: Sequence[dict[str, Any]]) -> N
 
 def append_message(state: RunContext, message: Mapping[str, Any]) -> None:
     state.ledger.messages.append(copy.deepcopy(dict(message)))
+
+
+def apply_tool_message_content_updates(
+    state: RunContext,
+    updates: Sequence[ContentUpdate],
+) -> None:
+    for update in updates:
+        _replace_tool_message_content(
+            state.ledger.messages,
+            tool_call_id=update.tool_call_id,
+            content=update.content,
+        )
+
+
+def remove_tool_call_from_messages(
+    state: RunContext,
+    *,
+    tool_call_id: str | None,
+) -> None:
+    if not tool_call_id:
+        return
+
+    kept_messages: list[dict[str, Any]] = []
+    for message in state.ledger.messages:
+        if message.get("role") == "tool":
+            if message.get("tool_call_id") != tool_call_id:
+                kept_messages.append(message)
+            continue
+
+        if message.get("role") != "assistant":
+            kept_messages.append(message)
+            continue
+
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            kept_messages.append(message)
+            continue
+
+        remaining_tool_calls = [
+            tool_call for tool_call in tool_calls if tool_call.get("id") != tool_call_id
+        ]
+        if remaining_tool_calls:
+            message["tool_calls"] = remaining_tool_calls
+        else:
+            message.pop("tool_calls", None)
+        content = message.get("content")
+        if remaining_tool_calls or _has_preservable_assistant_content(content):
+            kept_messages.append(message)
+
+    state.ledger.messages[:] = kept_messages
 
 
 def set_tool_schemas(
@@ -84,6 +135,29 @@ def _extract_text_content(content: str | list[dict[str, Any]] | None) -> str | N
     return "\n".join(texts) if texts else None
 
 
+def _replace_tool_message_content(
+    messages: list[dict[str, Any]],
+    *,
+    tool_call_id: str,
+    content: str,
+) -> None:
+    for message in messages:
+        if message.get("role") != "tool":
+            continue
+        if message.get("tool_call_id") != tool_call_id:
+            continue
+        message["content"] = content
+        break
+
+
+def _has_preservable_assistant_content(content: object) -> bool:
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, (list, dict)):
+        return len(content) > 0
+    return False
+
+
 def _track_assistant_step(state: RunContext, step: StepView) -> None:
     ledger = state.ledger
     if not step.is_assistant_step():
@@ -111,7 +185,9 @@ def track_step_state(
 
 __all__ = [
     "append_message",
+    "apply_tool_message_content_updates",
     "record_compaction_metadata",
+    "remove_tool_call_from_messages",
     "replace_messages",
     "set_termination_reason",
     "set_tool_schemas",

--- a/agiwo/agent/runtime/state_ops.py
+++ b/agiwo/agent/runtime/state_ops.py
@@ -13,7 +13,8 @@ from agiwo.agent.models.run import CompactMetadata
 from agiwo.agent.models.run import TerminationReason
 from agiwo.agent.models.step import StepView
 from agiwo.agent.runtime.context import RunContext
-from agiwo.agent.introspect.models import ContentUpdate
+
+ToolMessageContentUpdate = tuple[str, str]
 
 
 def replace_messages(state: RunContext, messages: Sequence[dict[str, Any]]) -> None:
@@ -31,13 +32,13 @@ def append_message(state: RunContext, message: Mapping[str, Any]) -> None:
 
 def apply_tool_message_content_updates(
     state: RunContext,
-    updates: Sequence[ContentUpdate],
+    updates: Sequence[ToolMessageContentUpdate],
 ) -> None:
-    for update in updates:
+    for tool_call_id, content in updates:
         _replace_tool_message_content(
             state.ledger.messages,
-            tool_call_id=update.tool_call_id,
-            content=update.content,
+            tool_call_id=tool_call_id,
+            content=content,
         )
 
 
@@ -184,6 +185,7 @@ def track_step_state(
 
 
 __all__ = [
+    "ToolMessageContentUpdate",
     "append_message",
     "apply_tool_message_content_updates",
     "record_compaction_metadata",

--- a/agiwo/agent/runtime/state_ops.py
+++ b/agiwo/agent/runtime/state_ops.py
@@ -46,7 +46,7 @@ def remove_tool_call_from_messages(
     *,
     tool_call_id: str | None,
 ) -> None:
-    if not tool_call_id:
+    if tool_call_id is None:
         return
 
     kept_messages: list[dict[str, Any]] = []

--- a/agiwo/agent/runtime/state_writer.py
+++ b/agiwo/agent/runtime/state_writer.py
@@ -52,6 +52,17 @@ class RunStateWriter:
         await self._state.session_runtime.append_run_log_entries(typed_entries)
         return typed_entries
 
+    async def project_entries(self, entries: list[object]) -> None:
+        if not entries:
+            return
+        await self._state.session_runtime.project_run_log_entries(
+            entries,
+            run_id=self._state.run_id,
+            agent_id=self._state.agent_id,
+            parent_run_id=self._state.parent_run_id,
+            depth=self._state.depth,
+        )
+
     async def start_run(self, user_input: UserInput) -> list[object]:
         return await self.append_entries(
             [

--- a/console/web/src/app/traces/[id]/page.test.tsx
+++ b/console/web/src/app/traces/[id]/page.test.tsx
@@ -143,6 +143,14 @@ describe("TraceDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Mainline" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Debug" })).not.toBeInTheDocument();
     expect(screen.getByText("fix the bug")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open session" })).toHaveAttribute(
+      "href",
+      "/sessions/sess-1",
+    );
+    expect(screen.getByRole("link", { name: "Open scheduler state" })).toHaveAttribute(
+      "href",
+      "/scheduler/agent-1",
+    );
     expect(screen.getAllByText("2 results condensed after checkpoint seq 4").length).toBeGreaterThan(0);
     expect(screen.queryByText("Run Narrative")).not.toBeInTheDocument();
     expect(screen.queryByText("Span Waterfall (0 spans)")).not.toBeInTheDocument();

--- a/console/web/src/app/traces/[id]/page.tsx
+++ b/console/web/src/app/traces/[id]/page.tsx
@@ -144,10 +144,10 @@ export default function TraceDetailPage() {
         )}
         {trace.agent_id && (
           <Link
-            href={`/agents/${trace.agent_id}`}
+            href={`/scheduler/${trace.agent_id}`}
             className="ui-button ui-button-secondary min-h-9 px-3 py-1.5 text-xs"
           >
-            Open agent
+            Open scheduler state
           </Link>
         )}
       </div>

--- a/console/web/src/lib/api.test.ts
+++ b/console/web/src/lib/api.test.ts
@@ -54,6 +54,28 @@ describe("fetch timeout and abort handling", () => {
     expect(fetchSignal?.aborted).toBe(true);
   });
 
+  test("cascades caller aborts that happened before fetch starts", async () => {
+    const callerController = new AbortController();
+    callerController.abort();
+    let fetchSignal: AbortSignal | undefined;
+    const abortError = new DOMException("Aborted", "AbortError");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+        fetchSignal = init?.signal;
+        return Promise.reject(abortError);
+      }),
+    );
+    const api = await import("./api");
+
+    await expect(
+      api.getAgentState("state-1", { signal: callerController.signal }),
+    ).rejects.toBe(abortError);
+    expect(fetchSignal).toBeDefined();
+    expect(fetchSignal).not.toBe(callerController.signal);
+    expect(fetchSignal?.aborted).toBe(true);
+  });
+
   test("reports timeout only for the internal timeout abort", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(

--- a/console/web/src/lib/api.test.ts
+++ b/console/web/src/lib/api.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 afterEach(() => {
   delete process.env.NEXT_PUBLIC_API_URL;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
   vi.resetModules();
 });
 
@@ -22,5 +24,54 @@ describe("api url base", () => {
     expect(api.sessionInputStreamUrl("sess-1")).toBe(
       "http://localhost:8422/api/sessions/sess-1/input",
     );
+  });
+});
+
+describe("fetch timeout and abort handling", () => {
+  test("passes the internal timeout signal and cascades caller aborts", async () => {
+    const callerController = new AbortController();
+    let fetchSignal: AbortSignal | undefined;
+    const abortError = new DOMException("Aborted", "AbortError");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+        fetchSignal = init?.signal;
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(abortError));
+        });
+      }),
+    );
+    const api = await import("./api");
+
+    const request = api.getAgentState("state-1", {
+      signal: callerController.signal,
+    });
+    callerController.abort();
+
+    await expect(request).rejects.toBe(abortError);
+    expect(fetchSignal).toBeDefined();
+    expect(fetchSignal).not.toBe(callerController.signal);
+    expect(fetchSignal?.aborted).toBe(true);
+  });
+
+  test("reports timeout only for the internal timeout abort", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }),
+    );
+    const api = await import("./api");
+
+    const request = api.getAgentState("state-1");
+    const expectation = expect(request).rejects.toThrow("Request timed out after 30s");
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expectation;
   });
 });

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -22,7 +22,11 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const callerSignal = init?.signal;
   let timedOut = false;
   const abortFromCaller = () => controller.abort();
-  callerSignal?.addEventListener("abort", abortFromCaller);
+  if (callerSignal?.aborted) {
+    abortFromCaller();
+  } else {
+    callerSignal?.addEventListener("abort", abortFromCaller);
+  }
   const timeout = globalThis.setTimeout(() => {
     timedOut = true;
     controller.abort();

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -19,25 +19,31 @@ export class ApiError extends Error {
 
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const controller = new AbortController();
+  const callerSignal = init?.signal;
+  let timedOut = false;
+  const abortFromCaller = () => controller.abort();
+  callerSignal?.addEventListener("abort", abortFromCaller);
   const timeout = globalThis.setTimeout(() => {
+    timedOut = true;
     controller.abort();
   }, DEFAULT_FETCH_TIMEOUT_MS);
   let res: Response;
   try {
     res = await fetch(apiUrl(path), {
       ...init,
-      signal: init?.signal ?? controller.signal,
+      signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
         ...init?.headers,
       },
     });
   } catch (err) {
-    if (err instanceof DOMException && err.name === "AbortError") {
+    if (timedOut && err instanceof DOMException && err.name === "AbortError") {
       throw new Error(`Request timed out after ${DEFAULT_FETCH_TIMEOUT_MS / 1000}s`);
     }
     throw err;
   } finally {
+    callerSignal?.removeEventListener("abort", abortFromCaller);
     globalThis.clearTimeout(timeout);
   }
   if (!res.ok) {
@@ -884,8 +890,8 @@ export function listAgentStates(params?: { status?: string; limit?: number; offs
   return fetchJSON<PageResponse<AgentStateListItem>>(`/api/scheduler/states?${q}`);
 }
 
-export function getAgentState(stateId: string) {
-  return fetchJSON<AgentStateDetail>(`/api/scheduler/states/${stateId}`);
+export function getAgentState(stateId: string, init?: RequestInit) {
+  return fetchJSON<AgentStateDetail>(`/api/scheduler/states/${stateId}`, init);
 }
 
 export function getAgentStateChildren(stateId: string) {

--- a/console/web/src/lib/api.ts
+++ b/console/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ?? "";
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 
 function apiUrl(path: string): string {
   return `${API_BASE}${path}`;
@@ -17,13 +18,28 @@ export class ApiError extends Error {
 }
 
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(apiUrl(path), {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...init?.headers,
-    },
-  });
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => {
+    controller.abort();
+  }, DEFAULT_FETCH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(apiUrl(path), {
+      ...init,
+      signal: init?.signal ?? controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers,
+      },
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error(`Request timed out after ${DEFAULT_FETCH_TIMEOUT_MS / 1000}s`);
+    }
+    throw err;
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
   if (!res.ok) {
     let detail = res.statusText;
     try {

--- a/tests/agent/test_run_tool_batch.py
+++ b/tests/agent/test_run_tool_batch.py
@@ -1,12 +1,13 @@
+import asyncio
 from dataclasses import dataclass, field
 
 import pytest
 
-from agiwo.agent.introspect.apply import _remove_review_tool_call
 from agiwo.agent.introspect.models import Milestone
 import agiwo.agent.run_tool_batch as run_tool_batch_module
 from agiwo.agent.models.config import AgentOptions
 from agiwo.agent.models.log import (
+    ContextStepsHidden,
     GoalMilestonesUpdated,
     IntrospectionCheckpointRecorded,
     IntrospectionOutcomeRecorded,
@@ -15,6 +16,7 @@ from agiwo.agent.models.log import (
 )
 from agiwo.agent.models.run import RunLedger, TerminationReason
 from agiwo.agent.runtime.session import SessionRuntime
+from agiwo.agent.runtime.state_ops import remove_tool_call_from_messages
 from agiwo.agent.storage.base import InMemoryRunLogStorage
 from agiwo.tool.base import ToolResult
 from agiwo.utils.abort_signal import AbortSignal
@@ -501,6 +503,113 @@ async def test_aligned_review_cleans_prior_system_review_from_context_and_storag
 
 
 @pytest.mark.asyncio
+async def test_aligned_review_publishes_hidden_steps_to_live_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batches = [
+        [
+            ToolResult.success(
+                tool_name="search",
+                tool_call_id="tc_search",
+                content="Found results",
+                output={},
+            )
+        ],
+        [
+            ToolResult.success(
+                tool_name="review_trajectory",
+                tool_call_id="tc_review",
+                content="Trajectory review: aligned=True.",
+                output={"aligned": True, "experience": ""},
+            )
+        ],
+    ]
+
+    async def fake_execute_tool_batch(*args, **kwargs):
+        del args, kwargs
+        return batches.pop(0)
+
+    monkeypatch.setattr(
+        run_tool_batch_module, "execute_tool_batch", fake_execute_tool_batch
+    )
+
+    storage = InMemoryRunLogStorage()
+    session_runtime = SessionRuntime(session_id="sess-1", run_log_storage=storage)
+    stream = session_runtime.subscribe()
+    ledger = RunLedger()
+    ledger.goal.milestones = [
+        Milestone(id="locate", description="Locate the auth bug", status="active")
+    ]
+    ledger.goal.active_milestone_id = "locate"
+    context = _FakeContext(
+        config=AgentOptions(
+            enable_goal_directed_review=True,
+            review_step_interval=1,
+        ),
+        ledger=ledger,
+        hooks=_FakeHooks(),
+        session_runtime=session_runtime,
+    )
+    runtime = _FakeRuntime(tools_map=_review_tools_map())
+
+    async def commit_step(step):
+        committed_step = await _commit_step_to_ledger_and_storage(context, step)
+        await session_runtime.project_run_log_entries(
+            [build_committed_step_entry(committed_step)],
+            run_id=context.run_id,
+            agent_id=context.agent_id,
+            parent_run_id=context.parent_run_id,
+            depth=context.depth,
+        )
+        return committed_step
+
+    async def set_termination_reason(reason: TerminationReason, tool_name: str) -> None:
+        del reason, tool_name
+
+    await run_tool_batch_module.execute_tool_batch_cycle(
+        context=context,
+        runtime=runtime,
+        tool_calls=[
+            {"id": "tc_search", "type": "function", "function": {"name": "search"}}
+        ],
+        assistant_step_id="assistant-step-search",
+        set_termination_reason=set_termination_reason,
+        commit_step=commit_step,
+    )
+    await stream.__anext__()
+
+    await run_tool_batch_module.execute_tool_batch_cycle(
+        context=context,
+        runtime=runtime,
+        tool_calls=[
+            {
+                "id": "tc_review",
+                "type": "function",
+                "function": {"name": "review_trajectory"},
+            }
+        ],
+        assistant_step_id="assistant-step-review",
+        set_termination_reason=set_termination_reason,
+        commit_step=commit_step,
+    )
+
+    stream_items = [
+        await asyncio.wait_for(stream.__anext__(), timeout=1) for _ in range(2)
+    ]
+    hidden_events = [
+        item for item in stream_items if item.type == "context_steps_hidden"
+    ]
+    assert len(hidden_events) == 1
+    assert hidden_events[0].reason == "introspection_metadata"
+    assert "assistant-step-review" in hidden_events[0].step_ids
+
+    entries = await storage.list_entries(session_id=context.session_id)
+    hidden_facts = [entry for entry in entries if isinstance(entry, ContextStepsHidden)]
+    assert len(hidden_facts) == 1
+    assert hidden_events[0].step_ids == hidden_facts[0].step_ids
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_batch_cycle_calls_after_step_back_hook(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -588,51 +697,73 @@ async def test_execute_tool_batch_cycle_calls_after_step_back_hook(
 
 
 def test_remove_review_tool_call_omits_empty_tool_calls_key() -> None:
-    messages = [
-        {
-            "role": "assistant",
-            "content": "Need to review this path.",
-            "tool_calls": [
+    context = _FakeContext(
+        config=AgentOptions(),
+        ledger=RunLedger(
+            messages=[
                 {
-                    "id": "tc_review",
-                    "type": "function",
-                    "function": {"name": "review_trajectory", "arguments": "{}"},
+                    "role": "assistant",
+                    "content": "Need to review this path.",
+                    "tool_calls": [
+                        {
+                            "id": "tc_review",
+                            "type": "function",
+                            "function": {
+                                "name": "review_trajectory",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
                 }
-            ],
-        }
-    ]
-
-    _remove_review_tool_call(
-        messages,
-        review_tool_call_id="tc_review",
+            ]
+        ),
+        hooks=_FakeHooks(),
+        session_runtime=SessionRuntime(
+            session_id="sess-1",
+            run_log_storage=InMemoryRunLogStorage(),
+        ),
     )
 
-    assert len(messages) == 1
-    assert "tool_calls" not in messages[0]
+    remove_tool_call_from_messages(context, tool_call_id="tc_review")
+
+    assert len(context.ledger.messages) == 1
+    assert "tool_calls" not in context.ledger.messages[0]
 
 
 def test_remove_review_tool_call_preserves_structured_assistant_content() -> None:
-    messages = [
-        {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "Keep this structured content."}],
-            "tool_calls": [
+    context = _FakeContext(
+        config=AgentOptions(),
+        ledger=RunLedger(
+            messages=[
                 {
-                    "id": "tc_review",
-                    "type": "function",
-                    "function": {"name": "review_trajectory", "arguments": "{}"},
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Keep this structured content."}
+                    ],
+                    "tool_calls": [
+                        {
+                            "id": "tc_review",
+                            "type": "function",
+                            "function": {
+                                "name": "review_trajectory",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
                 }
-            ],
-        }
-    ]
-
-    _remove_review_tool_call(
-        messages,
-        review_tool_call_id="tc_review",
+            ]
+        ),
+        hooks=_FakeHooks(),
+        session_runtime=SessionRuntime(
+            session_id="sess-1",
+            run_log_storage=InMemoryRunLogStorage(),
+        ),
     )
 
-    assert len(messages) == 1
-    assert messages[0]["content"] == [
+    remove_tool_call_from_messages(context, tool_call_id="tc_review")
+
+    assert len(context.ledger.messages) == 1
+    assert context.ledger.messages[0]["content"] == [
         {"type": "text", "text": "Keep this structured content."}
     ]
-    assert "tool_calls" not in messages[0]
+    assert "tool_calls" not in context.ledger.messages[0]

--- a/tests/agent/test_run_tool_batch.py
+++ b/tests/agent/test_run_tool_batch.py
@@ -696,6 +696,94 @@ async def test_execute_tool_batch_cycle_calls_after_step_back_hook(
     assert outcomes[0].notice_cleaned_step_ids == []
 
 
+@pytest.mark.asyncio
+async def test_step_back_excludes_trailing_batch_tool_after_review_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_execute_tool_batch(*args, **kwargs):
+        del args, kwargs
+        return [
+            ToolResult.success(
+                tool_name="search",
+                tool_call_id="tc_search",
+                content="Verbose search output",
+                output={},
+            ),
+            ToolResult.success(
+                tool_name="review_trajectory",
+                tool_call_id="tc_review",
+                content="Trajectory review: aligned=False. narrow the search",
+                output={"aligned": False, "experience": "narrow the search"},
+            ),
+            ToolResult.success(
+                tool_name="read",
+                tool_call_id="tc_read",
+                content="Read output after review",
+                output={},
+            ),
+        ]
+
+    monkeypatch.setattr(
+        run_tool_batch_module, "execute_tool_batch", fake_execute_tool_batch
+    )
+
+    storage = InMemoryRunLogStorage()
+    session_runtime = SessionRuntime(session_id="sess-1", run_log_storage=storage)
+    context = _FakeContext(
+        config=AgentOptions(
+            enable_goal_directed_review=True,
+            review_step_interval=100,
+        ),
+        ledger=RunLedger(),
+        hooks=_FakeHooks(),
+        session_runtime=session_runtime,
+    )
+    runtime = _FakeRuntime(tools_map=_review_tools_map())
+
+    async def commit_step(step):
+        return await _commit_step_to_ledger_and_storage(context, step)
+
+    async def set_termination_reason(reason: TerminationReason, tool_name: str) -> None:
+        del reason, tool_name
+
+    await run_tool_batch_module.execute_tool_batch_cycle(
+        context=context,
+        runtime=runtime,
+        tool_calls=[
+            {"id": "tc_search", "type": "function", "function": {"name": "search"}},
+            {
+                "id": "tc_review",
+                "type": "function",
+                "function": {"name": "review_trajectory"},
+            },
+            {"id": "tc_read", "type": "function", "function": {"name": "read"}},
+        ],
+        assistant_step_id="assistant-step",
+        set_termination_reason=set_termination_reason,
+        commit_step=commit_step,
+    )
+
+    tool_messages = [
+        msg for msg in context.ledger.messages if msg.get("role") == "tool"
+    ]
+    assert [(msg.get("tool_call_id"), msg.get("content")) for msg in tool_messages] == [
+        ("tc_search", "[EXPERIENCE] narrow the search"),
+        ("tc_read", "Read output after review"),
+    ]
+    entries = await storage.list_entries(session_id=context.session_id)
+    outcomes = [
+        entry for entry in entries if isinstance(entry, IntrospectionOutcomeRecorded)
+    ]
+    assert len(outcomes) == 1
+    assert outcomes[0].condensed_step_ids
+    condensed_steps = await storage.list_step_views(
+        session_id=context.session_id,
+        include_hidden_from_context=True,
+    )
+    read_step = next(step for step in condensed_steps if step.tool_call_id == "tc_read")
+    assert read_step.condensed_content is None
+
+
 def test_remove_review_tool_call_omits_empty_tool_calls_key() -> None:
     context = _FakeContext(
         config=AgentOptions(),
@@ -728,6 +816,40 @@ def test_remove_review_tool_call_omits_empty_tool_calls_key() -> None:
 
     assert len(context.ledger.messages) == 1
     assert "tool_calls" not in context.ledger.messages[0]
+
+
+def test_remove_tool_call_from_messages_treats_empty_string_as_real_id() -> None:
+    context = _FakeContext(
+        config=AgentOptions(),
+        ledger=RunLedger(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "",
+                            "type": "function",
+                            "function": {
+                                "name": "review_trajectory",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "", "content": "review"},
+            ]
+        ),
+        hooks=_FakeHooks(),
+        session_runtime=SessionRuntime(
+            session_id="sess-1",
+            run_log_storage=InMemoryRunLogStorage(),
+        ),
+    )
+
+    remove_tool_call_from_messages(context, tool_call_id="")
+
+    assert context.ledger.messages == []
 
 
 def test_remove_review_tool_call_preserves_structured_assistant_content() -> None:


### PR DESCRIPTION
## Summary
- publish introspection outcome facts, including hidden review metadata, through the live stream
- centralize introspection message mutations in runtime state ops
- share milestone transition rules between live runtime and replay
- respect introspection repair sequence windows for both persisted and in-batch tool-step lookups
- preserve empty-string tool call IDs during review metadata cleanup
- cascade caller abort signals through the console API fetch timeout wrapper without mislabeling caller aborts as timeouts
- add trace page scheduler link and API fetch timeout behavior from the existing frontend changes

## Tests
- uv run pytest tests/agent/test_introspect_goal.py tests/agent/test_introspect_replay.py tests/agent/test_run_tool_batch.py tests/agent/test_run_log_replay_parity.py tests/agent/test_introspect_state_writer.py -v
- uv run pytest tests/agent/test_run_tool_batch.py -v
- uv run python scripts/lint.py ci
- cd console/web && npm run lint
- cd console/web && npm test -- src/lib/api.test.ts
- cd console/web && npm test
- cd console/web && npm run build
- pre-push: uv run python scripts/check.py pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request timeout handling (30-second limit) for API calls with clear timeout error messages.

* **Improvements**
  * Trace detail page navigation now links to scheduler state for better workflow integration.
  * Enhanced tool message handling during introspection and step-back operations.
  * Improved milestone transition detection for more intelligent introspection triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->